### PR TITLE
feat(wds): dialog 확장성 있는 인터페이스로 변경

### DIFF
--- a/docs/src/docs/hooks/use-dialog.mdx
+++ b/docs/src/docs/hooks/use-dialog.mdx
@@ -9,7 +9,7 @@ description: useDialog for WDS Utility
 
 ## 활용
 
-<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
+<Demo code={`import { useDialog, Button, DialogButton } from '@wanteddev/wds';
 
 const Demo = () => {
   const dialog = useDialog();
@@ -18,8 +18,8 @@ const Demo = () => {
     const result = await dialog({
       title: '제목',
       content: '설명',
-      confirm: <DialogConfirm>확인</DialogConfirm>,
-      cancel: <DialogCancel>취소</DialogCancel>,
+      confirm: <DialogButton>확인</DialogButton>,
+      cancel: <DialogButton variant="assistive">취소</DialogButton>,
     });
 
     alert('결과: ' + result);
@@ -48,13 +48,9 @@ export default Demo;`}
 { name: 'disableEscapeKeyDownClose', types: 'boolean | undefined', defaultValue: 'false' },
 ]} />
 
-### DialogConfirm
+### DialogButton
 
-<PropsTable component="DialogConfirm" />
-
-### DialogCancel
-
-<PropsTable component="DialogCancel" />
+<PropsTable component="DialogButton" />
 
 ## Examples
 
@@ -62,7 +58,7 @@ export default Demo;`}
 
 확인과 취소 버튼 위치를 변경합니다.
 
-<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
+<Demo code={`import { useDialog, Button, DialogButton } from '@wanteddev/wds';
 
 const Demo = () => {
   const dialog = useDialog();
@@ -71,8 +67,8 @@ const Demo = () => {
     const result = await dialog({
       title: '제목',
       content: '설명',
-      confirm: <DialogConfirm>확인</DialogConfirm>,
-      cancel: <DialogCancel>취소</DialogCancel>,
+      confirm: <DialogButton>확인</DialogButton>,
+      cancel: <DialogButton variant="assistive">취소</DialogButton>,
       direction: 'reverse'
     });
 
@@ -87,11 +83,11 @@ const Demo = () => {
 export default Demo;`}
 />
 
-### Custom Color
+### Button Color
 
-Confirm 버튼의 색상 및 인터렉션 색상을 변경합니다.
+`variant` 옵션에 따라 버튼의 색상이 달라집니다.
 
-<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
+<Demo code={`import { useDialog, Button, DialogButton } from '@wanteddev/wds';
 
 const Demo = () => {
   const dialog = useDialog();
@@ -100,8 +96,8 @@ const Demo = () => {
     const result = await dialog({
       title: '정말로 삭제하시겠습니까?',
       content: '삭제된 내용은 복구할 수 없습니다.',
-      confirm: <DialogConfirm confirmColor="palette.status.negative">확인</DialogConfirm>,
-      cancel: <DialogCancel>취소</DialogCancel>
+      confirm: <DialogButton variant="negative">확인</DialogButton>,
+      cancel: <DialogButton variant="assistive">취소</DialogButton>
     });
 
     alert('결과: ' + result);
@@ -119,7 +115,7 @@ export default Demo;`}
 
 `sx` Prop을 통해 커스텀 스타일을 적용할 수 있습니다.
 
-<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
+<Demo code={`import { useDialog, Button, DialogButton } from '@wanteddev/wds';
 
 const Demo = () => {
   const dialog = useDialog();
@@ -128,9 +124,38 @@ const Demo = () => {
     const result = await dialog({
       title: '정말로 삭제하시겠습니까?',
       content: '삭제된 내용은 복구할 수 없습니다.',
-      confirm: <DialogConfirm confirmColor="palette.status.negative">확인</DialogConfirm>,
-      cancel: <DialogCancel>취소</DialogCancel>,
+      confirm: <DialogButton>확인</DialogButton>,
+      cancel: <DialogButton variant="assistive">취소</DialogButton>,
       sx: { padding: 40 }
+    });
+
+    alert('결과: ' + result);
+  };
+
+  return (
+    <Button onClick={handleClick}>클릭</Button>
+  )
+}
+
+export default Demo;`}
+/>
+
+
+### Prevent Event
+
+`e.preventDefault` 를 이용하면 클릭 액션을 막을 수 있습니다.
+
+<Demo code={`import { useDialog, Button, DialogButton } from '@wanteddev/wds';
+
+const Demo = () => {
+  const dialog = useDialog();
+
+  const handleClick = async () => {
+    const result = await dialog({
+      title: '제목',
+      content: '내용',
+      confirm: <DialogButton onClick={e => e.preventDefault()}>확인</DialogButton>,
+      cancel: <DialogButton variant="assistive">취소</DialogButton>,
     });
 
     alert('결과: ' + result);

--- a/docs/src/docs/hooks/use-dialog.mdx
+++ b/docs/src/docs/hooks/use-dialog.mdx
@@ -9,7 +9,7 @@ description: useDialog for WDS Utility
 
 ## 활용
 
-<Demo code={`import { useDialog, Button } from '@wanteddev/wds';
+<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
 
 const Demo = () => {
   const dialog = useDialog();
@@ -18,8 +18,8 @@ const Demo = () => {
     const result = await dialog({
       title: '제목',
       content: '설명',
-      confirmText: '확인',
-      cancelText: '취소',
+      confirm: <DialogConfirm>확인</DialogConfirm>,
+      cancel: <DialogCancel>취소</DialogCancel>,
     });
 
     alert('결과: ' + result);
@@ -35,16 +35,26 @@ export default Demo;`}
 
 ## Props
 
+### useDialog
+
 <PropsTable component="useDialog" fallback={[
 { name: 'title', types: 'ReactNode | undefined' },
 { name: 'content', types: 'ReactNode', required: true },
-{ name: 'cancelText', types: 'string | undefined' },
-{ name: 'confirmText', types: 'string', required: true },
-{ name: 'confirmColor', types: '"palette.label.strong" | "palette.label.normal" | "palette.label.disable" | "palette.label.assistive" | "palette.label.neutral" | "palette.label.alternative" | "palette.line.normal.normal" | ... 197 more ... | undefined', defaultValue: 'palette.primary.normal' },
+{ name: 'cancel', types: 'ReactNode | undefined' },
+{ name: 'confirm', types: 'ReactNode', required: true },
+{ name: 'sx', types: 'SxProp | undefined' },
 { name: 'direction', types: '"normal" | "reverse" \ undefined', description: "버튼 순서를 변경합니다.", defaultValue: "normal" },
 { name: 'disableOutsideClickClose', types: 'boolean | undefined', defaultValue: 'false' },
 { name: 'disableEscapeKeyDownClose', types: 'boolean | undefined', defaultValue: 'false' },
 ]} />
+
+### DialogConfirm
+
+<PropsTable component="DialogConfirm" />
+
+### DialogCancel
+
+<PropsTable component="DialogCancel" />
 
 ## Examples
 
@@ -52,7 +62,7 @@ export default Demo;`}
 
 확인과 취소 버튼 위치를 변경합니다.
 
-<Demo code={`import { useDialog, Button } from '@wanteddev/wds';
+<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
 
 const Demo = () => {
   const dialog = useDialog();
@@ -61,9 +71,66 @@ const Demo = () => {
     const result = await dialog({
       title: '제목',
       content: '설명',
-      confirmText: '확인',
-      cancelText: '취소',
+      confirm: <DialogConfirm>확인</DialogConfirm>,
+      cancel: <DialogCancel>취소</DialogCancel>,
       direction: 'reverse'
+    });
+
+    alert('결과: ' + result);
+  };
+
+  return (
+    <Button onClick={handleClick}>클릭</Button>
+  )
+}
+
+export default Demo;`}
+/>
+
+### Custom Color
+
+Confirm 버튼의 색상 및 인터렉션 색상을 변경합니다.
+
+<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
+
+const Demo = () => {
+  const dialog = useDialog();
+
+  const handleClick = async () => {
+    const result = await dialog({
+      title: '정말로 삭제하시겠습니까?',
+      content: '삭제된 내용은 복구할 수 없습니다.',
+      confirm: <DialogConfirm confirmColor="palette.status.negative">확인</DialogConfirm>,
+      cancel: <DialogCancel>취소</DialogCancel>
+    });
+
+    alert('결과: ' + result);
+  };
+
+  return (
+    <Button onClick={handleClick}>클릭</Button>
+  )
+}
+
+export default Demo;`}
+/>
+
+### Custom Style
+
+`sx` Prop을 통해 커스텀 스타일을 적용할 수 있습니다.
+
+<Demo code={`import { useDialog, Button, DialogConfirm, DialogCancel } from '@wanteddev/wds';
+
+const Demo = () => {
+  const dialog = useDialog();
+
+  const handleClick = async () => {
+    const result = await dialog({
+      title: '정말로 삭제하시겠습니까?',
+      content: '삭제된 내용은 복구할 수 없습니다.',
+      confirm: <DialogConfirm confirmColor="palette.status.negative">확인</DialogConfirm>,
+      cancel: <DialogCancel>취소</DialogCancel>,
+      sx: { padding: 40 }
     });
 
     alert('결과: ' + result);

--- a/packages/wds/src/components/dialog/index.tsx
+++ b/packages/wds/src/components/dialog/index.tsx
@@ -17,13 +17,11 @@ import {
   dialogWrapperStyle,
 } from './style';
 
-import type { TextButtonProps } from '../text-button/types';
-import type { ElementRef, ElementType, ForwardedRef } from 'react';
+import type { DialogButtonProps } from './types';
+import type { ElementRef, ElementType, ForwardedRef, MouseEvent } from 'react';
 import type {
-  Merge,
   PolymorphicComponent,
   PolymorphicProps,
-  ThemeColorsToken,
 } from '@wanteddev/wds-engine';
 import type { DialogItem } from '../../stores/dialog-store';
 
@@ -62,15 +60,29 @@ const Item = ({
     hide(id);
   }, [hide, id]);
 
-  const handleCancel = useCallback(() => {
-    handleClose();
-    resolve('cancel');
-  }, [handleClose, resolve]);
+  const handleCancel = useCallback(
+    (e?: MouseEvent<HTMLElement>) => {
+      if (e?.defaultPrevented) {
+        return;
+      }
 
-  const handleConfirm = useCallback(() => {
-    handleClose();
-    resolve('confirm');
-  }, [handleClose, resolve]);
+      handleClose();
+      resolve('cancel');
+    },
+    [handleClose, resolve],
+  );
+
+  const handleConfirm = useCallback(
+    (e?: MouseEvent<HTMLElement>) => {
+      if (e?.defaultPrevented) {
+        return;
+      }
+
+      handleClose();
+      resolve('confirm');
+    },
+    [handleClose, resolve],
+  );
 
   useEffect(() => {
     const element = ref.current;
@@ -176,54 +188,38 @@ const Item = ({
   );
 };
 
-type DialogConfirmProps = Merge<
-  {
-    confirmColor?: ThemeColorsToken;
-  },
-  TextButtonProps
->;
-
-export const DialogConfirm = forwardRef(
+export const DialogButton = forwardRef(
   <E extends ElementType = 'button'>(
-    {
-      confirmColor = 'palette.primary.normal',
-      ...props
-    }: PolymorphicProps<DialogConfirmProps, E>,
+    { variant = 'normal', ...props }: PolymorphicProps<DialogButtonProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
     return (
       <TextButton
         size="medium"
-        variant="assistive"
+        variant={variant === 'normal' ? 'primary' : 'assistive'}
         ref={ref}
         {...props}
-        sx={[
-          (theme) => ({
-            color: getColorByToken(theme, confirmColor),
-            ['[wds-component="with-interaction"]']: {
-              backgroundColor: getColorByToken(theme, confirmColor),
-            },
-          }),
-          props.sx,
-        ]}
+        sx={
+          variant === 'negative'
+            ? [
+                (theme) => ({
+                  color: getColorByToken(theme, 'palette.status.negative'),
+                  ['[wds-component="with-interaction"]']: {
+                    backgroundColor: getColorByToken(
+                      theme,
+                      'palette.status.negative',
+                    ),
+                  },
+                }),
+                props.sx,
+              ]
+            : props.sx
+        }
       />
     );
   },
-) as PolymorphicComponent<DialogConfirmProps, 'button'>;
+) as PolymorphicComponent<DialogButtonProps, 'button'>;
 
-DialogConfirm.displayName = 'DialogConfirm';
-
-export const DialogCancel = forwardRef(
-  <E extends ElementType = 'button'>(
-    props: PolymorphicProps<TextButtonProps, E>,
-    ref: ForwardedRef<ElementRef<E>>,
-  ) => {
-    return (
-      <TextButton size="medium" variant="assistive" ref={ref} {...props} />
-    );
-  },
-) as PolymorphicComponent<TextButtonProps, 'button'>;
-
-DialogCancel.displayName = 'DialogCancel';
+DialogButton.displayName = 'DialogButton';
 
 export default Dialog;

--- a/packages/wds/src/components/dialog/index.tsx
+++ b/packages/wds/src/components/dialog/index.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { useCallback, useEffect, useId, useRef } from 'react';
-import { Slot } from '@radix-ui/react-slot';
+import { forwardRef, useCallback, useEffect, useId, useRef } from 'react';
+import { Slot, Slottable } from '@radix-ui/react-slot';
 import { Box, getColorByToken } from '@wanteddev/wds-engine';
 
 import { hideOthers } from '../../utils/aria-hidden';
@@ -17,8 +17,14 @@ import {
   dialogWrapperStyle,
 } from './style';
 
-import type { PropsWithChildren } from 'react';
-import type { ThemeColorsToken } from '@wanteddev/wds-engine';
+import type { TextButtonProps } from '../text-button/types';
+import type { ElementRef, ElementType, ForwardedRef } from 'react';
+import type {
+  Merge,
+  PolymorphicComponent,
+  PolymorphicProps,
+  ThemeColorsToken,
+} from '@wanteddev/wds-engine';
 import type { DialogItem } from '../../stores/dialog-store';
 
 const Dialog = () => {
@@ -37,12 +43,12 @@ const Item = ({
   id,
   content,
   title,
-  confirmText,
-  confirmColor = 'palette.primary.normal',
+  confirm,
+  cancel,
   direction = 'normal',
-  cancelText,
   disableOutsideClickClose,
   disableEscapeKeyDownClose,
+  sx,
   resolve,
 }: DialogItem) => {
   const hide = useDialogStore((state) => state.hide);
@@ -108,15 +114,17 @@ const Item = ({
               aria-describedby={descriptionId}
               aria-labelledby={titleId}
               flexDirection="column"
-              sx={dialogContentStyle}
+              sx={[dialogContentStyle, sx]}
             >
               <FlexBox
+                wds-component="dialog-wrapper"
                 flexDirection="column"
                 gap="6px"
                 sx={{ padding: '20px' }}
               >
                 {Boolean(title) && (
                   <Typography
+                    wds-component="dialog-title"
                     variant="headline1"
                     weight="bold"
                     color="palette.label.normal"
@@ -126,6 +134,7 @@ const Item = ({
                 )}
 
                 <Typography
+                  wds-component="dialog-content"
                   variant="body2_normal"
                   weight="regular"
                   color="palette.label.alternative"
@@ -142,17 +151,22 @@ const Item = ({
               <FlexBox
                 flexDirection={direction === 'reverse' ? 'row-reverse' : 'row'}
                 alignItems="center"
+                wds-component="dialog-action-wrapper"
                 justifyContent={
                   direction === 'reverse' ? 'initial' : 'flex-end'
                 }
                 gap="24px"
                 sx={dialogActionStyle}
               >
-                <CancelButton onClick={handleCancel}>{cancelText}</CancelButton>
+                <Slot onClick={handleConfirm}>
+                  <Slottable>{confirm}</Slottable>
+                </Slot>
 
-                <ConfirmButton onClick={handleConfirm} color={confirmColor}>
-                  {confirmText}
-                </ConfirmButton>
+                {Boolean(cancel) && (
+                  <Slot onClick={handleCancel}>
+                    <Slottable>{cancel}</Slottable>
+                  </Slot>
+                )}
               </FlexBox>
             </FlexBox>
           </Box>
@@ -162,40 +176,54 @@ const Item = ({
   );
 };
 
-type DialogButtonProps = PropsWithChildren<{
-  color: ThemeColorsToken;
-  onClick: () => void;
-}>;
+type DialogConfirmProps = Merge<
+  {
+    confirmColor?: ThemeColorsToken;
+  },
+  TextButtonProps
+>;
 
-const ConfirmButton = ({ color, onClick, children }: DialogButtonProps) => (
-  <TextButton
-    size="medium"
-    variant="primary"
-    onClick={onClick}
-    sx={(theme) => ({
-      color: getColorByToken(theme, color),
-      ['[wds-component="with-interaction"]']: {
-        backgroundColor: getColorByToken(theme, color),
-      },
-    })}
-  >
-    {children}
-  </TextButton>
-);
+export const DialogConfirm = forwardRef(
+  <E extends ElementType = 'button'>(
+    {
+      confirmColor = 'palette.primary.normal',
+      ...props
+    }: PolymorphicProps<DialogConfirmProps, E>,
+    ref: ForwardedRef<ElementRef<E>>,
+  ) => {
+    return (
+      <TextButton
+        size="medium"
+        variant="assistive"
+        ref={ref}
+        {...props}
+        sx={[
+          (theme) => ({
+            color: getColorByToken(theme, confirmColor),
+            ['[wds-component="with-interaction"]']: {
+              backgroundColor: getColorByToken(theme, confirmColor),
+            },
+          }),
+          props.sx,
+        ]}
+      />
+    );
+  },
+) as PolymorphicComponent<DialogConfirmProps, 'button'>;
 
-const CancelButton = ({
-  onClick,
-  children,
-}: Omit<DialogButtonProps, 'color'>) => {
-  if (!children) {
-    return null;
-  }
+DialogConfirm.displayName = 'DialogConfirm';
 
-  return (
-    <TextButton size="medium" variant="assistive" onClick={onClick}>
-      {children}
-    </TextButton>
-  );
-};
+export const DialogCancel = forwardRef(
+  <E extends ElementType = 'button'>(
+    props: PolymorphicProps<TextButtonProps, E>,
+    ref: ForwardedRef<ElementRef<E>>,
+  ) => {
+    return (
+      <TextButton size="medium" variant="assistive" ref={ref} {...props} />
+    );
+  },
+) as PolymorphicComponent<TextButtonProps, 'button'>;
+
+DialogCancel.displayName = 'DialogCancel';
 
 export default Dialog;

--- a/packages/wds/src/components/dialog/types.ts
+++ b/packages/wds/src/components/dialog/types.ts
@@ -1,0 +1,9 @@
+import type { Merge } from '@wanteddev/wds-engine';
+import type { TextButtonProps } from '../text-button/types';
+
+export type DialogButtonProps = Merge<
+  {
+    variant?: 'normal' | 'assistive' | 'negative';
+  },
+  Omit<TextButtonProps, 'color'>
+>;

--- a/packages/wds/src/components/index.ts
+++ b/packages/wds/src/components/index.ts
@@ -10,7 +10,7 @@ export { default as ChipAction } from './chip-action';
 export { default as ChipMultiSelect } from './chip-multi-select';
 export * from './compact-tooltip';
 export { default as ContentBadge } from './content-badge';
-export { DialogConfirm, DialogCancel } from './dialog';
+export { DialogButton } from './dialog';
 export { default as DismissableLayer } from './dismissable-layer';
 export { default as Divider } from './divider';
 export { default as FlexBox } from './flex-box';

--- a/packages/wds/src/components/index.ts
+++ b/packages/wds/src/components/index.ts
@@ -10,6 +10,7 @@ export { default as ChipAction } from './chip-action';
 export { default as ChipMultiSelect } from './chip-multi-select';
 export * from './compact-tooltip';
 export { default as ContentBadge } from './content-badge';
+export { DialogConfirm, DialogCancel } from './dialog';
 export { default as DismissableLayer } from './dismissable-layer';
 export { default as Divider } from './divider';
 export { default as FlexBox } from './flex-box';

--- a/packages/wds/src/stores/dialog-store.ts
+++ b/packages/wds/src/stores/dialog-store.ts
@@ -4,7 +4,7 @@ import { useStore } from 'zustand';
 
 import { generateId } from './helpers';
 
-import type { ThemeColorsToken } from '@wanteddev/wds-engine';
+import type { SxProp } from '@wanteddev/wds-engine';
 import type { StoreApi } from 'zustand';
 import type { ReactNode } from 'react';
 
@@ -14,13 +14,13 @@ export type DialogItem = {
   id: string;
   title?: ReactNode;
   content: ReactNode;
-  confirmText: ReactNode;
-  cancelText?: ReactNode;
-  confirmColor?: ThemeColorsToken;
   direction?: 'normal' | 'reverse';
   disableOutsideClickClose?: boolean;
   disableEscapeKeyDownClose?: boolean;
   resolve: (value: DialogReturnType | PromiseLike<DialogReturnType>) => void;
+  confirm: ReactNode;
+  cancel?: ReactNode;
+  sx?: SxProp;
 };
 
 export type DialogState = {


### PR DESCRIPTION
- confirmText -> confirm: `<DialogButton>확인</DialogButton>`
- cancelText -> cancel: `<DialogButton variant="assistive">취소</DialogButton>`
- confirmColor -> confirm: `<DialogButton variant="negative">확인</DialogButton>`

추가)

- sx prop 지원
- preventDefault 지원
  - confirm: `<DialogButton onClick={e => e.preventDefault()}>확인</DialogButton>`