### PR TITLE
fix(wds): modal 에서 조건부 렌더링의 경우 스크롤 높이를 감지하지 못 하는 이슈

### DIFF
--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -24,6 +24,7 @@ import ScrollArea from '../scroll-area';
 import TextButton from '../text-button';
 import Typography from '../typography';
 import PortalOrFragment from '../portal-or-fragment';
+import useResizeObserver from '../../hooks/use-resize-observer';
 
 import {
   ModalActionAreaProvider,
@@ -69,7 +70,6 @@ import type {
   ElementRef,
   ElementType,
   ForwardedRef,
-  UIEventHandler,
 } from 'react';
 import type {
   ModalContainerProps,
@@ -165,12 +165,13 @@ const ModalContainer = forwardRef<
       context.innerContainerRef,
     );
 
-    const [scrollHeight, setScrollHeight] = useState(0);
+    const detectScrollRef = useRef<HTMLDivElement>(null);
 
+    const [scrollHeight, setScrollHeight] = useState(0);
     const [hasScroll, setHasScroll] = useState(false);
 
-    const handleOnScroll: UIEventHandler<HTMLDivElement> = useCallback(
-      (e) => {
+    const handleOnScroll = useCallback(
+      (e: Event) => {
         const target = e.target as Element;
 
         setScrollHeight(target.scrollTop);
@@ -178,22 +179,29 @@ const ModalContainer = forwardRef<
       [setScrollHeight],
     );
 
+    const handleResize = useCallback(() => {
+      const target = innerContainerRef.current;
+      if (!target) {
+        return;
+      }
+
+      setHasScroll(
+        target.scrollHeight - target.clientHeight !== target.scrollTop,
+      );
+    }, [setHasScroll]);
+
+    useResizeObserver(detectScrollRef.current, handleResize);
+
     useEffect(() => {
-      const handleResize = () => {
-        if (innerContainerRef.current) {
-          setHasScroll(
-            innerContainerRef.current.scrollHeight -
-              innerContainerRef.current.clientHeight !==
-              scrollHeight,
-          );
-        }
-      };
+      const target = innerContainerRef.current;
+      if (!target) {
+        return;
+      }
 
-      handleResize();
-      window.addEventListener('resize', handleResize);
+      target.addEventListener('scroll', handleOnScroll);
 
-      return () => window.removeEventListener('resize', handleResize);
-    }, [innerContainerRef, scrollHeight, setHasScroll]);
+      return () => target.removeEventListener('scroll', handleOnScroll);
+    }, [handleOnScroll]);
 
     useEffect(() => {
       const content = containerRef.current;
@@ -320,30 +328,20 @@ const ModalContainer = forwardRef<
                     sx={{
                       display: 'flex',
                       flexGrow: '1',
-                      ['& > div']: {
-                        display: 'flex !important',
-                        flexDirection: 'column',
-                      },
                     }}
                     zIndex={11}
-                    asChild
-                    viewPortProps={{
-                      onScroll: handleOnScroll,
-                      sx: {
-                        flexGrow: 1,
-                        height: 'initial',
-                      },
-                    }}
                   >
-                    {isEnabled && (
-                      <FlexBox
-                        justifyContent="center"
-                        sx={modalGrabberStyle}
-                        {...dragProps}
-                      />
-                    )}
+                    <FlexBox flexDirection="column" ref={detectScrollRef}>
+                      {isEnabled && (
+                        <FlexBox
+                          justifyContent="center"
+                          sx={modalGrabberStyle}
+                          {...dragProps}
+                        />
+                      )}
 
-                    {children}
+                      {children}
+                    </FlexBox>
                   </ScrollArea>
                 </Box>
               </DismissableLayer>

--- a/packages/wds/src/components/tab/index.tsx
+++ b/packages/wds/src/components/tab/index.tsx
@@ -16,6 +16,7 @@ import { Box } from '@wanteddev/wds-engine';
 
 import FlexBox from '../flex-box';
 import ScrollArea from '../scroll-area';
+import useResizeObserver from '../../hooks/use-resize-observer';
 
 import {
   scrollWrapperStyle,
@@ -131,26 +132,20 @@ const TabList = forwardRef<
       }
     }, [scrollLeft, scrollWidth]);
 
-    useEffect(() => {
-      const handleResize = () => {
-        if (!viewportRef.current || !containerRef.current) {
-          return;
-        }
+    const handleResize = useCallback(() => {
+      const target = viewportRef.current;
+      if (!target) {
+        return;
+      }
 
-        const width = viewportRef.current.scrollWidth;
-        const left = viewportRef.current.scrollLeft;
+      const width = target.scrollWidth;
+      const left = target.scrollLeft;
 
-        setScrollLeft(left);
-        setScrollWidth(width);
-      };
+      setScrollLeft(left);
+      setScrollWidth(width);
+    }, [setScrollLeft]);
 
-      handleResize();
-      window.addEventListener('resize', handleResize);
-
-      return () => {
-        window.removeEventListener('resize', handleResize);
-      };
-    }, []);
+    useResizeObserver(viewportRef.current, handleResize);
 
     return (
       <RovingFocusGroup.Root asChild orientation="horizontal" loop dir="ltr">

--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import { forwardRef, useCallback, useRef, useState } from 'react';
 import { composeRefs, useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Box, css } from '@wanteddev/wds-engine';
 import { useSize } from '@radix-ui/react-use-size';
@@ -8,6 +8,7 @@ import FlexBox from '../flex-box';
 import Typography from '../typography';
 import ScrollArea from '../scroll-area';
 import { typographyStyle } from '../../utils/typography';
+import useResizeObserver from '../../hooks/use-resize-observer';
 
 import {
   maxLengthStyle,
@@ -18,31 +19,6 @@ import {
 
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { TextAreaProps } from './types';
-
-export interface Cancelable {
-  clear(): void;
-}
-
-const debounce = <T extends (...args: Array<any>) => any>(
-  func: T,
-  wait = 166,
-) => {
-  let timeout: ReturnType<typeof setTimeout>;
-  function debounced(...args: Parameters<T>) {
-    const later = () => {
-      // @ts-ignore
-      func.apply(this, args);
-    };
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-  }
-
-  debounced.clear = () => {
-    clearTimeout(timeout);
-  };
-
-  return debounced as T & Cancelable;
-};
 
 const TextArea = forwardRef<
   HTMLTextAreaElement,
@@ -161,53 +137,7 @@ const TextArea = forwardRef<
       );
     }, [maxRows, minRows, props.placeholder, maxLength]);
 
-    useEffect(() => {
-      if (!textAreaRef.current) {
-        return;
-      }
-      let resizeObserverEntries: Array<ResizeObserverEntry> = [];
-
-      const handleResize = () => {
-        syncTextAreaHeight();
-      };
-      let rAF: any;
-      const rAFHandleResize = () => {
-        cancelAnimationFrame(rAF);
-        rAF = requestAnimationFrame(() => {
-          handleResize();
-        });
-      };
-      const debounceHandleResize = debounce(handleResize);
-      const textArea = textAreaRef.current;
-      const containerWindow = textArea.ownerDocument.defaultView || window;
-      containerWindow.addEventListener('resize', debounceHandleResize);
-      let resizeObserver: ResizeObserver;
-      if (typeof ResizeObserver !== 'undefined') {
-        resizeObserver = new ResizeObserver((entries) => {
-          resizeObserverEntries = entries;
-
-          const func =
-            process.env.NODE_ENV === 'test' ? rAFHandleResize : handleResize;
-
-          func();
-        });
-        resizeObserver.observe(textArea);
-      }
-      return () => {
-        debounceHandleResize.clear();
-        cancelAnimationFrame(rAF);
-        containerWindow.removeEventListener('resize', debounceHandleResize);
-        resizeObserverEntries.forEach((entry) => entry.target.remove());
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (resizeObserver) {
-          resizeObserver.disconnect();
-        }
-      };
-    }, [syncTextAreaHeight]);
-
-    useEffect(() => {
-      syncTextAreaHeight();
-    });
+    useResizeObserver(textAreaRef.current, syncTextAreaHeight);
 
     return (
       <ScrollArea

--- a/packages/wds/src/hooks/use-resize-observer.ts
+++ b/packages/wds/src/hooks/use-resize-observer.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+import { debounce } from '../utils/debounce';
+
+const useResizeObserver = (
+  target: HTMLElement | null,
+  callback: () => void,
+) => {
+  useEffect(() => {
+    callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!target) {
+      return;
+    }
+
+    let resizeObserverEntries: Array<ResizeObserverEntry> = [];
+
+    let rAF: any;
+    const rAFHandleResize = () => {
+      cancelAnimationFrame(rAF);
+      rAF = requestAnimationFrame(() => {
+        callback();
+      });
+    };
+    const debounceHandleResize = debounce(callback);
+    const containerWindow = target.ownerDocument.defaultView || window;
+    containerWindow.addEventListener('resize', debounceHandleResize);
+    let resizeObserver: ResizeObserver;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver((entries) => {
+        resizeObserverEntries = entries;
+
+        const func =
+          process.env.NODE_ENV === 'test' ? rAFHandleResize : callback;
+
+        func();
+      });
+      resizeObserver.observe(target);
+    }
+    return () => {
+      debounceHandleResize.clear();
+      cancelAnimationFrame(rAF);
+      containerWindow.removeEventListener('resize', debounceHandleResize);
+      resizeObserverEntries.forEach((entry) => entry.target.remove());
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  }, [target, callback]);
+};
+
+export default useResizeObserver;

--- a/packages/wds/src/utils/debounce.ts
+++ b/packages/wds/src/utils/debounce.ts
@@ -1,0 +1,24 @@
+export type Cancelable = {
+  clear(): void;
+};
+
+export const debounce = <T extends (...args: Array<any>) => any>(
+  func: T,
+  wait = 166,
+) => {
+  let timeout: ReturnType<typeof setTimeout>;
+  function debounced(...args: Parameters<T>) {
+    const later = () => {
+      // @ts-ignore
+      func.apply(this, args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  }
+
+  debounced.clear = () => {
+    clearTimeout(timeout);
+  };
+
+  return debounced as T & Cancelable;
+};


### PR DESCRIPTION
Resolved: https://github.com/wanteddev/wanted-one-frontend/pull/414

추가적으로 스크롤을 감지하는 부분이 있는 Tab에도 resize observer를 반영하였고
TextArea에서는 리렌더링 최적화를 진행했습니다.