### PR TITLE
fix(wds): text area 에서 maxLength 콤마가 표시되지 않음

### DIFF
--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -297,7 +297,7 @@ const TextArea = forwardRef<
             }
             sx={maxLengthStyle}
           >
-            {length}&#47;
+            {length.toLocaleString()}&#47;
             {maxLength!.toLocaleString()}
           </Typography>
         )}


### PR DESCRIPTION
Resolve: #20