### PR TITLE
fix(wds): 환경에 따라 icon-button의 mix-blend-mode가 적용되지 않는 이슈

### DIFF
--- a/packages/wds/src/components/icon-button/index.tsx
+++ b/packages/wds/src/components/icon-button/index.tsx
@@ -5,7 +5,11 @@ import { Box } from '@wanteddev/wds-engine';
 import WithInteraction from '../with-interaction';
 import PushBadge from '../push-badge';
 
-import { backgroundBlendStyle, iconButtonStyle } from './style';
+import {
+  backgroundBlendLayerStyle,
+  backgroundBlendStyle,
+  iconButtonStyle,
+} from './style';
 
 import type {
   PolymorphicComponent,
@@ -111,12 +115,20 @@ const IconButton = forwardRef(
           ]}
         >
           {variant === 'background' && !alternative && (
-            <Box
-              as="span"
-              role="presentation"
-              data-role="icon-button-background-alternative"
-              sx={backgroundBlendStyle}
-            />
+            <>
+              <Box
+                as="span"
+                role="presentation"
+                data-role="icon-button-background-blend"
+                sx={backgroundBlendStyle}
+              />
+              <Box
+                as="span"
+                role="presentation"
+                data-role="icon-button-background-blend-layer"
+                sx={backgroundBlendLayerStyle}
+              />
+            </>
           )}
           {children}
 

--- a/packages/wds/src/components/icon-button/style.ts
+++ b/packages/wds/src/components/icon-button/style.ts
@@ -157,15 +157,27 @@ const iconButtonColorStyle = (
         background-color: transparent;
         color: ${alternative
           ? addOpacity(theme.palette.static.white, theme.opacity[88])
-          : addOpacity(theme.palette.coolNeutral[50], theme.opacity[61])};
+          : addOpacity(theme.palette.static.black, theme.opacity[43])};
+
+        ${!alternative &&
+        css`
+          @supports (-webkit-backdrop-filter: none) {
+            color: ${addOpacity(
+              theme.palette.coolNeutral[50],
+              theme.opacity[61],
+            )};
+          }
+        `}
 
         svg {
           position: relative;
 
           ${!alternative &&
           css`
-            will-change: mix-blend-mode;
-            mix-blend-mode: difference;
+            @supports (-webkit-backdrop-filter: none) {
+              will-change: mix-blend-mode;
+              mix-blend-mode: difference;
+            }
           `}
         }
 
@@ -185,12 +197,6 @@ const iconButtonColorStyle = (
                 )};
               `
             : css`
-                background-color: ${addOpacity(
-                  theme.palette.static.white,
-                  theme.opacity[35],
-                )};
-                mix-blend-mode: plus-lighter;
-                will-change: mix-blend-mode, backdrop-filter;
                 backdrop-filter: blur(32px);
               `}
           width: calc(100% + 8px);
@@ -231,7 +237,10 @@ const iconButtonColorStyle = (
             mix-blend-mode: initial;
           }
 
-          & > [data-role='icon-button-background-alternative'] {
+          & > [data-role='icon-button-background-blend'] {
+            display: none;
+          }
+          & > [data-role='icon-button-background-blend-layer'] {
             display: none;
           }
         }
@@ -273,6 +282,25 @@ const iconButtonColorStyle = (
 };
 
 export const backgroundBlendStyle = (theme: Theme) => css`
+  position: absolute;
+  content: '';
+  width: calc(100% + 8px);
+  height: calc(100% + 8px);
+  top: -4px;
+  left: -4px;
+  border-radius: inherit;
+  background-color: ${addOpacity(
+    theme.palette.static.white,
+    theme.opacity[35],
+  )};
+
+  @supports (-webkit-backdrop-filter: none) {
+    mix-blend-mode: plus-lighter;
+    will-change: mix-blend-mode;
+  }
+`;
+
+export const backgroundBlendLayerStyle = (theme: Theme) => css`
   position: absolute;
   content: '';
   background-color: ${addOpacity(theme.palette.static.black, theme.opacity[5])};

--- a/packages/wds/src/components/icon-button/style.ts
+++ b/packages/wds/src/components/icon-button/style.ts
@@ -26,6 +26,12 @@ export const iconButtonStyle =
     align-items: center;
     justify-content: center;
 
+    &:disabled,
+    &[aria-disabled='true'] {
+      pointer-events: none;
+      cursor: not-allowed;
+    }
+
     ${iconButtonSizeStyle(
       props.size || getDefaultSize(props.variant),
       props.variant,


### PR DESCRIPTION
safari에서만 mix-blend-mode가 올바르게 동작하여 분기처리해서 수정해주었습니다