### PR TITLE
PI-65917 [WDS][토스트] width 규칙 미적용 이슈

### DIFF
--- a/packages/wds/src/components/region-status/index.tsx
+++ b/packages/wds/src/components/region-status/index.tsx
@@ -18,7 +18,7 @@ import {
   bottomRegionStatusStyle,
   bottomUnmountKeyFrames,
   firstOverlayStyle,
-  fullWidthBoxStyle,
+  fullWidthFlexBoxStyle,
   messageStyle,
   secondOverlayStyle,
   snackbarActionStyle,
@@ -177,53 +177,56 @@ const Snackbar = ({
     >
       <Box role="presentation" sx={firstOverlayStyle} />
       <Box role="presentation" sx={secondOverlayStyle} />
-      <Box sx={fullWidthBoxStyle}>
-        <FlexBox gap="12px" alignItems="center" justifyContent="space-between">
-          <FlexBox gap="12px" alignItems="center">
-            {extraContent && (
-              <FlexBox
-                flexShrink={0}
-                sx={{ width: 'fit-content', height: 'fit-content' }}
+      <FlexBox
+        gap="12px"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={fullWidthFlexBoxStyle}
+      >
+        <FlexBox gap="12px" alignItems="center">
+          {extraContent && (
+            <FlexBox
+              flexShrink={0}
+              sx={{ width: 'fit-content', height: 'fit-content' }}
+            >
+              {extraContent}
+            </FlexBox>
+          )}
+
+          <FlexBox flexDirection="column" sx={messageStyle}>
+            {heading && (
+              <Typography
+                color="palette.static.white"
+                variant="body2_normal"
+                weight="bold"
+                id={headingId}
+                sx={textStyle}
               >
-                {extraContent}
-              </FlexBox>
+                {heading}
+              </Typography>
             )}
 
-            <FlexBox flexDirection="column" sx={messageStyle}>
-              {heading && (
-                <Typography
-                  color="palette.static.white"
-                  variant="body2_normal"
-                  weight="bold"
-                  id={headingId}
-                  sx={textStyle}
-                >
-                  {heading}
-                </Typography>
-              )}
-
-              {description && (
-                <Typography
-                  color="palette.static.white"
-                  variant="label2"
-                  weight="regular"
-                  id={descriptionId}
-                  sx={[textStyle, ellipsisTypographyStyle(2)]}
-                >
-                  {description}
-                </Typography>
-              )}
-            </FlexBox>
+            {description && (
+              <Typography
+                color="palette.static.white"
+                variant="label2"
+                weight="regular"
+                id={descriptionId}
+                sx={[textStyle, ellipsisTypographyStyle(2)]}
+              >
+                {description}
+              </Typography>
+            )}
           </FlexBox>
-
-          <TextButton
-            variant="assistive"
-            size="medium"
-            {...action}
-            sx={[snackbarActionStyle, action.sx]}
-          />
         </FlexBox>
-      </Box>
+
+        <TextButton
+          variant="assistive"
+          size="medium"
+          {...action}
+          sx={[snackbarActionStyle, action.sx]}
+        />
+      </FlexBox>
     </Box>
   );
 };

--- a/packages/wds/src/components/region-status/index.tsx
+++ b/packages/wds/src/components/region-status/index.tsx
@@ -18,6 +18,7 @@ import {
   bottomRegionStatusStyle,
   bottomUnmountKeyFrames,
   firstOverlayStyle,
+  fullWidthBoxStyle,
   messageStyle,
   secondOverlayStyle,
   snackbarActionStyle,
@@ -176,49 +177,53 @@ const Snackbar = ({
     >
       <Box role="presentation" sx={firstOverlayStyle} />
       <Box role="presentation" sx={secondOverlayStyle} />
-      <FlexBox gap="12px" alignItems="center">
-        {extraContent && (
-          <FlexBox
-            flexShrink={0}
-            sx={{ width: 'fit-content', height: 'fit-content' }}
-          >
-            {extraContent}
+      <Box sx={fullWidthBoxStyle}>
+        <FlexBox gap="12px" alignItems="center" justifyContent="space-between">
+          <FlexBox gap="12px" alignItems="center">
+            {extraContent && (
+              <FlexBox
+                flexShrink={0}
+                sx={{ width: 'fit-content', height: 'fit-content' }}
+              >
+                {extraContent}
+              </FlexBox>
+            )}
+
+            <FlexBox flexDirection="column" sx={messageStyle}>
+              {heading && (
+                <Typography
+                  color="palette.static.white"
+                  variant="body2_normal"
+                  weight="bold"
+                  id={headingId}
+                  sx={textStyle}
+                >
+                  {heading}
+                </Typography>
+              )}
+
+              {description && (
+                <Typography
+                  color="palette.static.white"
+                  variant="label2"
+                  weight="regular"
+                  id={descriptionId}
+                  sx={[textStyle, ellipsisTypographyStyle(2)]}
+                >
+                  {description}
+                </Typography>
+              )}
+            </FlexBox>
           </FlexBox>
-        )}
 
-        <FlexBox flexDirection="column" sx={messageStyle}>
-          {heading && (
-            <Typography
-              color="palette.static.white"
-              variant="body2_normal"
-              weight="bold"
-              id={headingId}
-              sx={textStyle}
-            >
-              {heading}
-            </Typography>
-          )}
-
-          {description && (
-            <Typography
-              color="palette.static.white"
-              variant="label2"
-              weight="regular"
-              id={descriptionId}
-              sx={[textStyle, ellipsisTypographyStyle(2)]}
-            >
-              {description}
-            </Typography>
-          )}
+          <TextButton
+            variant="assistive"
+            size="medium"
+            {...action}
+            sx={[snackbarActionStyle, action.sx]}
+          />
         </FlexBox>
-
-        <TextButton
-          variant="assistive"
-          size="medium"
-          {...action}
-          sx={[snackbarActionStyle, action.sx]}
-        />
-      </FlexBox>
+      </Box>
     </Box>
   );
 };

--- a/packages/wds/src/components/region-status/style.ts
+++ b/packages/wds/src/components/region-status/style.ts
@@ -130,3 +130,7 @@ export const snackbarActionStyle = (theme: Theme) => css`
 export const textStyle = (theme: Theme) => css`
   opacity: ${theme.opacity[88]};
 `;
+
+export const fullWidthBoxStyle = css`
+  width: 100%;
+`;

--- a/packages/wds/src/components/region-status/style.ts
+++ b/packages/wds/src/components/region-status/style.ts
@@ -116,7 +116,7 @@ export const messageStyle = css`
 `;
 
 export const snackbarActionStyle = (theme: Theme) => css`
-  color: ${theme.palette.background.normal.normal};
+  color: ${theme.palette.static.white};
 
   & [wds-component='with-interaction'] {
     background-color: ${theme.palette.background.normal.normal};

--- a/packages/wds/src/components/region-status/style.ts
+++ b/packages/wds/src/components/region-status/style.ts
@@ -131,6 +131,6 @@ export const textStyle = (theme: Theme) => css`
   opacity: ${theme.opacity[88]};
 `;
 
-export const fullWidthBoxStyle = css`
+export const fullWidthFlexBoxStyle = css`
   width: 100%;
 `;

--- a/packages/wds/src/components/region-status/style.ts
+++ b/packages/wds/src/components/region-status/style.ts
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@wanteddev/wds-engine';
 
-import { addOpacity } from '../../utils';
+import { addOpacity, respondMore, respondTo } from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
 
@@ -28,51 +28,55 @@ export const bottomUnmountKeyFrames = keyframes`
   }
 `;
 
-export const bottomRegionStatusStyle = (
-  duration: number,
-  isMountAnimationDone: boolean,
-) => css`
-  padding: 11px 16px;
-  max-width: 100%;
-  border-radius: 12px;
-  display: flex;
-  gap: 16px;
-  width: fit-content;
-  max-width: 360px;
-  font-size: 20px;
-  pointer-events: auto;
-  align-items: center;
-  position: relative;
-  overflow: hidden;
-  backdrop-filter: blur(32px);
+export const bottomRegionStatusStyle =
+  (duration: number, isMountAnimationDone: boolean) => (theme: Theme) => css`
+    padding: 11px 16px;
+    max-width: 100%;
+    border-radius: 12px;
+    display: flex;
+    gap: 16px;
+    font-size: 20px;
+    pointer-events: auto;
+    align-items: center;
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(32px);
 
-  animation:
-    ${bottomMountKeyFrames} 200ms cubic-bezier(0.4, 0, 0.2, 1),
-    ${bottomUnmountKeyFrames} 200ms ${duration}ms cubic-bezier(0.4, 0, 0.2, 1);
-
-  & > :not([role='presentation']) {
-    z-index: 1;
-  }
-
-  ${isMountAnimationDone &&
-  css`
-    &:hover {
-      animation-play-state: paused;
+    ${respondMore(theme.breakpoint.sm)} {
+      min-width: 356px;
+      max-width: 360px;
+    }
+    ${respondTo(theme.breakpoint.sm)} {
+      width: 100%;
     }
 
-    &:where(:focus-within) {
-      animation-play-state: paused;
+    animation:
+      ${bottomMountKeyFrames} 200ms cubic-bezier(0.4, 0, 0.2, 1),
+      ${bottomUnmountKeyFrames} 200ms ${duration}ms cubic-bezier(0.4, 0, 0.2, 1);
+
+    & > :not([role='presentation']) {
+      z-index: 1;
     }
 
-    &:where(:focus) {
-      animation-play-state: paused;
-    }
+    ${isMountAnimationDone &&
+    css`
+      &:hover {
+        animation-play-state: paused;
+      }
 
-    &:where(:hover) {
-      animation-play-state: paused;
-    }
-  `}
-`;
+      &:where(:focus-within) {
+        animation-play-state: paused;
+      }
+
+      &:where(:focus) {
+        animation-play-state: paused;
+      }
+
+      &:where(:hover) {
+        animation-play-state: paused;
+      }
+    `}
+  `;
 
 export const toastCircleIconWrapperStyle = (theme: Theme) => css`
   width: fit-content;

--- a/packages/wds/src/theme-provider/store-provider.tsx
+++ b/packages/wds/src/theme-provider/store-provider.tsx
@@ -1,19 +1,19 @@
 'use client';
+import { Box } from '@wanteddev/wds-engine';
 import { useRef } from 'react';
 import { type StoreApi } from 'zustand';
-import { Box } from '@wanteddev/wds-engine';
 
+import Dialog from '../components/dialog';
+import RegionStatus from '../components/region-status';
+import { DialogContext, createDialogStore } from '../stores/dialog-store';
 import {
   RegionContext,
   createRegionStore,
   useRegionStore,
 } from '../stores/region-store';
-import RegionStatus from '../components/region-status';
-import { DialogContext, createDialogStore } from '../stores/dialog-store';
-import Dialog from '../components/dialog';
 
-import type { DialogStore } from '../stores/dialog-store';
 import type { CSSProperties, PropsWithChildren } from 'react';
+import type { DialogStore } from '../stores/dialog-store';
 import type { RegionStore } from '../stores/region-store';
 
 const StoreProvider = ({ children }: PropsWithChildren) => {
@@ -81,6 +81,7 @@ const RegionArea = () => {
           bottom: 'var(--wds-region-viewport-bottom, 0px)',
           paddingBottom: '40px',
           [`@media (max-width: ${theme.breakpoint.sm})`]: {
+            minWidth: '100%',
             paddingBottom: '34px',
           },
         })}


### PR DESCRIPTION
## 변경사항

- `Toast`, `Snackbar`
  - 데탑에서 min-width: 356px, 모웹에서 padding 제외 100%
  - content 내용이 적을 때 가로 정렬 수정: `justifyContent="space-between"`
- `Snackbar`
  - action button 컬러 static.white로 변경 (저번 버전에 버튼 색상 변경 누락한 걸 발견했어요. 😅)

## as-is

### Toast

<img width="759" alt="스크린샷 2024-07-12 오후 12 30 08" src="https://github.com/user-attachments/assets/3968bd22-8ce0-425f-b843-f51f6d8a6343">

<img width="578" alt="스크린샷 2024-07-12 오후 12 31 19" src="https://github.com/user-attachments/assets/af4f2c9d-acbb-4333-8e40-ad4176b9b8bc">


### Snackbar

<img width="759" alt="스크린샷 2024-07-12 오후 12 30 18" src="https://github.com/user-attachments/assets/eb65e9dc-90e3-4890-bb7b-81b418c580be">

<img width="564" alt="스크린샷 2024-07-12 오후 12 30 38" src="https://github.com/user-attachments/assets/9b2825f6-7113-467b-9db4-abf784b8b1ca">

## to-be

### Toast

<img width="457" alt="스크린샷 2024-07-12 오후 12 24 42" src="https://github.com/user-attachments/assets/cd07531a-7427-4efd-ba04-e99d5a016d7f">
<img width="548" alt="스크린샷 2024-07-12 오후 12 24 59" src="https://github.com/user-attachments/assets/53b4606f-f50a-4a7a-9fe1-5cf185025798">

### Snackbar

<img width="790" alt="스크린샷 2024-07-12 오후 12 25 19" src="https://github.com/user-attachments/assets/b0a9f7ce-455d-431d-95f3-609befff19e9">

<img width="562" alt="스크린샷 2024-07-12 오후 12 29 00" src="https://github.com/user-attachments/assets/b7244226-5fe8-43fe-adba-f68eae49fba1">
