### PR TITLE
feat(wds): menu, select, text-input 디자인 qa

### DIFF
--- a/packages/wds/src/components/chip-filter/index.tsx
+++ b/packages/wds/src/components/chip-filter/index.tsx
@@ -65,7 +65,7 @@ const ChipFilter = forwardRef(
           sx={[actionStyle({ variant, size, xs, sm, md, lg, xl }), props.sx]}
         >
           <span id={id}>{children}</span>
-          {textNumber !== null && textNumber !== undefined && (
+          {textNumber !== null && textNumber !== undefined && active && (
             <span data-role="chip-filter-text-number">{textNumber}</span>
           )}
           {expanded ? <IconCaretUp /> : <IconCaretDown />}

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -9,6 +9,7 @@ import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { IconChevronRightTightSmall } from '@wanteddev/wds-icon';
 
 import { Divider, FlexBox, Typography, WithInteraction } from '..';
+import { useMenuItemContext } from '../menu/contexts';
 
 import {
   LIST_CELL_NAME,
@@ -278,21 +279,18 @@ ListCell.displayName = LIST_CELL_NAME;
 
 const ListText = forwardRef(
   <E extends ElementType = 'p'>(
-    {
-      caption,
-      bold = false,
-      children,
-      ...props
-    }: PolymorphicProps<ListTextProps, E>,
+    { caption, bold, children, ...props }: PolymorphicProps<ListTextProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
     const { active, disabled } = useListItemContext(LIST_TEXT_NAME);
+    const { bold: menuItemBold } = useMenuItemContext() || {};
 
     if (!children) {
       return null;
     }
 
-    const weight: TypographyWeight = bold ? 'medium' : 'regular';
+    const weight: TypographyWeight =
+      bold ?? menuItemBold ? 'medium' : 'regular';
 
     const getParagraphColor = (): ThemeColorsToken => {
       if (disabled) {

--- a/packages/wds/src/components/menu/contexts.ts
+++ b/packages/wds/src/components/menu/contexts.ts
@@ -1,6 +1,8 @@
 import { createContext } from '@radix-ui/react-context';
 
-import { MENU_NAME } from './constants';
+import createLooseContext from '../../hooks/use-loose-context';
+
+import { MENU_ITEM_NAME, MENU_NAME } from './constants';
 
 import type { MenuDefaultProps } from './types';
 
@@ -11,3 +13,10 @@ type MenuContextType = {
 
 export const [MenuProvider, useMenuContext] =
   createContext<MenuContextType>(MENU_NAME);
+
+type MenuItemContextType = {
+  bold?: boolean;
+};
+
+export const [MenuItemProvider, useMenuItemContext] =
+  createLooseContext<MenuItemContextType>(MENU_ITEM_NAME);

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -36,7 +36,7 @@ import {
   menuPopoverContentStyle,
   menuScrollAreaStyle,
 } from './style';
-import { MenuProvider, useMenuContext } from './context';
+import { MenuItemProvider, MenuProvider, useMenuContext } from './contexts';
 
 import type { ListProps } from '../list/types';
 import type {
@@ -239,20 +239,22 @@ const MenuItem = forwardRef(
     };
 
     return (
-      <RovingFocusGroupItem
-        asChild
-        focusable={!disabled}
-        active={normalActive}
-        data-active={normalActive}
-        onKeyDown={composeEventHandlers(onKeyDown, (e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            (e.target as HTMLElement).click();
-          }
-        })}
-      >
-        {renderComponent[variant]}
-      </RovingFocusGroupItem>
+      <MenuItemProvider bold={variant === 'normal' ? normalActive : undefined}>
+        <RovingFocusGroupItem
+          asChild
+          focusable={!disabled}
+          active={normalActive}
+          data-active={normalActive}
+          onKeyDown={composeEventHandlers(onKeyDown, (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              (e.target as HTMLElement).click();
+            }
+          })}
+        >
+          {renderComponent[variant]}
+        </RovingFocusGroupItem>
+      </MenuItemProvider>
     );
   },
 ) as PolymorphicComponent<MenuItemProps, 'li'>;

--- a/packages/wds/src/components/select/style.ts
+++ b/packages/wds/src/components/select/style.ts
@@ -147,6 +147,9 @@ export const invalidIconWrapperStyle = (theme: Theme) => css`
     content: '';
     width: 50%;
     height: 50%;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     background-color: ${theme.palette.static.white};
   }
 

--- a/packages/wds/src/components/text-area/style.ts
+++ b/packages/wds/src/components/text-area/style.ts
@@ -208,6 +208,9 @@ export const invalidIconWrapperStyle = (theme: Theme) => css`
     content: '';
     width: 50%;
     height: 50%;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     background-color: ${theme.palette.static.white};
   }
 

--- a/packages/wds/src/components/text-input/index.tsx
+++ b/packages/wds/src/components/text-input/index.tsx
@@ -157,7 +157,12 @@ const TextInput = forwardRef<
             });
           }}
         >
-          <IconButton type="button" size={22} tabIndex={-1}>
+          <IconButton
+            type="button"
+            size={22}
+            tabIndex={-1}
+            sx={(theme) => ({ color: theme.palette.label.assistive })}
+          >
             <IconCircleClose />
           </IconButton>
         </TextInputContent>

--- a/packages/wds/src/components/text-input/style.ts
+++ b/packages/wds/src/components/text-input/style.ts
@@ -233,6 +233,9 @@ export const invalidIconWrapperStyle = (theme: Theme) => css`
     content: '';
     width: 50%;
     height: 50%;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     background-color: ${theme.palette.static.white};
   }
 


### PR DESCRIPTION
- Menu에서 variant='normal' 상태 && active 상태일 때 하위 ListItemText에 bold 상태를 context로 주입합니다.
- chip-filter에서 textNumber는 active 상태일 때만 표시합니다.
- text-input에서 reset 버튼의 색상을 변경합니다.
- text-input, text-area, select, select-multiple 의 invalid, positive 상태의 아이콘 뒤 백그라운드의 위치가 올바르지 않는 현상 수정했습니다.