### PR TITLE
feat(wds): PI-68051 [WDS] Select/Multiple에서 Overflow 속성 추가

### DIFF
--- a/docs/src/docs/components/select-multiple.mdx
+++ b/docs/src/docs/components/select-multiple.mdx
@@ -11,6 +11,7 @@ description: Select Multiple Component
 
 - 여러 옵션 중 하나의 값을 선택할 수 있어요.
 - leftContent에 요소를 추가 할 때는 `SelectContent`로 감싸서 사용합니다.
+- 모든 옵션을 스크롤 없이 노출하고 싶다면 overflow=true로 설정해주세요.
 
 <Demo code={`import { SelectMultiple, Option, OptionGroup, Label, FlexBox } from '@wanteddev/wds';
 

--- a/docs/src/docs/components/select-multiple.mdx
+++ b/docs/src/docs/components/select-multiple.mdx
@@ -11,7 +11,7 @@ description: Select Multiple Component
 
 - 여러 옵션 중 하나의 값을 선택할 수 있어요.
 - leftContent에 요소를 추가 할 때는 `SelectContent`로 감싸서 사용합니다.
-- 모든 옵션을 스크롤 없이 노출하고 싶다면 overflow=true로 설정해주세요.
+- 모든 옵션을 스크롤 없이 노출할 때는 overflow=true로 설정해주세요.
 
 <Demo code={`import { SelectMultiple, Option, OptionGroup, Label, FlexBox } from '@wanteddev/wds';
 

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -83,6 +83,7 @@ const SelectMultiple = forwardRef<
     const [isScrollable, setIsScrollable] = useState(false);
     const [scrollLeft, setScrollLeft] = useState(0);
     const [scrollWidth, setScrollWidth] = useState(0);
+    const [clientWidth, setClientWidth] = useState(0);
 
     const [menuValue = [], setMenuValue] = useControllableState({
       prop: menuValueProp,
@@ -119,16 +120,13 @@ const SelectMultiple = forwardRef<
     );
 
     useEffect(() => {
-      if (
-        scrollWidth - scrollLeft <=
-        (renderWrapperNode?.clientWidth || 0) + 1
-      ) {
+      if (scrollWidth - scrollLeft <= (clientWidth || 0) + 1) {
         setIsScrollable(false);
-      } else if (scrollWidth !== renderWrapperNode?.clientWidth) {
+      } else if (scrollWidth !== clientWidth) {
         setIsScrollable(true);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scrollLeft, scrollWidth, renderWrapperNode?.clientWidth]);
+    }, [scrollLeft, scrollWidth, clientWidth]);
 
     const handleResize = useCallback(() => {
       const target = renderWrapperNode;
@@ -138,9 +136,11 @@ const SelectMultiple = forwardRef<
 
       const targetScrollWidth = target.scrollWidth;
       const targetScrollLeft = target.scrollLeft;
+      const targetClientWidth = target.clientWidth;
 
       setScrollLeft(targetScrollLeft);
       setScrollWidth(targetScrollWidth);
+      setClientWidth(targetClientWidth);
     }, [renderWrapperNode]);
 
     useResizeObserver(renderWrapperNode, handleResize);

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -130,13 +130,6 @@ const SelectMultiple = forwardRef<
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [scrollLeft, scrollWidth]);
 
-    useEffect(() => {
-      if (overflow === false) {
-        setScrollWidth(renderWrapperNode?.scrollWidth || 0);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [enableMenuBottom ? menuValue.length : value.length]);
-
     const handleResize = useCallback(() => {
       const target = renderWrapperNode;
       if (!target) {
@@ -148,8 +141,7 @@ const SelectMultiple = forwardRef<
 
       setScrollLeft(targetScrollLeft);
       setScrollWidth(targetScrollWidth);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [setScrollLeft]);
+    }, [renderWrapperNode]);
 
     useResizeObserver(renderWrapperNode, handleResize);
 
@@ -293,18 +285,20 @@ const SelectMultiple = forwardRef<
 
               {typeof render === 'function' && !shouldShowPlaceholder && (
                 <FlexBox
-                  ref={setRenderWrapperNode}
                   flex="1"
-                  gap="4px"
-                  flexWrap="wrap"
                   data-role="select-multiple-render-wrapper"
-                  onScrollCapture={handleOnScroll}
                   sx={customSelectMultipleRenderWrapperStyle({
                     overflow,
                     isScrollable,
                   })}
                 >
-                  {render(label, value)}
+                  <FlexBox
+                    ref={setRenderWrapperNode}
+                    gap="4px"
+                    onScrollCapture={handleOnScroll}
+                  >
+                    {render(label, value)}
+                  </FlexBox>
                 </FlexBox>
               )}
 

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -1,5 +1,12 @@
 'use client';
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   IconChevronDownThickSmall,
   IconChevronUpThickSmall,
@@ -24,9 +31,11 @@ import {
   selectIconStyle,
   selectStyle,
 } from '../select/style';
+import useResizeObserver from '../../hooks/use-resize-observer';
 
 import { customSelectMultipleRenderWrapperStyle } from './style';
 
+import type { UIEventHandler } from 'react';
 import type { SelectMultipleProps } from './types';
 
 const SelectMultiple = forwardRef<
@@ -64,10 +73,16 @@ const SelectMultiple = forwardRef<
     forwardedRef,
   ) => {
     const [node, setNode] = useState<HTMLDivElement | null>(null);
+    const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
+
+    const [renderWrapperNode, setRenderWrapperNode] =
+      useState<HTMLDivElement | null>(null);
 
     const { width: contentWidth, height: contentHeight } = useSize(node) || {};
 
-    const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
+    const [isScrollable, setIsScrollable] = useState(false);
+    const [scrollLeft, setScrollLeft] = useState(0);
+    const [scrollWidth, setScrollWidth] = useState(0);
 
     const [menuValue = [], setMenuValue] = useControllableState({
       prop: menuValueProp,
@@ -93,6 +108,51 @@ const SelectMultiple = forwardRef<
       },
     });
 
+    const handleOnScroll: UIEventHandler<HTMLDivElement> = useCallback(
+      (e) => {
+        const target = e.target as Element;
+
+        setScrollLeft(target.scrollLeft);
+        setScrollWidth(target.scrollWidth);
+      },
+      [setScrollLeft, setScrollWidth],
+    );
+
+    useEffect(() => {
+      if (
+        scrollWidth - scrollLeft <=
+        (renderWrapperNode?.clientWidth || 0) + 1
+      ) {
+        setIsScrollable(false);
+      } else if (scrollWidth !== renderWrapperNode?.clientWidth) {
+        setIsScrollable(true);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scrollLeft, scrollWidth]);
+
+    useEffect(() => {
+      if (overflow === false) {
+        setScrollWidth(renderWrapperNode?.scrollWidth || 0);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enableMenuBottom ? menuValue.length : value.length]);
+
+    const handleResize = useCallback(() => {
+      const target = renderWrapperNode;
+      if (!target) {
+        return;
+      }
+
+      const targetScrollWidth = target.scrollWidth;
+      const targetScrollLeft = target.scrollLeft;
+
+      setScrollLeft(targetScrollLeft);
+      setScrollWidth(targetScrollWidth);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [setScrollLeft]);
+
+    useResizeObserver(renderWrapperNode, handleResize);
+
     const shouldShowPlaceholder = useMemo(
       () => value.length === 0,
       [value.length],
@@ -105,7 +165,6 @@ const SelectMultiple = forwardRef<
     }, [value, children]);
 
     const isFormControl = node ? Boolean(node.closest('form')) : true;
-
     const initialValueStateRef = useRef(value);
 
     useEffect(() => {
@@ -233,11 +292,16 @@ const SelectMultiple = forwardRef<
 
               {typeof render === 'function' && !shouldShowPlaceholder && (
                 <FlexBox
+                  ref={setRenderWrapperNode}
                   flex="1"
                   gap="4px"
                   flexWrap="wrap"
                   data-role="select-multiple-render-wrapper"
-                  sx={customSelectMultipleRenderWrapperStyle(overflow)}
+                  onScrollCapture={handleOnScroll}
+                  sx={customSelectMultipleRenderWrapperStyle({
+                    overflow,
+                    isScrollable,
+                  })}
                 >
                   {render(label, value)}
                 </FlexBox>

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -165,6 +165,7 @@ const SelectMultiple = forwardRef<
     }, [value, children]);
 
     const isFormControl = node ? Boolean(node.closest('form')) : true;
+
     const initialValueStateRef = useRef(value);
 
     useEffect(() => {

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -80,7 +80,9 @@ const SelectMultiple = forwardRef<
 
     const { width: contentWidth, height: contentHeight } = useSize(node) || {};
 
-    const [isScrollable, setIsScrollable] = useState(false);
+    const [isScrollableLeft, setIsScrollableLeft] = useState(false);
+    const [isScrollableRight, setIsScrollableRight] = useState(false);
+
     const [scrollLeft, setScrollLeft] = useState(0);
     const [scrollWidth, setScrollWidth] = useState(0);
     const [clientWidth, setClientWidth] = useState(0);
@@ -120,10 +122,12 @@ const SelectMultiple = forwardRef<
     );
 
     useEffect(() => {
+      setIsScrollableLeft(scrollLeft > 0);
+
       if (scrollWidth - scrollLeft <= (clientWidth || 0) + 1) {
-        setIsScrollable(false);
+        setIsScrollableRight(false);
       } else if (scrollWidth !== clientWidth) {
-        setIsScrollable(true);
+        setIsScrollableRight(true);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [scrollLeft, scrollWidth, clientWidth]);
@@ -289,7 +293,8 @@ const SelectMultiple = forwardRef<
                   data-role="select-multiple-render-wrapper"
                   sx={customSelectMultipleRenderWrapperStyle({
                     overflow,
-                    isScrollable,
+                    isScrollableLeft,
+                    isScrollableRight,
                   })}
                 >
                   <FlexBox

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -25,6 +25,8 @@ import {
   selectStyle,
 } from '../select/style';
 
+import { customSelectMultipleRenderWrapperStyle } from './style';
+
 import type { SelectMultipleProps } from './types';
 
 const SelectMultiple = forwardRef<
@@ -48,6 +50,7 @@ const SelectMultiple = forwardRef<
       width,
       height,
       enableMenuBottom,
+      overflow = false,
       menuValue: menuValueProp,
       onMenuValueChange,
       contentProps,
@@ -182,6 +185,7 @@ const SelectMultiple = forwardRef<
                   invalid,
                   width,
                   height,
+                  overflow,
                   xs,
                   sm,
                   md,
@@ -231,6 +235,7 @@ const SelectMultiple = forwardRef<
                   gap="4px"
                   flexWrap="wrap"
                   data-role="select-multiple-render-wrapper"
+                  sx={customSelectMultipleRenderWrapperStyle(overflow)}
                 >
                   {render(label, value)}
                 </FlexBox>

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -218,10 +218,12 @@ const SelectMultiple = forwardRef<
                   ) : (
                     <Typography
                       data-role="select-multiple-values"
-                      noWrap
                       variant="body1_normal"
                       weight="regular"
-                      sx={ellipsisTypographyStyle(1)}
+                      {...(overflow === false && {
+                        noWrap: true,
+                        sx: ellipsisTypographyStyle(1),
+                      })}
                     >
                       {label.join(', ')}
                     </Typography>

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -128,7 +128,7 @@ const SelectMultiple = forwardRef<
         setIsScrollable(true);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scrollLeft, scrollWidth]);
+    }, [scrollLeft, scrollWidth, renderWrapperNode?.clientWidth]);
 
     const handleResize = useCallback(() => {
       const target = renderWrapperNode;

--- a/packages/wds/src/components/select-multiple/style.ts
+++ b/packages/wds/src/components/select-multiple/style.ts
@@ -11,17 +11,19 @@ export const customSelectMultipleRenderWrapperStyle = ({
 }) =>
   overflow === false &&
   css`
-    flex-wrap: nowrap;
-    overflow-y: hidden;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-
+    overflow: hidden;
     ${isScrollable &&
     css`
       ${gradient('transparent', 'right', '40px')}
     `}
+
+    > div {
+      overflow: scroll;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+    }
   `;

--- a/packages/wds/src/components/select-multiple/style.ts
+++ b/packages/wds/src/components/select-multiple/style.ts
@@ -4,15 +4,18 @@ import { gradient } from '../../utils';
 
 export const customSelectMultipleRenderWrapperStyle = ({
   overflow,
-  isScrollable,
+  isScrollableLeft,
+  isScrollableRight,
 }: {
   overflow: boolean;
-  isScrollable: boolean;
+  isScrollableLeft: boolean;
+  isScrollableRight: boolean;
 }) =>
   overflow === false &&
   css`
     overflow: hidden;
-    ${isScrollable &&
+
+    ${isScrollableRight &&
     css`
       ${gradient('transparent', 'right', '40px')}
     `}
@@ -25,5 +28,10 @@ export const customSelectMultipleRenderWrapperStyle = ({
       }
       -ms-overflow-style: none;
       scrollbar-width: none;
+
+      ${isScrollableLeft &&
+      css`
+        ${gradient('transparent', 'left', '40px')}
+      `}
     }
   `;

--- a/packages/wds/src/components/select-multiple/style.ts
+++ b/packages/wds/src/components/select-multiple/style.ts
@@ -1,0 +1,21 @@
+import { css } from '@wanteddev/wds-engine';
+
+import { gradient } from '../../utils';
+
+import type { Theme } from '@wanteddev/wds-engine';
+
+export const customSelectMultipleRenderWrapperStyle =
+  (overflow: boolean) => (theme: Theme) => css`
+    ${!overflow &&
+    css`
+      ${gradient(theme.palette.background.normal.normal, 'right', '40px')}
+      flex-wrap: nowrap;
+      overflow-y: hidden;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+    `}
+  `;

--- a/packages/wds/src/components/select-multiple/style.ts
+++ b/packages/wds/src/components/select-multiple/style.ts
@@ -2,24 +2,26 @@ import { css } from '@wanteddev/wds-engine';
 
 import { gradient } from '../../utils';
 
-import type { Theme } from '@wanteddev/wds-engine';
+export const customSelectMultipleRenderWrapperStyle = ({
+  overflow,
+  isScrollable,
+}: {
+  overflow: boolean;
+  isScrollable: boolean;
+}) =>
+  overflow === false &&
+  css`
+    flex-wrap: nowrap;
+    overflow-y: hidden;
 
-export const customSelectMultipleRenderWrapperStyle =
-  ({ overflow, isScrollable }: { overflow: boolean; isScrollable: boolean }) =>
-  (theme: Theme) =>
-    overflow === false &&
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+
+    ${isScrollable &&
     css`
-      flex-wrap: nowrap;
-      overflow-y: hidden;
-
-      &::-webkit-scrollbar {
-        display: none;
-      }
-      -ms-overflow-style: none;
-      scrollbar-width: none;
-
-      ${isScrollable &&
-      css`
-        ${gradient(theme.palette.background.normal.normal, 'right', '40px')}
-      `}
-    `;
+      ${gradient('transparent', 'right', '40px')}
+    `}
+  `;

--- a/packages/wds/src/components/select-multiple/style.ts
+++ b/packages/wds/src/components/select-multiple/style.ts
@@ -5,10 +5,10 @@ import { gradient } from '../../utils';
 import type { Theme } from '@wanteddev/wds-engine';
 
 export const customSelectMultipleRenderWrapperStyle =
-  (overflow: boolean) => (theme: Theme) => css`
-    ${overflow === false &&
+  ({ overflow, isScrollable }: { overflow: boolean; isScrollable: boolean }) =>
+  (theme: Theme) =>
+    overflow === false &&
     css`
-      ${gradient(theme.palette.background.normal.normal, 'right', '40px')}
       flex-wrap: nowrap;
       overflow-y: hidden;
 
@@ -17,5 +17,9 @@ export const customSelectMultipleRenderWrapperStyle =
       }
       -ms-overflow-style: none;
       scrollbar-width: none;
-    `}
-  `;
+
+      ${isScrollable &&
+      css`
+        ${gradient(theme.palette.background.normal.normal, 'right', '40px')}
+      `}
+    `;

--- a/packages/wds/src/components/select-multiple/style.ts
+++ b/packages/wds/src/components/select-multiple/style.ts
@@ -6,7 +6,7 @@ import type { Theme } from '@wanteddev/wds-engine';
 
 export const customSelectMultipleRenderWrapperStyle =
   (overflow: boolean) => (theme: Theme) => css`
-    ${!overflow &&
+    ${overflow === false &&
     css`
       ${gradient(theme.palette.background.normal.normal, 'right', '40px')}
       flex-wrap: nowrap;

--- a/packages/wds/src/components/select-multiple/types.ts
+++ b/packages/wds/src/components/select-multiple/types.ts
@@ -16,6 +16,7 @@ export type SelectMultipleDefaultProps = {
   render?: (label: Array<string>, value: Array<string>) => ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
+  overflow?: boolean;
   onOpenChange?: (state: boolean) => void;
   contentProps?: ComponentProps<typeof MenuContent>;
 

--- a/packages/wds/src/components/select/style.ts
+++ b/packages/wds/src/components/select/style.ts
@@ -23,7 +23,7 @@ export const selectStyle =
   }: SelectMultipleProps) =>
   (theme: Theme) => css`
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     border-radius: 12px;
     border: none;
     box-shadow:


### PR DESCRIPTION
- https://wantedlab.atlassian.net/browse/PI-68051
- https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=2965-4630&node-type=section&t=A6JKkmspIEGmugW9-0

## 작업 내용

- `SelectMuptile` overflow props 추가
  - overflow=false: gradient 적용, height 고정
  - overflow=true: height 변동
    - height가 늘어날 때, arrow icon 정렬 변경 (align-items: center --> align-items: flex-start)
- `Tab` 스크롤 계산 로직 추가
  - select 내부 요소가 추가/삭제될 때 scrollLeft, scrollWidth 재설정

## 스크린샷

### text, overflow=false
![스크린샷 2024-09-11 오후 1 34 22](https://github.com/user-attachments/assets/ae5b910a-95cc-4c53-abda-315de867c9ca)

### text, overflow=true
![스크린샷 2024-09-11 오후 1 33 20](https://github.com/user-attachments/assets/3ff0ea64-490f-4bdd-8c22-075ccd65736b)

### chip, overflow=true
https://github.com/user-attachments/assets/37ab8d90-1078-4eda-a413-a698fdd14f4b

### chip, overflow=false
![스크린샷 2024-09-11 오후 1 41 28](https://github.com/user-attachments/assets/91cc74d7-ae5f-4cf6-bba1-43cdb3201876)