### PR TITLE
feat(wds): chip 여백 업데이트

### DIFF
--- a/packages/wds/src/components/chip-action/style.ts
+++ b/packages/wds/src/components/chip-action/style.ts
@@ -50,34 +50,36 @@ const actionSizeStyle = ({ size }: ChipActionProps = {}) => {
     case 'xsmall':
       return css`
         border-radius: 6px;
-        padding: 4px 6px;
-        gap: 4px;
+        padding: 4px 7px;
+        gap: 2px;
 
         svg {
           font-size: 12px;
         }
         & > span {
           ${typographyStyle('caption1', 'medium')}
+          padding: 0 1px;
         }
       `;
     case 'small':
       return css`
         border-radius: 8px;
-        padding: 6px 10px;
-        gap: 4px;
+        padding: 6px 8px;
+        gap: 2px;
 
         svg {
           font-size: 14px;
         }
         & > span {
           ${typographyStyle('label1_normal', 'medium')}
+          padding: 0 2px;
         }
       `;
     case 'normal':
       return css`
         border-radius: 8px;
-        padding: 7px 12px;
-        gap: 4px;
+        padding: 7px 11px;
+        gap: 3px;
 
         svg {
           font-size: 14px;
@@ -85,19 +87,21 @@ const actionSizeStyle = ({ size }: ChipActionProps = {}) => {
 
         & > span {
           ${typographyStyle('body2_normal', 'medium')}
+          padding: 0 2px;
         }
       `;
     case 'large':
       return css`
         border-radius: 10px;
         padding: 9px 12px;
-        gap: 6px;
+        gap: 3px;
 
         svg {
           font-size: 16px;
         }
         & > span {
           ${typographyStyle('body2_normal', 'medium')}
+          padding: 0 2px;
         }
       `;
   }

--- a/packages/wds/src/components/chip-filter/index.tsx
+++ b/packages/wds/src/components/chip-filter/index.tsx
@@ -4,6 +4,7 @@ import { Box } from '@wanteddev/wds-engine';
 import { IconCaretDown, IconCaretUp } from '@wanteddev/wds-icon';
 
 import WithInteraction from '../with-interaction';
+import FlexBox from '../flex-box';
 
 import { actionStyle } from './style';
 
@@ -64,10 +65,12 @@ const ChipFilter = forwardRef(
           {...props}
           sx={[actionStyle({ variant, size, xs, sm, md, lg, xl }), props.sx]}
         >
-          <span id={id}>{children}</span>
-          {activeLabel !== null && activeLabel !== undefined && active && (
-            <span data-role="chip-filter-active-label">{activeLabel}</span>
-          )}
+          <FlexBox data-role="chip-filter-wrapper" alignItems="center">
+            <span id={id}>{children}</span>
+            {activeLabel !== null && activeLabel !== undefined && active && (
+              <span data-role="chip-filter-active-label">{activeLabel}</span>
+            )}
+          </FlexBox>
           {expanded ? <IconCaretUp /> : <IconCaretDown />}
         </Box>
       </WithInteraction>

--- a/packages/wds/src/components/chip-filter/style.ts
+++ b/packages/wds/src/components/chip-filter/style.ts
@@ -46,7 +46,7 @@ const actionSizeStyle = ({ size }: ChipFilterProps = {}) => {
     case 'xsmall':
       return css`
         border-radius: 6px;
-        padding: 4px 6px 4px 8px;
+        padding: 4px 7px 4px 5px;
         gap: 2px;
 
         svg {
@@ -62,7 +62,7 @@ const actionSizeStyle = ({ size }: ChipFilterProps = {}) => {
     case 'small':
       return css`
         border-radius: 8px;
-        padding: 6px 8px 6px 10px;
+        padding: 6px 6px 6px 8px;
         gap: 4px;
 
         svg {
@@ -78,7 +78,7 @@ const actionSizeStyle = ({ size }: ChipFilterProps = {}) => {
     case 'normal':
       return css`
         border-radius: 10px;
-        padding: 7px 8px 7px 12px;
+        padding: 7px 9px 7px 11px;
         gap: 5px;
 
         svg {
@@ -95,7 +95,7 @@ const actionSizeStyle = ({ size }: ChipFilterProps = {}) => {
     case 'large':
       return css`
         border-radius: 10px;
-        padding: 9px 8px 9px 12px;
+        padding: 9px 10px 9px 12px;
         gap: 5px;
 
         svg {

--- a/packages/wds/src/components/chip-filter/style.ts
+++ b/packages/wds/src/components/chip-filter/style.ts
@@ -47,42 +47,55 @@ const actionSizeStyle = ({ size }: ChipFilterProps = {}) => {
       return css`
         border-radius: 6px;
         padding: 4px 7px 4px 5px;
-        gap: 2px;
+        gap: 1px;
 
-        svg {
-          font-size: 12px;
+        [data-role='chip-filter-wrapper'] {
+          padding: 0 1px;
+          gap: 3px;
         }
+
         span {
           ${typographyStyle('caption1', 'medium')}
         }
         [data-role='chip-filter-active-label'] {
           ${typographyStyle('caption1', 'bold')}
         }
+
+        svg {
+          font-size: 12px;
+        }
       `;
     case 'small':
       return css`
         border-radius: 8px;
         padding: 6px 6px 6px 8px;
-        gap: 4px;
+        gap: 1px;
 
-        svg {
-          font-size: 16px;
+        [data-role='chip-filter-wrapper'] {
+          padding: 0 2px;
+          gap: 4px;
         }
+
         span {
           ${typographyStyle('label1_normal', 'medium')}
         }
         [data-role='chip-filter-active-label'] {
           ${typographyStyle('label1_normal', 'bold')}
         }
+
+        svg {
+          font-size: 16px;
+        }
       `;
     case 'normal':
       return css`
         border-radius: 10px;
         padding: 7px 9px 7px 11px;
-        gap: 5px;
+        gap: 2px;
 
-        svg {
-          font-size: 16px;
+        [data-role='chip-filter-wrapper'] {
+          padding: 0 2px;
+          gap: 4px;
         }
 
         span {
@@ -90,22 +103,32 @@ const actionSizeStyle = ({ size }: ChipFilterProps = {}) => {
         }
         [data-role='chip-filter-active-label'] {
           ${typographyStyle('body2_normal', 'bold')}
+        }
+
+        svg {
+          font-size: 16px;
         }
       `;
     case 'large':
       return css`
         border-radius: 10px;
         padding: 9px 10px 9px 12px;
-        gap: 5px;
+        gap: 2px;
 
-        svg {
-          font-size: 16px;
+        [data-role='chip-filter-wrapper'] {
+          padding: 0 2px;
+          gap: 4px;
         }
+
         span {
           ${typographyStyle('body2_normal', 'medium')}
         }
         [data-role='chip-filter-active-label'] {
           ${typographyStyle('body2_normal', 'bold')}
+        }
+
+        svg {
+          font-size: 16px;
         }
       `;
   }


### PR DESCRIPTION
## 작업 내용

- chip-action 여백 조정
- chip-filter 여백 조정
  - 텍스트(텍스트 + 아이콘)의 padding, gap이 추가되어서 텍스트와 아이콘을 `chip-filter-wrapper` FlexBox로 묶었습니다.
 
<img width="944" alt="스크린샷 2024-10-21 오후 3 24 45" src="https://github.com/user-attachments/assets/c9f3b1a9-d272-49fd-88da-c04e431fd8ca">

## 참고

- https://wantedlab.atlassian.net/browse/PI-68875