### PR TITLE
fix(wds): select의 option에서 children 값이 number, array 일 때 오류 수정

### DIFF
--- a/docs/src/docs/components/select-multiple.mdx
+++ b/docs/src/docs/components/select-multiple.mdx
@@ -180,7 +180,7 @@ const Demo = () => {
       <SelectMultiple
         ref={ref}
         value={value}
-        onValueChange={setValue}
+        onChange={setValue}
         width="300px"
         placeholder="선택해주세요."
         render={() => (
@@ -322,7 +322,7 @@ const Demo = () => {
         open={open}
         onOpenChange={setOpen}
         value={value}
-        onValueChange={setValue}
+        onChange={setValue}
         menuValue={menuValue}
         onMenuValueChange={setMenuValue}
         width="300px"

--- a/docs/src/docs/components/select.mdx
+++ b/docs/src/docs/components/select.mdx
@@ -260,7 +260,7 @@ const Demo = () => {
         open={open}
         onOpenChange={setOpen}
         value={value}
-        onValueChange={setValue}
+        onChange={setValue}
         menuValue={menuValue}
         onMenuValueChange={setMenuValue}
         width="300px"

--- a/docs/src/docs/overview/changelog.mdx
+++ b/docs/src/docs/overview/changelog.mdx
@@ -115,6 +115,7 @@ description: Changelog
 - 디자인이 새롭게 변경되었습니다.
 - `leftIcon`, `rightIcon` 의 prop 이름이 `leftContent`, `rightContent`로 변경되었습니다.
 - `leftContent`, `rightContent` 에 요소를 넣을 때는 `TextAreaContent` 로 한번 감싸서 넘겨주어야 합니다. (문서 참고)
+- maxLength 속성으로 추가되던 최대 길이가 `<TextAreaContent variant="characterCounter">{maxLength}</TextAreaContent>` 로 사용하도록 변경되었습니다.
 
 ### TopNavigation
 

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -48,7 +48,7 @@ const SelectMultiple = forwardRef<
       disabled,
       defaultValue = [],
       value: valueProp,
-      onValueChange,
+      onChange,
       placeholder,
       children,
       open: openProp,
@@ -98,7 +98,7 @@ const SelectMultiple = forwardRef<
       defaultProp: defaultValue,
       onChange: (v) => {
         setMenuValue(v);
-        onValueChange?.(v);
+        onChange?.(v);
       },
     });
 

--- a/packages/wds/src/components/select-multiple/types.ts
+++ b/packages/wds/src/components/select-multiple/types.ts
@@ -11,9 +11,9 @@ export type SelectMultipleDefaultProps = {
   value?: Array<string>;
   defaultValue?: Array<string>;
   leftContent?: ReactNode;
-  onValueChange?: (value: Array<string>) => void;
+  onChange?: (value: Array<string>) => void;
   placeholder?: string;
-  render?: (label: Array<string>, value: Array<string>) => ReactNode;
+  render?: (label: Array<ReactNode>, value: Array<string>) => ReactNode;
   open?: boolean;
   defaultOpen?: boolean;
   overflow?: boolean;

--- a/packages/wds/src/components/select/helpers.ts
+++ b/packages/wds/src/components/select/helpers.ts
@@ -1,8 +1,10 @@
 import { Children, isValidElement } from 'react';
 
+import type { ReactNode } from 'react';
+
 type Options = {
   value: string;
-  label: string;
+  label: ReactNode;
 };
 
 const convertNodeToOption = (
@@ -14,16 +16,16 @@ const convertNodeToOption = (
     props: { children, value, ...restProps },
   } = node;
 
-  if (typeof children === 'string') {
-    return {
-      key,
-      value: givenValue ?? value,
-      label: children,
-      ...restProps,
-    };
+  if (isValidElement(children)) {
+    return convertNodeToOption(children, givenValue ?? value);
   }
 
-  return convertNodeToOption(children, givenValue ?? value);
+  return {
+    key,
+    value: givenValue ?? value,
+    label: children,
+    ...restProps,
+  };
 };
 
 export const convertChildrenToData = (nodes: React.ReactNode) => {

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -64,7 +64,7 @@ const Select = forwardRef<
     {
       value: valueProp,
       defaultValue = '',
-      onValueChange,
+      onChange,
       defaultOpen,
       open: openProp,
       onOpenChange,
@@ -106,7 +106,7 @@ const Select = forwardRef<
       defaultProp: defaultValue,
       onChange: (v) => {
         setMenuValue(v);
-        onValueChange?.(v);
+        onChange?.(v);
       },
     });
 

--- a/packages/wds/src/components/select/types.ts
+++ b/packages/wds/src/components/select/types.ts
@@ -13,8 +13,8 @@ export type SelectDefaultProps = {
   defaultValue?: string;
   placeholder?: string;
   leftContent?: ReactNode;
-  render?: (label: string, value: string) => ReactNode;
-  onValueChange?: (value: string) => void;
+  render?: (label: ReactNode, value: string) => ReactNode;
+  onChange?: (value: string) => void;
   contentProps?: ComponentProps<typeof MenuContent>;
   // Popover props
   open?: boolean;


### PR DESCRIPTION
일반적으로 native select에서 마이그레이션 할 때 onValueChange를 놓치는 경우가 생길 수 있을 것 같아 onChange로 이름을 변경해두었습니다.

- onValueChange -> onChange

