### PR TITLE
fix(wds): text-input, text-area, list content 아이콘 색상 override 개선

### DIFF
--- a/packages/wds/src/components/icon-button/contexts.ts
+++ b/packages/wds/src/components/icon-button/contexts.ts
@@ -1,0 +1,14 @@
+import createLooseContext from '../../hooks/use-loose-context';
+
+import type { ThemeColorsToken } from '@wanteddev/wds-engine';
+import type { IconButtonVariant } from './types';
+
+type IconButtonContextValue = {
+  [key in IconButtonVariant]?: ThemeColorsToken;
+};
+
+/**
+ * @description icon button의 기본 color 값을 쉽게 override 하기 위해 사용합니다.
+ */
+export const [IconButtonProvider, useIconButtonContext] =
+  createLooseContext<IconButtonContextValue>('AnyComponent');

--- a/packages/wds/src/components/icon-button/index.tsx
+++ b/packages/wds/src/components/icon-button/index.tsx
@@ -6,6 +6,7 @@ import WithInteraction from '../with-interaction';
 import PushBadge from '../push-badge';
 
 import { backgroundBlendStyle, iconButtonStyle } from './style';
+import { useIconButtonContext } from './contexts';
 
 import type {
   PolymorphicComponent,
@@ -36,9 +37,15 @@ const IconButton = forwardRef(
     }: PolymorphicProps<IconButtonProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
+    const context = useIconButtonContext();
+
     const color = useMemo(() => {
       if (originColor) {
         return originColor;
+      }
+
+      if (context?.[variant]) {
+        return context[variant];
       }
 
       switch (variant) {
@@ -46,10 +53,12 @@ const IconButton = forwardRef(
           return 'palette.static.white';
         case 'background':
           return undefined;
+        case 'normal':
+          return 'palette.label.normal';
         default:
           return 'palette.label.normal';
       }
-    }, [originColor, variant]);
+    }, [context, originColor, variant]);
 
     const getInteractionSize = () => {
       switch (variant) {

--- a/packages/wds/src/components/icon-button/types.ts
+++ b/packages/wds/src/components/icon-button/types.ts
@@ -4,7 +4,7 @@ import type {
   ThemeColorsToken,
 } from '@wanteddev/wds-engine';
 
-type IconButtonVariant = 'normal' | 'background' | 'outlined' | 'solid';
+export type IconButtonVariant = 'normal' | 'background' | 'outlined' | 'solid';
 
 export type IconButtonDefaultProps = {
   variant?: IconButtonVariant;

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -10,6 +10,8 @@ import { IconChevronRightTightSmall } from '@wanteddev/wds-icon';
 
 import { Divider, FlexBox, Typography, WithInteraction } from '..';
 import { useMenuItemContext } from '../menu/contexts';
+import { IconButtonProvider } from '../icon-button/contexts';
+import { TextButtonProvider } from '../text-button/contexts';
 
 import {
   LIST_CELL_NAME,
@@ -159,7 +161,14 @@ const ListItemContent = forwardRef<
           ref={ref}
           alignItems="center"
           {...props}
-          sx={[listItemContentStyle, { fontSize: '24px' }, props.sx]}
+          sx={[
+            listItemContentStyle,
+            (theme) => ({
+              fontSize: '24px',
+              color: theme.palette.label.assistive,
+            }),
+            props.sx,
+          ]}
         >
           {children}
         </FlexBox>
@@ -171,15 +180,16 @@ const ListItemContent = forwardRef<
           ref={ref}
           alignItems="center"
           {...props}
-          sx={[listItemContentStyle, { fontSize: '24px' }, props.sx]}
+          sx={[listItemContentStyle, props.sx]}
         >
-          {children}
+          <IconButtonProvider normal="palette.label.alternative">
+            {children}
+          </IconButtonProvider>
         </FlexBox>
       );
 
     case 'radio':
     case 'checkbox':
-    case 'button':
       return (
         <FlexBox
           wds-component="list-item-content"
@@ -189,6 +199,20 @@ const ListItemContent = forwardRef<
           sx={[listItemContentStyle, props.sx]}
         >
           {children}
+        </FlexBox>
+      );
+    case 'button':
+      return (
+        <FlexBox
+          wds-component="list-item-content"
+          ref={ref}
+          alignItems="center"
+          {...props}
+          sx={[listItemContentStyle, props.sx]}
+        >
+          <TextButtonProvider assistive="palette.label.alternative">
+            {children}
+          </TextButtonProvider>
         </FlexBox>
       );
     case 'chevron':

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -125,23 +125,13 @@ export const listCellDividerStyle = css`
   width: 100%;
 `;
 
-export const listItemContentStyle = (theme: Theme) => css`
+export const listItemContentStyle = css`
   max-height: 24px;
   flex-shrink: 0;
   width: fit-content;
   height: fit-content;
   position: relative;
 
-  & > svg {
-    color: ${theme.palette.label.assistive};
-  }
-
-  [wds-component='icon-button'][data-variant='normal'] {
-    color: ${theme.palette.label.alternative};
-  }
-  [wds-component='text-button'][data-variant='assistive'] {
-    color: ${theme.palette.label.alternative};
-  }
   [wds-component='with-interaction'] {
     z-index: 1;
   }

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -372,7 +372,14 @@ const MenuBottomContent = forwardRef<
           wds-component="menu-bottom-content"
           ref={ref}
           {...props}
-          sx={[menuBottomContentStyle, { fontSize: '24px' }, sx]}
+          sx={[
+            menuBottomContentStyle,
+            (theme) => ({
+              fontSize: '24px',
+              color: theme.palette.label.alternative,
+            }),
+            sx,
+          ]}
         >
           {children}
         </FlexBox>

--- a/packages/wds/src/components/menu/style.ts
+++ b/packages/wds/src/components/menu/style.ts
@@ -81,12 +81,8 @@ export const menuBottomStyle = (theme: Theme) => css`
   border-top: 1px solid ${theme.palette.line.solid.alternative};
 `;
 
-export const menuBottomContentStyle = (theme: Theme) => css`
+export const menuBottomContentStyle = css`
   flex-shrink: 0;
   width: fit-content;
   height: fit-content;
-
-  & > svg {
-    color: ${theme.palette.label.alternative};
-  }
 `;

--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -9,6 +9,7 @@ import Typography from '../typography';
 import ScrollArea from '../scroll-area';
 import { typographyStyle } from '../../utils/typography';
 import useResizeObserver from '../../hooks/use-resize-observer';
+import { IconButtonProvider } from '../icon-button/contexts';
 
 import { getTextAreaDefaultHeight } from './helpers';
 import {
@@ -348,7 +349,15 @@ const TextAreaContent = forwardRef<
         <FlexBox
           wds-component="text-area-content"
           ref={ref}
-          sx={[textAreaContentStyle, { fontSize: '22px', padding: '1px' }, sx]}
+          sx={[
+            textAreaContentStyle,
+            (theme) => ({
+              fontSize: '22px',
+              padding: '1px',
+              color: theme.palette.label.assistive,
+            }),
+            sx,
+          ]}
           {...props}
         >
           {children}
@@ -362,7 +371,9 @@ const TextAreaContent = forwardRef<
           sx={[textAreaContentStyle, sx]}
           {...props}
         >
-          {children}
+          <IconButtonProvider normal="palette.label.alternative">
+            {children}
+          </IconButtonProvider>
         </FlexBox>
       );
     case 'custom':

--- a/packages/wds/src/components/text-area/style.ts
+++ b/packages/wds/src/components/text-area/style.ts
@@ -186,18 +186,10 @@ export const textAreaBottomAreaStyle = css`
   width: 100%;
 `;
 
-export const textAreaContentStyle = (theme: Theme) => css`
+export const textAreaContentStyle = css`
   flex-shrink: 0;
   width: fit-content;
   height: fit-content;
-
-  & > svg {
-    color: ${theme.palette.label.assistive};
-  }
-
-  [wds-component='icon-button'][data-variant='normal'] {
-    color: ${theme.palette.label.alternative};
-  }
 `;
 
 export const invalidIconWrapperStyle = (theme: Theme) => css`

--- a/packages/wds/src/components/text-button/contexts.ts
+++ b/packages/wds/src/components/text-button/contexts.ts
@@ -1,0 +1,14 @@
+import createLooseContext from '../../hooks/use-loose-context';
+
+import type { ThemeColorsToken } from '@wanteddev/wds-engine';
+import type { TextButtonVariant } from './types';
+
+type TextButtonContextValue = {
+  [key in TextButtonVariant]?: ThemeColorsToken;
+};
+
+/**
+ * @description text button의 기본 color 값을 쉽게 override 하기 위해 사용합니다.
+ */
+export const [TextButtonProvider, useTextButtonContext] =
+  createLooseContext<TextButtonContextValue>('AnyComponent');

--- a/packages/wds/src/components/text-button/index.tsx
+++ b/packages/wds/src/components/text-button/index.tsx
@@ -1,10 +1,11 @@
 'use client';
-import { forwardRef, useId } from 'react';
+import { forwardRef, useId, useMemo } from 'react';
 import { Box } from '@wanteddev/wds-engine';
 
 import WithInteraction from '../with-interaction';
 
 import { textButtonStyle } from './style';
+import { useTextButtonContext } from './contexts';
 
 import type {
   PolymorphicComponent,
@@ -35,9 +36,14 @@ const TextButton = forwardRef(
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
     const id = useId();
+    const context = useTextButtonContext();
 
     const interactionColor: ThemeColorsToken =
       variant === 'primary' ? 'palette.primary.normal' : 'palette.label.normal';
+
+    const color = useMemo(() => {
+      return context?.[variant];
+    }, [context, variant]);
 
     return (
       <WithInteraction
@@ -58,6 +64,7 @@ const TextButton = forwardRef(
           {...props}
           sx={[
             textButtonStyle({
+              color,
               size,
               variant,
               xs,

--- a/packages/wds/src/components/text-button/style.ts
+++ b/packages/wds/src/components/text-button/style.ts
@@ -3,11 +3,15 @@ import { css } from '@wanteddev/wds-engine';
 import { typographyStyle } from '../../utils/typography';
 import { createResponsiveStyle } from '../../utils';
 
-import type { Theme } from '@wanteddev/wds-engine';
+import type { Theme, ThemeColorsToken } from '@wanteddev/wds-engine';
 import type { TextButtonProps } from './types';
 
+type TextButtonStyleProps = TextButtonProps & {
+  color?: ThemeColorsToken;
+};
+
 export const textButtonStyle =
-  ({ xs, sm, md, lg, xl, ...props }: TextButtonProps) =>
+  ({ xs, sm, md, lg, xl, ...props }: TextButtonStyleProps) =>
   (theme: Theme) => css`
     display: inline-flex;
     align-items: center;
@@ -40,11 +44,14 @@ export const textButtonStyle =
     )}
   `;
 
-const getColorTheme = ({ variant }: TextButtonProps, theme: Theme) => {
+const getColorTheme = (
+  { variant, color }: TextButtonStyleProps,
+  theme: Theme,
+) => {
   switch (variant) {
     case 'primary':
       return css`
-        color: ${theme.palette.primary.normal};
+        color: ${color ?? theme.palette.primary.normal};
         background-color: transparent;
         border: none;
         box-shadow: none;
@@ -59,7 +66,7 @@ const getColorTheme = ({ variant }: TextButtonProps, theme: Theme) => {
         background-color: transparent;
         border: none;
         box-shadow: none;
-        color: ${theme.palette.label.alternative};
+        color: ${color ?? theme.palette.label.alternative};
 
         &:disabled,
         &[aria-disabled='true'] {

--- a/packages/wds/src/components/text-button/types.ts
+++ b/packages/wds/src/components/text-button/types.ts
@@ -1,6 +1,8 @@
 import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
 import type { ReactNode } from 'react';
 
+export type TextButtonVariant = 'primary' | 'assistive';
+
 export type TextButtonDefaultProps = {
   variant?: 'primary' | 'assistive';
   disabled?: boolean;

--- a/packages/wds/src/components/text-input/index.tsx
+++ b/packages/wds/src/components/text-input/index.tsx
@@ -12,6 +12,7 @@ import FlexBox from '../flex-box';
 import IconButton from '../icon-button';
 import Typography from '../typography';
 import Button from '../button';
+import { IconButtonProvider } from '../icon-button/contexts';
 
 import {
   invalidIconWrapperStyle,
@@ -226,15 +227,41 @@ const TextInputContent = forwardRef<
         </Typography>
       );
     case 'icon':
+      return (
+        <FlexBox
+          wds-component="text-input-content"
+          ref={ref}
+          sx={[
+            textInputContentStyle,
+            (theme) => ({
+              padding: '1px',
+              fontSize: '22px',
+              color: theme.palette.label.alternative,
+            }),
+            sx,
+          ]}
+          {...props}
+        >
+          {children}
+        </FlexBox>
+      );
     case 'icon-button':
       return (
         <FlexBox
           wds-component="text-input-content"
           ref={ref}
-          sx={[textInputContentStyle, { padding: '1px', fontSize: '22px' }, sx]}
+          sx={[
+            textInputContentStyle,
+            {
+              padding: '1px',
+            },
+            sx,
+          ]}
           {...props}
         >
-          {children}
+          <IconButtonProvider normal="palette.label.alternative">
+            {children}
+          </IconButtonProvider>
         </FlexBox>
       );
     case 'custom':

--- a/packages/wds/src/components/text-input/style.ts
+++ b/packages/wds/src/components/text-input/style.ts
@@ -262,19 +262,11 @@ export const positiveIconWrapperStyle = (theme: Theme) => css`
   }
 `;
 
-export const textInputContentStyle = (theme: Theme) => css`
+export const textInputContentStyle = css`
   flex-shrink: 0;
   width: fit-content;
   height: fit-content;
   max-height: 24px;
-
-  & > svg {
-    color: ${theme.palette.label.alternative};
-  }
-
-  [wds-component='icon-button'][data-variant='normal'] {
-    color: ${theme.palette.label.alternative};
-  }
 `;
 
 export const textInputButtonStyle =


### PR DESCRIPTION
- icon, icon-button을 content로 사용할 때 색상을 변경하려면 important를 써야만 반영되는 현상이 있어 loose context를 사용하여 사용성을 개선했습니다.