### PR TITLE
feat(wds): select, select-multiple에 menu bottom 대응 및 일부 스타일 조정

### DIFF
--- a/docs/src/docs/components/select-multiple.mdx
+++ b/docs/src/docs/components/select-multiple.mdx
@@ -141,13 +141,17 @@ export default Demo;`}
 
 ### Disabled
 
-<Demo code={`import { SelectMultiple, Option, OptionGroup, FlexBox } from '@wanteddev/wds';
+<Demo code={`import { SelectMultiple, Option, FlexBox } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
     <FlexBox flexDirection="column" gap="8px">
-      <SelectMultiple disabled width="300px" placeholder="선택해주세요." />
-      <SelectMultiple disabled value={['값']} width="300px" placeholder="선택해주세요." />
+      <SelectMultiple disabled width="300px" placeholder="선택해주세요.">
+        <Option value="">값</Option>
+      </Select>
+      <SelectMultiple disabled value={["값"]} width="300px" placeholder="선택해주세요.">
+        <Option value="값">값</Option>
+      </SelectMultiple>
     </FlexBox>
   )
 }
@@ -157,19 +161,23 @@ export default Demo;`}
 
 ### Chip
 
-`render` prop을 이용하여 chip으로 렌더링 할 수 있습니다.
+`render` prop을 이용하여 Chip으로 렌더링 할 수 있습니다.
+
+Chip 에 onClick 이 들어가는 경우 `e.stopPropagation` 을 통해 메뉴 열리고 닫히는 동작을 막을 수 있습니다.
 
 <Demo code={`import { ChipAction, SelectMultiple, Option, OptionGroup, Label, FlexBox } from '@wanteddev/wds';
 import { IconCloseThick } from '@wanteddev/wds-icon';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 const Demo = () => {
-  const [value, setValue] = useState([])
+  const [value, setValue] = useState([]);
+  const ref = useRef(null);
 
   return (
     <FlexBox flexDirection="column" gap="8px">
       <Label>Label</Label>
       <SelectMultiple
+        ref={ref}
         value={value}
         onValueChange={setValue}
         width="300px"
@@ -181,7 +189,11 @@ const Demo = () => {
               size="xsmall"
               variant="filled"
               rightContent={<IconCloseThick />}
-              onClick={() => setValue(value.filter(data => data !== v))}
+              onClick={(e) => {
+                e.stopPropagation();
+                setValue(value.filter(data => data !== v))
+                ref.current?.focus();
+              }}
             >
               {v}
             </ChipAction>
@@ -236,6 +248,7 @@ const Demo = () => {
           </OptionGroup>
         ))}
       </SelectMultiple>
+
       <SelectMultiple
         width="300px"
         placeholder="선택해주세요."
@@ -268,6 +281,52 @@ const Demo = () => {
           </SelectContent>
         }
       >
+          {new Array(3).fill(0).map((_, i) => (
+            <OptionGroup key={i} title={\`그룹 \${i + 1}\`}>
+              {new Array(3).fill(0)
+                .map((__, j) => (
+                  <Option key={j} value={\`값 \${i} \${j}\`}>
+                    {\`값 \${i} \${j}\`}
+                  </Option>
+                ))
+              }
+            </OptionGroup>
+          ))}
+      </SelectMultiple>
+    </FlexBox>
+  )
+}
+
+export default Demo;`}
+/>
+
+### With Bottom
+
+bottom 영역을 사용하신다면 `enableMenuBottom` prop 을 활용해야합니다.
+
+<Demo code={`import { Typography, SelectMultiple, Option, OptionGroup, SelectContent, Label, FlexBox, ellipsisTypographyStyle, MenuBottom, MenuBottomContent, IconButton, Button } from '@wanteddev/wds';
+import { IconRefresh } from '@wanteddev/wds-icon';
+import { useState } from 'react';
+
+const Demo = () => {
+  const [value, setValue] = useState([]);
+  const [menuValue, setMenuValue] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <FlexBox flexDirection="column" gap="8px">
+      <Label>Label</Label>
+      <SelectMultiple
+        enableMenuBottom
+        open={open}
+        onOpenChange={setOpen}
+        value={value}
+        onValueChange={setValue}
+        menuValue={menuValue}
+        onMenuValueChange={setMenuValue}
+        width="300px"
+        placeholder="선택해주세요."
+      >
         {new Array(3).fill(0).map((_, i) => (
           <OptionGroup key={i} title={\`그룹 \${i + 1}\`}>
             {new Array(3).fill(0)
@@ -279,6 +338,26 @@ const Demo = () => {
             }
           </OptionGroup>
         ))}
+
+        <MenuBottom
+          leftContent={
+            <MenuBottomContent variant="icon-button">
+              <IconButton variant="outlined" size="small" onClick={() => setMenuValue([])}>
+                <IconRefresh />
+              </IconButton>
+            </MenuBottomContent>
+          }
+          rightContent={
+            <MenuBottomContent variant="button">
+              <Button size="small" onClick={() => {
+                setValue(menuValue);
+                setOpen(false);
+              }}>
+                적용
+              </Button>
+            </MenuBottomContent>
+          }
+        />
       </SelectMultiple>
     </FlexBox>
   )

--- a/docs/src/docs/components/select-multiple.mdx
+++ b/docs/src/docs/components/select-multiple.mdx
@@ -304,7 +304,7 @@ export default Demo;`}
 
 bottom 영역을 사용하신다면 `enableMenuBottom` prop 을 활용해야합니다.
 
-<Demo code={`import { Typography, SelectMultiple, Option, OptionGroup, SelectContent, Label, FlexBox, ellipsisTypographyStyle, MenuBottom, MenuBottomContent, IconButton, Button } from '@wanteddev/wds';
+<Demo code={`import { Typography, SelectMultiple, Option, OptionGroup, SelectContent, Label, FlexBox, ellipsisTypographyStyle, MenuBottom, MenuBottomContent, Button } from '@wanteddev/wds';
 import { IconRefresh } from '@wanteddev/wds-icon';
 import { useState } from 'react';
 
@@ -341,10 +341,16 @@ const Demo = () => {
 
         <MenuBottom
           leftContent={
-            <MenuBottomContent variant="icon-button">
-              <IconButton variant="outlined" size="small" onClick={() => setMenuValue([])}>
+            <MenuBottomContent variant="button">
+              <Button
+                variant="outlined"
+                color="assistive"
+                iconOnly
+                size="small"
+                onClick={() => setMenuValue([])}
+              >
                 <IconRefresh />
-              </IconButton>
+              </Button> 
             </MenuBottomContent>
           }
           rightContent={

--- a/docs/src/docs/components/select.mdx
+++ b/docs/src/docs/components/select.mdx
@@ -243,7 +243,7 @@ export default Demo;`}
 
 bottom 영역을 사용하신다면 `enableMenuBottom` prop 을 활용해야합니다.
 
-<Demo code={`import { Typography, Select, Option, OptionGroup, SelectContent, Label, FlexBox, ellipsisTypographyStyle, MenuBottom, MenuBottomContent, IconButton, Button } from '@wanteddev/wds';
+<Demo code={`import { Typography, Select, Option, OptionGroup, SelectContent, Label, FlexBox, ellipsisTypographyStyle, MenuBottom, MenuBottomContent, Button } from '@wanteddev/wds';
 import { IconRefresh } from '@wanteddev/wds-icon';
 import { useState } from 'react';
 
@@ -280,10 +280,16 @@ const Demo = () => {
 
         <MenuBottom
           leftContent={
-            <MenuBottomContent variant="icon-button">
-              <IconButton variant="outlined" size="small" onClick={() => setMenuValue([])}>
+            <MenuBottomContent variant="button">
+              <Button
+                variant="outlined"
+                color="assistive"
+                iconOnly
+                size="small"
+                onClick={() => setMenuValue([])}
+              >
                 <IconRefresh />
-              </IconButton>
+              </Button> 
             </MenuBottomContent>
           }
           rightContent={

--- a/docs/src/docs/components/select.mdx
+++ b/docs/src/docs/components/select.mdx
@@ -286,7 +286,7 @@ const Demo = () => {
                 color="assistive"
                 iconOnly
                 size="small"
-                onClick={() => setMenuValue([])}
+                onClick={() => setMenuValue('')}
               >
                 <IconRefresh />
               </Button> 

--- a/docs/src/docs/components/select.mdx
+++ b/docs/src/docs/components/select.mdx
@@ -141,13 +141,17 @@ export default Demo;`}
 
 ### Disabled
 
-<Demo code={`import { Select, Option, OptionGroup, FlexBox } from '@wanteddev/wds';
+<Demo code={`import { Select, Option, FlexBox } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
     <FlexBox flexDirection="column" gap="8px">
-      <Select disabled width="300px" placeholder="선택해주세요." />
-      <Select disabled value="값" width="300px" placeholder="선택해주세요." />
+      <Select disabled width="300px" placeholder="선택해주세요.">
+        <Option value="">값</Option>
+      </Select>
+      <Select disabled value="값" width="300px" placeholder="선택해주세요.">
+        <Option value="값">값</Option>
+      </Select>
     </FlexBox>
   )
 }
@@ -227,6 +231,72 @@ const Demo = () => {
             }
           </OptionGroup>
         ))}
+      </Select>
+    </FlexBox>
+  )
+}
+
+export default Demo;`}
+/>
+
+### With Bottom
+
+bottom 영역을 사용하신다면 `enableMenuBottom` prop 을 활용해야합니다.
+
+<Demo code={`import { Typography, Select, Option, OptionGroup, SelectContent, Label, FlexBox, ellipsisTypographyStyle, MenuBottom, MenuBottomContent, IconButton, Button } from '@wanteddev/wds';
+import { IconRefresh } from '@wanteddev/wds-icon';
+import { useState } from 'react';
+
+const Demo = () => {
+  const [value, setValue] = useState('');
+  const [menuValue, setMenuValue] = useState('');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <FlexBox flexDirection="column" gap="8px">
+      <Label>Label</Label>
+      <Select
+        enableMenuBottom
+        open={open}
+        onOpenChange={setOpen}
+        value={value}
+        onValueChange={setValue}
+        menuValue={menuValue}
+        onMenuValueChange={setMenuValue}
+        width="300px"
+        placeholder="선택해주세요."
+      >
+        {new Array(3).fill(0).map((_, i) => (
+          <OptionGroup key={i} title={\`그룹 \${i + 1}\`}>
+            {new Array(3).fill(0)
+              .map((__, j) => (
+                <Option key={j} value={\`값 \${i} \${j}\`}>
+                  {\`값 \${i} \${j}\`}
+                </Option>
+              ))
+            }
+          </OptionGroup>
+        ))}
+
+        <MenuBottom
+          leftContent={
+            <MenuBottomContent variant="icon-button">
+              <IconButton variant="outlined" size="small" onClick={() => setMenuValue([])}>
+                <IconRefresh />
+              </IconButton>
+            </MenuBottomContent>
+          }
+          rightContent={
+            <MenuBottomContent variant="button">
+              <Button size="small" onClick={() => {
+                setValue(menuValue);
+                setOpen(false);
+              }}>
+                적용
+              </Button>
+            </MenuBottomContent>
+          }
+        />
       </Select>
     </FlexBox>
   )

--- a/docs/src/features/mdx/components/demo/editor/style.ts
+++ b/docs/src/features/mdx/components/demo/editor/style.ts
@@ -73,6 +73,7 @@ export const collapseWrapperStyle =
         border-bottom-right-radius: 8px;
         border-bottom-left-radius: 8px;
         left: 1px;
+        pointer-events: none;
         ${gradient(theme.palette.background.normal.alternative, 'top')}
       }
     `}

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -6,11 +6,9 @@ import type { Theme } from '@wanteddev/wds-engine';
 import type { ListCellProps, ListItemProps } from './types';
 
 export const listStyle = css`
-  && {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
+  list-style: none;
+  margin: 0;
+  padding: 0;
 `;
 
 export const listItemStyle =

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -114,10 +114,11 @@ const MenuContent = forwardRef<
         offset={offset}
         container={container}
         disablePortal={disablePortal}
+        trappedContent
         {...props}
         sx={[menuPopoverContentStyle, sx]}
       >
-        <RovingFocusGroup orientation="vertical" dir="ltr" loop asChild>
+        <RovingFocusGroup orientation="vertical" dir="ltr" asChild>
           <ScrollArea zIndex={11} sx={menuScrollAreaStyle}>
             {children}
           </ScrollArea>
@@ -241,6 +242,8 @@ const MenuItem = forwardRef(
       <RovingFocusGroupItem
         asChild
         focusable={!disabled}
+        active={normalActive}
+        data-active={normalActive}
         onKeyDown={composeEventHandlers(onKeyDown, (e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();

--- a/packages/wds/src/components/menu/style.ts
+++ b/packages/wds/src/components/menu/style.ts
@@ -37,13 +37,23 @@ export const menuGroupStyle = css`
 `;
 
 export const menuListStyle = css`
-  && {
-    padding: 8px 0;
-  }
+  padding: 8px 0;
 `;
 
 export const menuItemStyle = (theme: Theme) => css`
   width: calc(100% - 40px);
+
+  &:focus {
+    > [wds-component='with-interaction'] {
+      opacity: ${theme.opacity[0]};
+    }
+
+    &:hover {
+      > [wds-component='with-interaction'] {
+        opacity: ${theme.opacity[5]};
+      }
+    }
+  }
 
   &:focus-visible {
     outline: none;
@@ -68,7 +78,7 @@ export const menuBottomStyle = (theme: Theme) => css`
   max-height: 56px;
   background-color: ${theme.palette.background.elevated.normal};
   z-index: 10;
-  border: 1px solid ${theme.palette.line.solid.alternative};
+  border-top: 1px solid ${theme.palette.line.solid.alternative};
 `;
 
 export const menuBottomContentStyle = (theme: Theme) => css`

--- a/packages/wds/src/components/menu/types.ts
+++ b/packages/wds/src/components/menu/types.ts
@@ -13,7 +13,15 @@ export type MenuProps = Merge<MenuDefaultProps, PopoverProps>;
 
 export type MenuContentPopoverContentProps = Pick<
   PopoverContentProps,
-  'position' | 'offset' | 'container' | 'disablePortal'
+  | 'position'
+  | 'offset'
+  | 'container'
+  | 'disablePortal'
+  | 'trappedContent'
+  | 'onMountAutoFocus'
+  | 'onUnmountAutoFocus'
+  | 'trapped'
+  | 'loop'
 >;
 export type MenuContentProps = MenuContentPopoverContentProps;
 

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { forwardRef, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 import {
   IconChevronDownThickSmall,
   IconChevronUpThickSmall,
@@ -10,6 +10,7 @@ import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useSize } from '@radix-ui/react-use-size';
+import { Box, type DefaultComponentProps } from '@wanteddev/wds-engine';
 
 import { Menu, MenuContent, MenuList, MenuTrigger } from '../menu';
 import FlexBox from '../flex-box';
@@ -17,14 +18,13 @@ import Typography from '../typography';
 import { ellipsisTypographyStyle } from '../../utils';
 import { SelectContent } from '../select';
 import { convertChildrenToData } from '../select/helpers';
-
 import {
   invalidIconWrapperStyle,
+  selectBubbleInputStyle,
   selectIconStyle,
-  selectMultipleStyle,
-} from './style';
+  selectStyle,
+} from '../select/style';
 
-import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { SelectMultipleProps } from './types';
 
 const SelectMultiple = forwardRef<
@@ -62,7 +62,7 @@ const SelectMultiple = forwardRef<
   ) => {
     const [node, setNode] = useState<HTMLDivElement | null>(null);
 
-    const { width: contentWidth } = useSize(node) || {};
+    const { width: contentWidth, height: contentHeight } = useSize(node) || {};
 
     const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
 
@@ -101,139 +101,175 @@ const SelectMultiple = forwardRef<
         .map(({ label: labelValue }) => labelValue);
     }, [value, children]);
 
-    return (
-      <Menu
-        value={enableMenuBottom ? menuValue : value}
-        onValueChange={useCallbackRef(
-          (v: string | Array<string> | undefined) => {
-            if (!Array.isArray(v) && process.env.NODE_ENV !== 'production') {
-              throw new Error(
-                'SelectMultiple 값에 오류가 발생했습니다. radio를 사용하였거나 value가 Array 형식이 아닌지 확인해주세요.',
-              );
-            }
+    const isFormControl = node ? Boolean(node.closest('form')) : true;
 
-            if (enableMenuBottom) {
-              setMenuValue(v as Array<string>);
-            } else {
-              setValue(v as Array<string>);
-            }
-          },
-        )}
-        open={open && !disabled}
-        onOpenChange={setOpen}
-      >
-        <MenuTrigger>
-          <FlexBox
-            ref={composedRefs}
-            gap="8px"
+    const initialValueStateRef = useRef(value);
+
+    useEffect(() => {
+      const form = node?.closest('form');
+
+      if (form) {
+        const reset = () => setValue(initialValueStateRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [node, setValue]);
+
+    return (
+      <>
+        {isFormControl && (
+          <Box
+            as="input"
+            name={props.name}
+            value={value.join(',')}
             aria-invalid={invalid}
-            aria-disabled={disabled}
-            tabIndex={disabled ? -1 : 0}
-            role="combobox"
-            data-placeholder={shouldShowPlaceholder}
-            {...props}
-            onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
-              if (
-                (e.key === 'Enter' || e.key === ' ') &&
-                (e.target as HTMLElement) === node
-              ) {
-                e.preventDefault();
-                e.currentTarget.click();
-              }
-            })}
+            disabled={disabled}
+            tabIndex={-1}
+            aria-hidden
+            readOnly
             sx={[
-              selectMultipleStyle({
-                disabled,
-                invalid,
-                width,
-                height,
-                xs,
-                sm,
-                md,
-                lg,
-                xl,
-                ...props,
-              }),
-              props.sx,
+              {
+                width: contentWidth,
+                height: contentHeight,
+              },
+              selectBubbleInputStyle,
+            ]}
+          />
+        )}
+
+        <Menu
+          value={enableMenuBottom ? menuValue : value}
+          onValueChange={useCallbackRef(
+            (v: string | Array<string> | undefined) => {
+              if (!Array.isArray(v) && process.env.NODE_ENV !== 'production') {
+                throw new Error(
+                  'SelectMultiple 값에 오류가 발생했습니다. radio를 사용하였거나 value가 Array 형식이 아닌지 확인해주세요.',
+                );
+              }
+
+              if (enableMenuBottom) {
+                setMenuValue(v as Array<string>);
+              } else {
+                setValue(v as Array<string>);
+              }
+            },
+          )}
+          open={open && !disabled}
+          onOpenChange={setOpen}
+        >
+          <MenuTrigger>
+            <FlexBox
+              ref={composedRefs}
+              gap="8px"
+              aria-invalid={invalid}
+              aria-disabled={disabled}
+              tabIndex={disabled ? -1 : 0}
+              role="combobox"
+              data-placeholder={shouldShowPlaceholder}
+              {...props}
+              onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
+                if (
+                  (e.key === 'Enter' || e.key === ' ') &&
+                  (e.target as HTMLElement) === node
+                ) {
+                  e.preventDefault();
+                  e.currentTarget.click();
+                }
+              })}
+              sx={[
+                selectStyle({
+                  disabled,
+                  invalid,
+                  width,
+                  height,
+                  xs,
+                  sm,
+                  md,
+                  lg,
+                  xl,
+                  ...props,
+                }),
+                props.sx,
+              ]}
+            >
+              {Boolean(leftContent) && leftContent}
+
+              {(typeof render === 'undefined' || shouldShowPlaceholder) && (
+                <FlexBox
+                  flex="1"
+                  gap="4px"
+                  data-role="select-multiple-render-wrapper"
+                  sx={{ padding: '0px 4px', overflow: 'hidden' }}
+                >
+                  {shouldShowPlaceholder ? (
+                    <Typography
+                      data-role="select-multiple-placeholder"
+                      noWrap
+                      variant="body1_normal"
+                      weight="regular"
+                      sx={ellipsisTypographyStyle(1)}
+                    >
+                      {placeholder}
+                    </Typography>
+                  ) : (
+                    <Typography
+                      data-role="select-multiple-values"
+                      noWrap
+                      variant="body1_normal"
+                      weight="regular"
+                      sx={ellipsisTypographyStyle(1)}
+                    >
+                      {label.join(', ')}
+                    </Typography>
+                  )}
+                </FlexBox>
+              )}
+
+              {typeof render === 'function' && !shouldShowPlaceholder && (
+                <FlexBox
+                  flex="1"
+                  gap="4px"
+                  flexWrap="wrap"
+                  data-role="select-multiple-render-wrapper"
+                >
+                  {render(label, value)}
+                </FlexBox>
+              )}
+
+              {invalid && (
+                <SelectContent
+                  data-role="select-multiple-invalid"
+                  variant="icon"
+                  sx={invalidIconWrapperStyle}
+                >
+                  <IconCircleExclamationFill />
+                </SelectContent>
+              )}
+
+              {open ? (
+                <IconChevronUpThickSmall sx={selectIconStyle({ disabled })} />
+              ) : (
+                <IconChevronDownThickSmall sx={selectIconStyle({ disabled })} />
+              )}
+            </FlexBox>
+          </MenuTrigger>
+
+          <MenuContent
+            {...contentProps}
+            sx={[
+              { width: contentWidth ?? '320px', minWidth: '140px' },
+              contentProps?.sx,
             ]}
           >
-            {Boolean(leftContent) && leftContent}
-
-            {(typeof render === 'undefined' || shouldShowPlaceholder) && (
-              <FlexBox
-                flex="1"
-                gap="4px"
-                data-role="select-multiple-render-wrapper"
-                sx={{ padding: '0px 4px', overflow: 'hidden' }}
-              >
-                {shouldShowPlaceholder ? (
-                  <Typography
-                    data-role="select-multiple-placeholder"
-                    noWrap
-                    variant="body1_normal"
-                    weight="regular"
-                    sx={ellipsisTypographyStyle(1)}
-                  >
-                    {placeholder}
-                  </Typography>
-                ) : (
-                  <Typography
-                    data-role="select-multiple-values"
-                    noWrap
-                    variant="body1_normal"
-                    weight="regular"
-                    sx={ellipsisTypographyStyle(1)}
-                  >
-                    {label.join(', ')}
-                  </Typography>
-                )}
-              </FlexBox>
-            )}
-
-            {typeof render === 'function' && !shouldShowPlaceholder && (
-              <FlexBox
-                flex="1"
-                gap="4px"
-                flexWrap="wrap"
-                data-role="select-multiple-render-wrapper"
-              >
-                {render(label, value)}
-              </FlexBox>
-            )}
-
-            {invalid && (
-              <SelectContent
-                data-role="select-multiple-invalid"
-                variant="icon"
-                sx={invalidIconWrapperStyle}
-              >
-                <IconCircleExclamationFill />
-              </SelectContent>
-            )}
-
-            {open ? (
-              <IconChevronUpThickSmall sx={selectIconStyle({ disabled })} />
-            ) : (
-              <IconChevronDownThickSmall sx={selectIconStyle({ disabled })} />
-            )}
-          </FlexBox>
-        </MenuTrigger>
-
-        <MenuContent
-          {...contentProps}
-          sx={[
-            { width: contentWidth ?? '320px', minWidth: '140px' },
-            contentProps?.sx,
-          ]}
-        >
-          <MenuList
-            role="listbox"
-            sx={enableMenuBottom ? { paddingBottom: '0px' } : undefined}
-          >
-            {children}
-          </MenuList>
-        </MenuContent>
-      </Menu>
+            <MenuList
+              role="listbox"
+              sx={enableMenuBottom ? { paddingBottom: '0px' } : undefined}
+            >
+              {children}
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      </>
     );
   },
 );

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -47,6 +47,9 @@ const SelectMultiple = forwardRef<
       render,
       width,
       height,
+      enableMenuBottom,
+      menuValue: menuValueProp,
+      onMenuValueChange,
       contentProps,
       xs,
       sm,
@@ -63,16 +66,28 @@ const SelectMultiple = forwardRef<
 
     const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
 
+    const [menuValue = [], setMenuValue] = useControllableState({
+      prop: menuValueProp,
+      defaultProp: defaultValue,
+      onChange: onMenuValueChange,
+    });
+
     const [value = [], setValue] = useControllableState({
       prop: valueProp,
       defaultProp: defaultValue,
-      onChange: onValueChange,
+      onChange: (v) => {
+        setMenuValue(v);
+        onValueChange?.(v);
+      },
     });
 
     const [open = false, setOpen] = useControllableState({
       prop: openProp,
       defaultProp: defaultOpen,
-      onChange: onOpenChange,
+      onChange: (v) => {
+        setMenuValue(value);
+        onOpenChange?.(v);
+      },
     });
 
     const shouldShowPlaceholder = useMemo(
@@ -80,15 +95,15 @@ const SelectMultiple = forwardRef<
       [value.length],
     );
 
-    const textValue = useMemo(() => {
+    const label = useMemo(() => {
       return convertChildrenToData(children)
         .filter((v) => value.includes(v.value))
-        .map(({ label }) => label);
+        .map(({ label: labelValue }) => labelValue);
     }, [value, children]);
 
     return (
       <Menu
-        value={value}
+        value={enableMenuBottom ? menuValue : value}
         onValueChange={useCallbackRef(
           (v: string | Array<string> | undefined) => {
             if (!Array.isArray(v) && process.env.NODE_ENV !== 'production') {
@@ -97,7 +112,11 @@ const SelectMultiple = forwardRef<
               );
             }
 
-            setValue(v as Array<string>);
+            if (enableMenuBottom) {
+              setMenuValue(v as Array<string>);
+            } else {
+              setValue(v as Array<string>);
+            }
           },
         )}
         open={open && !disabled}
@@ -165,30 +184,20 @@ const SelectMultiple = forwardRef<
                     weight="regular"
                     sx={ellipsisTypographyStyle(1)}
                   >
-                    {textValue.join(', ')}
+                    {label.join(', ')}
                   </Typography>
                 )}
               </FlexBox>
             )}
 
-            {typeof render === 'function' && (
+            {typeof render === 'function' && !shouldShowPlaceholder && (
               <FlexBox
                 flex="1"
                 gap="4px"
                 flexWrap="wrap"
                 data-role="select-multiple-render-wrapper"
-                onClick={(e) => {
-                  const closest = (e.target as HTMLElement).closest(
-                    '[role="checkbox"], [role="radio"], button:not([role="switch"]), [role="button"], a, [data-role="select-multiple-render-wrapper"]',
-                  );
-
-                  if (Boolean(closest) && closest !== e.currentTarget) {
-                    e.stopPropagation();
-                    node?.focus();
-                  }
-                }}
               >
-                {render(textValue, value)}
+                {render(label, value)}
               </FlexBox>
             )}
 
@@ -217,7 +226,12 @@ const SelectMultiple = forwardRef<
             contentProps?.sx,
           ]}
         >
-          <MenuList role="listbox">{children}</MenuList>
+          <MenuList
+            role="listbox"
+            sx={enableMenuBottom ? { paddingBottom: '0px' } : undefined}
+          >
+            {children}
+          </MenuList>
         </MenuContent>
       </Menu>
     );

--- a/packages/wds/src/components/select-multiple/types.ts
+++ b/packages/wds/src/components/select-multiple/types.ts
@@ -13,11 +13,15 @@ export type SelectMultipleDefaultProps = {
   leftContent?: ReactNode;
   onValueChange?: (value: Array<string>) => void;
   placeholder?: string;
-  render?: (textValue: Array<string>, value: Array<string>) => ReactNode;
+  render?: (label: Array<string>, value: Array<string>) => ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (state: boolean) => void;
   contentProps?: ComponentProps<typeof MenuContent>;
+
+  enableMenuBottom?: boolean;
+  menuValue?: Array<string>;
+  onMenuValueChange?: (value: Array<string>) => void;
 };
 
 export type SelectMultipleResponsiveProps = ResponsiveProps<

--- a/packages/wds/src/components/select/context.ts
+++ b/packages/wds/src/components/select/context.ts
@@ -4,6 +4,7 @@ import { SELECT_NAME } from './constants';
 
 type SelectContextType = {
   onOpenChange: (open: boolean) => void;
+  enableMenuBottom?: boolean;
 };
 
 export const [SelectProvider, useSelectContext] =

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -1,4 +1,12 @@
-import { type ElementType, forwardRef, memo, useMemo, useState } from 'react';
+import {
+  type ElementType,
+  forwardRef,
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   IconChevronDownThickSmall,
   IconChevronUpThickSmall,
@@ -6,6 +14,7 @@ import {
 } from '@wanteddev/wds-icon';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import {
+  Box,
   type DefaultComponentProps,
   type PolymorphicComponent,
   type PolymorphicProps,
@@ -27,13 +36,14 @@ import { TextInputContent } from '../text-input';
 import { ListText } from '../list';
 import FlexBox from '../flex-box';
 import Typography from '../typography';
-import {
-  selectIconStyle,
-  selectMultipleStyle,
-  selectTextStyle,
-} from '../select-multiple/style';
 import { invalidIconWrapperStyle } from '../text-input/style';
 
+import {
+  selectBubbleInputStyle,
+  selectIconStyle,
+  selectStyle,
+  selectTextStyle,
+} from './style';
 import { convertChildrenToData } from './helpers';
 import {
   OPTION_GROUP_NAME,
@@ -81,7 +91,7 @@ const Select = forwardRef<
   ) => {
     const [node, setNode] = useState<HTMLDivElement | null>(null);
 
-    const { width: contentWidth } = useSize(node) || {};
+    const { width: contentWidth, height: contentHeight } = useSize(node) || {};
 
     const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
 
@@ -121,11 +131,44 @@ const Select = forwardRef<
       );
     }, [value, children]);
 
+    const isFormControl = node ? Boolean(node.closest('form')) : true;
+
+    const initialValueStateRef = useRef(value);
+
+    useEffect(() => {
+      const form = node?.closest('form');
+
+      if (form) {
+        const reset = () => setValue(initialValueStateRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [node, setValue]);
+
     return (
       <SelectProvider
         onOpenChange={setOpen}
         enableMenuBottom={enableMenuBottom}
       >
+        {isFormControl && (
+          <Box
+            as="input"
+            name={props.name}
+            value={value}
+            aria-invalid={invalid}
+            disabled={disabled}
+            tabIndex={-1}
+            readOnly
+            aria-hidden
+            sx={[
+              {
+                width: contentWidth,
+                height: contentHeight,
+              },
+              selectBubbleInputStyle,
+            ]}
+          />
+        )}
         <Menu
           value={enableMenuBottom ? menuValue : value}
           onValueChange={useCallbackRef(
@@ -166,7 +209,7 @@ const Select = forwardRef<
                 }
               })}
               sx={[
-                selectMultipleStyle({
+                selectStyle({
                   disabled,
                   invalid,
                   width,

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -56,7 +56,7 @@ const Select = forwardRef<
       defaultValue = '',
       onValueChange,
       defaultOpen,
-      open: openProps,
+      open: openProp,
       onOpenChange,
       width,
       height,
@@ -65,6 +65,9 @@ const Select = forwardRef<
       render,
       placeholder,
       leftContent,
+      enableMenuBottom,
+      menuValue: menuValueProp,
+      onMenuValueChange,
       xs,
       sm,
       md,
@@ -82,16 +85,28 @@ const Select = forwardRef<
 
     const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
 
+    const [menuValue = '', setMenuValue] = useControllableState({
+      prop: menuValueProp,
+      defaultProp: defaultValue,
+      onChange: onMenuValueChange,
+    });
+
     const [value = '', setValue] = useControllableState({
       prop: valueProp,
       defaultProp: defaultValue,
-      onChange: onValueChange,
+      onChange: (v) => {
+        setMenuValue(v);
+        onValueChange?.(v);
+      },
     });
 
     const [open = false, setOpen] = useControllableState({
-      prop: openProps,
+      prop: openProp,
       defaultProp: defaultOpen,
-      onChange: onOpenChange,
+      onChange: (v) => {
+        setMenuValue(value);
+        onOpenChange?.(v);
+      },
     });
 
     const shouldShowPlaceholder = useMemo(
@@ -99,7 +114,7 @@ const Select = forwardRef<
       [value.length],
     );
 
-    const textValue = useMemo(() => {
+    const label = useMemo(() => {
       return (
         convertChildrenToData(children).find((v) => v.value === value)?.label ??
         ''
@@ -107,9 +122,12 @@ const Select = forwardRef<
     }, [value, children]);
 
     return (
-      <SelectProvider onOpenChange={setOpen}>
+      <SelectProvider
+        onOpenChange={setOpen}
+        enableMenuBottom={enableMenuBottom}
+      >
         <Menu
-          value={value}
+          value={enableMenuBottom ? menuValue : value}
           onValueChange={useCallbackRef(
             (v: string | Array<string> | undefined) => {
               if (Array.isArray(v) && process.env.NODE_ENV !== 'production') {
@@ -118,7 +136,11 @@ const Select = forwardRef<
                 );
               }
 
-              setValue(v as string);
+              if (enableMenuBottom) {
+                setMenuValue(v as string);
+              } else {
+                setValue(v as string);
+              }
             },
           )}
           open={open && !disabled}
@@ -186,30 +208,20 @@ const Select = forwardRef<
                       weight="regular"
                       sx={selectTextStyle}
                     >
-                      {textValue}
+                      {label}
                     </Typography>
                   )}
                 </FlexBox>
               )}
 
-              {typeof render === 'function' && (
+              {typeof render === 'function' && !shouldShowPlaceholder && (
                 <FlexBox
                   flex="1"
                   gap="4px"
                   flexWrap="wrap"
                   data-role="select-render-wrapper"
-                  onClick={(e) => {
-                    const closest = (e.target as HTMLElement).closest(
-                      '[role="checkbox"], [role="radio"], button:not([role="switch"]), [role="button"], a, [data-role="select-multiple-render-wrapper"]',
-                    );
-
-                    if (Boolean(closest) && closest !== e.currentTarget) {
-                      e.stopPropagation();
-                      node?.focus();
-                    }
-                  }}
                 >
-                  {render(textValue, value)}
+                  {render(label, value)}
                 </FlexBox>
               )}
 
@@ -238,7 +250,12 @@ const Select = forwardRef<
               contentProps?.sx,
             ]}
           >
-            <MenuList role="listbox">{children}</MenuList>
+            <MenuList
+              role="listbox"
+              sx={enableMenuBottom ? { paddingBottom: '0px' } : undefined}
+            >
+              {children}
+            </MenuList>
           </MenuContent>
         </Menu>
       </SelectProvider>
@@ -269,7 +286,7 @@ const Option = memo(
       }: PolymorphicProps<OptionProps, E>,
       ref: ForwardedRef<ElementRef<E>>,
     ) => {
-      const { onOpenChange } = useSelectContext() || {};
+      const { onOpenChange, enableMenuBottom } = useSelectContext() || {};
 
       return (
         <MenuItem
@@ -278,7 +295,7 @@ const Option = memo(
           variant={variant}
           {...props}
           onClick={composeEventHandlers(props.onClick, () => {
-            if (variant !== 'radio') {
+            if (variant !== 'radio' && !enableMenuBottom) {
               onOpenChange?.(false);
             }
           })}

--- a/packages/wds/src/components/select/style.ts
+++ b/packages/wds/src/components/select/style.ts
@@ -7,15 +7,9 @@ import {
 } from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
-import type { SelectMultipleProps } from './types';
+import type { SelectMultipleProps } from '../select-multiple/types';
 
-export const selectWrapperStyle = css`
-  width: fit-content;
-  height: fit-content;
-  position: relative;
-`;
-
-export const selectMultipleStyle =
+export const selectStyle =
   ({
     invalid,
     width = 'initial',
@@ -182,4 +176,13 @@ export const selectIconStyle =
 export const selectTextStyle = css`
   ${ellipsisTypographyStyle(1)}
   user-select: none;
+`;
+
+export const selectBubbleInputStyle = css`
+  display: none;
+  pointer-events: none;
+  position: absolute;
+  opacity: 0;
+  margin: 0;
+  transform: translateX(-100%);
 `;

--- a/packages/wds/src/components/select/types.ts
+++ b/packages/wds/src/components/select/types.ts
@@ -13,13 +13,17 @@ export type SelectDefaultProps = {
   defaultValue?: string;
   placeholder?: string;
   leftContent?: ReactNode;
-  render?: (textValue: string, value: string) => ReactNode;
+  render?: (label: string, value: string) => ReactNode;
   onValueChange?: (value: string) => void;
   contentProps?: ComponentProps<typeof MenuContent>;
   // Popover props
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (state: boolean) => void;
+
+  enableMenuBottom?: boolean;
+  menuValue?: string;
+  onMenuValueChange?: (value: string) => void;
 };
 
 export type SelectResponsiveProps = ResponsiveProps<


### PR DESCRIPTION
- stopPropagation -> select, select-multiple에서 처리하던 부분 직접 처리하도록 변경
- render 함수가 있는 경우 placeholder랑 겹치는 현상 수정
- enableMenuBottom 옵션으로 메뉴 바텀을 활성화한 경우 menuValue라는 내부값을 조정 가능
  - 이 때 menu 내부에서 값을 선택한 경우 실제 select value는 변경되지 않으며 menuValue라는 내부 값만 변경됨
- menuContent에 `trappedContent` Prop을 주어서 자동으로 active값 혹은 첫번째 값 포커스 처리
- form 내부 구성요소로 사용할 때 가짜 input 대응, form reset 대응


enableMenuBottom를 활성화 하지 않은 경우:
기존과 동일하게 value라는 상태값 사용

enableMenuBottom을 활성화 한 경우:
![image](https://github.com/user-attachments/assets/90c5beb5-5157-4896-9d3b-af21157ccb1e)
