### PR TITLE
feat(wds): scroll-area에 size 옵션 추가 및 메뉴, 탭 스크롤바 사이즈 조정

### DIFF
--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -470,6 +470,7 @@ const AutocompleteList = forwardRef<HTMLDivElement, AutocompleteListProps>(
       >
         <ScrollArea
           scrollbars="vertical"
+          size="small"
           viewportProps={{ sx: autocompleteScrollAreaStyle }}
         >
           <List role="listbox" id={contentId} gap="4px">
@@ -538,7 +539,7 @@ const AutocompleteOption = forwardRef<
           });
         })}
       >
-        <ListText caption={caption} bold={bold}>
+        <ListText caption={caption} bold={bold ?? active}>
           {children}
         </ListText>
       </ListCell>

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -119,7 +119,7 @@ const MenuContent = forwardRef<
         sx={[menuPopoverContentStyle, sx]}
       >
         <RovingFocusGroup orientation="vertical" dir="ltr" asChild>
-          <ScrollArea zIndex={11} sx={menuScrollAreaStyle}>
+          <ScrollArea zIndex={11} sx={menuScrollAreaStyle} size="small">
             {children}
           </ScrollArea>
         </RovingFocusGroup>

--- a/packages/wds/src/components/scroll-area/index.tsx
+++ b/packages/wds/src/components/scroll-area/index.tsx
@@ -103,7 +103,7 @@ export default ScrollArea;
 const ScrollBar = forwardRef<
   ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   ScrollBarProps
->(({ orientation = 'vertical', size, ...props }, ref) => (
+>(({ orientation = 'vertical', size = 'responsive', ...props }, ref) => (
   <Box
     as={ScrollAreaPrimitive.ScrollAreaScrollbar}
     forceMount

--- a/packages/wds/src/components/scroll-area/index.tsx
+++ b/packages/wds/src/components/scroll-area/index.tsx
@@ -21,6 +21,7 @@ const ScrollArea = forwardRef<
 >(
   (
     {
+      size = 'responsive',
       children,
       asChild,
       viewportRef,
@@ -37,13 +38,35 @@ const ScrollArea = forwardRef<
     } = {
       both: (
         <>
-          <Box as={ScrollBar} orientation="horizontal" sx={{ zIndex }} />
-          <Box as={ScrollBar} orientation="vertical" sx={{ zIndex }} />
+          <Box
+            as={ScrollBar}
+            orientation="horizontal"
+            size={size}
+            sx={{ zIndex }}
+          />
+          <Box
+            as={ScrollBar}
+            orientation="vertical"
+            size={size}
+            sx={{ zIndex }}
+          />
         </>
       ),
-      vertical: <Box as={ScrollBar} orientation="vertical" sx={{ zIndex }} />,
+      vertical: (
+        <Box
+          as={ScrollBar}
+          orientation="vertical"
+          size={size}
+          sx={{ zIndex }}
+        />
+      ),
       horizontal: (
-        <Box as={ScrollBar} orientation="horizontal" sx={{ zIndex }} />
+        <Box
+          as={ScrollBar}
+          orientation="horizontal"
+          size={size}
+          sx={{ zIndex }}
+        />
       ),
     };
 
@@ -80,14 +103,14 @@ export default ScrollArea;
 const ScrollBar = forwardRef<
   ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   ScrollBarProps
->(({ orientation = 'vertical', ...props }, ref) => (
+>(({ orientation = 'vertical', size, ...props }, ref) => (
   <Box
     as={ScrollAreaPrimitive.ScrollAreaScrollbar}
     forceMount
     ref={ref}
     orientation={orientation}
     {...props}
-    sx={[scrollBarStyle({ orientation }), props.sx]}
+    sx={[scrollBarStyle({ orientation, size }), props.sx]}
   >
     <WithInteraction color="palette.label.normal">
       <Box as={ScrollAreaPrimitive.ScrollAreaThumb} sx={scrollBarThumbStyle} />

--- a/packages/wds/src/components/scroll-area/style.ts
+++ b/packages/wds/src/components/scroll-area/style.ts
@@ -1,7 +1,7 @@
 import { css, keyframes } from '@wanteddev/wds-engine';
 
 import type { ScrollBarProps } from './types';
-import type { Theme } from '@wanteddev/wds-engine';
+import type { SerializedStyles, Theme } from '@wanteddev/wds-engine';
 
 export const scrollAreaStyle = css`
   position: relative;
@@ -32,7 +32,7 @@ const fadeOut = keyframes`
   `;
 
 export const scrollBarStyle =
-  ({ orientation }: ScrollBarProps) =>
+  ({ orientation, size }: ScrollBarProps) =>
   (theme: Theme) => css`
     display: flex;
     touch-action: none;
@@ -51,43 +51,16 @@ export const scrollBarStyle =
       animation: ${fadeIn} 300ms ease;
     }
 
-    ${orientation === 'vertical'
-      ? css`
-          height: 100%;
-          border-left-width: 1px;
-          border-left-color: transparent;
-          padding: 3px;
-        `
-      : css`
-          width: 100%;
-          flex-direction: column;
-          border-top-width: 1px;
-          border-top-color: transparent;
-          padding: 3px;
-        `}
+    ${scrollbarSizeStyle({ size, orientation }, theme)}
+  `;
 
-    ${orientation === 'vertical'
-      ? css`
-          width: 13px;
-          --radix-scroll-area-thumb-width: 7px;
-
-          &:hover {
-            width: 17px;
-            --radix-scroll-area-thumb-width: 11px;
-          }
-        `
-      : css`
-          height: 13px;
-          --radix-scroll-area-thumb-height: 7px;
-
-          &:hover {
-            height: 17px;
-            --radix-scroll-area-thumb-height: 11px;
-          }
-        `}
-
-    @media (max-width: ${theme.breakpoint.sm}) {
-      ${orientation === 'vertical'
+const scrollbarSizeStyle = (
+  { size, orientation }: ScrollBarProps,
+  theme: Theme,
+): SerializedStyles | undefined => {
+  switch (size) {
+    case 'small':
+      return orientation === 'vertical'
         ? css`
             width: 9px;
             --radix-scroll-area-thumb-width: 3px;
@@ -105,9 +78,32 @@ export const scrollBarStyle =
               height: 13px;
               --radix-scroll-area-thumb-height: 7px;
             }
-          `}
-    }
-  `;
+          `;
+    case 'normal':
+      return orientation === 'vertical'
+        ? css`
+            height: 100%;
+            border-left-width: 1px;
+            border-left-color: transparent;
+            padding: 3px;
+          `
+        : css`
+            width: 100%;
+            flex-direction: column;
+            border-top-width: 1px;
+            border-top-color: transparent;
+            padding: 3px;
+          `;
+    case 'responsive':
+      return css`
+        ${scrollbarSizeStyle({ size: 'normal', orientation }, theme)}
+
+        @media (max-width: ${theme.breakpoint.sm}) {
+          ${scrollbarSizeStyle({ size: 'small', orientation }, theme)}
+        }
+      `;
+  }
+};
 
 export const scrollBarThumbStyle = (theme: Theme) => css`
   cursor: initial;

--- a/packages/wds/src/components/scroll-area/style.ts
+++ b/packages/wds/src/components/scroll-area/style.ts
@@ -42,6 +42,21 @@ export const scrollBarStyle =
       width 0.2s ease,
       height 0.2s ease;
 
+    ${orientation === 'vertical'
+      ? css`
+          height: 100%;
+          border-left-width: 1px;
+          border-left-color: transparent;
+          padding: 3px;
+        `
+      : css`
+          width: 100%;
+          flex-direction: column;
+          border-top-width: 1px;
+          border-top-color: transparent;
+          padding: 3px;
+        `}
+
     &[data-state='hidden'] {
       opacity: 0;
       animation: ${fadeOut} 300ms ease;
@@ -82,17 +97,20 @@ const scrollbarSizeStyle = (
     case 'normal':
       return orientation === 'vertical'
         ? css`
-            height: 100%;
-            border-left-width: 1px;
-            border-left-color: transparent;
-            padding: 3px;
+            width: 13px;
+            --radix-scroll-area-thumb-width: 7px;
+            &:hover {
+              width: 17px;
+              --radix-scroll-area-thumb-width: 11px;
+            }
           `
         : css`
-            width: 100%;
-            flex-direction: column;
-            border-top-width: 1px;
-            border-top-color: transparent;
-            padding: 3px;
+            height: 13px;
+            --radix-scroll-area-thumb-height: 7px;
+            &:hover {
+              height: 17px;
+              --radix-scroll-area-thumb-height: 11px;
+            }
           `;
     case 'responsive':
       return css`

--- a/packages/wds/src/components/scroll-area/types.ts
+++ b/packages/wds/src/components/scroll-area/types.ts
@@ -4,6 +4,7 @@ import type * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
 export type ScrollAreaProps = DefaultComponentProps<
   {
+    size?: 'small' | 'normal' | 'responsive';
     scrollbars?: 'vertical' | 'horizontal' | 'both';
     viewportRef?: Ref<
       ElementRef<typeof ScrollAreaPrimitive.ScrollAreaViewport>
@@ -21,6 +22,6 @@ export type ScrollAreaProps = DefaultComponentProps<
 >;
 
 export type ScrollBarProps = DefaultComponentProps<
-  {},
+  Pick<ScrollAreaProps, 'size'>,
   typeof ScrollAreaPrimitive.ScrollAreaScrollbar
 >;

--- a/packages/wds/src/components/tab/index.tsx
+++ b/packages/wds/src/components/tab/index.tsx
@@ -184,6 +184,7 @@ const TabList = forwardRef<
             onScrollCapture={handleOnScroll}
             scrollbars="horizontal"
             viewportRef={composedViewportRef}
+            size="small"
           >
             <FlexBox>{children}</FlexBox>
           </ScrollArea>


### PR DESCRIPTION
- 스크롤바의 크기를 결정할 수 있습니다.
- tab, autocomplete, menu 등 스크롤의 크기가 거슬리는 UI에서 예외적으로 데스크탑에서 작은 사이즈의 스크롤바를 사용합니다.