### PR TITLE
fix(wds): text-input read-only 속성 추가 대응

### DIFF
--- a/packages/wds/src/components/text-input/index.tsx
+++ b/packages/wds/src/components/text-input/index.tsx
@@ -43,6 +43,7 @@ const TextInput = forwardRef<
       leftContent,
       rightContent,
       positive,
+      readOnly,
       className,
       style,
       onReset,
@@ -68,6 +69,7 @@ const TextInput = forwardRef<
         sx={[
           textInputWrapperStyle({
             invalid,
+            readOnly,
             type,
             positive,
             xs,
@@ -106,6 +108,8 @@ const TextInput = forwardRef<
         <input
           ref={composedRefs}
           type={type}
+          readOnly={readOnly}
+          aria-readonly={readOnly}
           aria-invalid={invalid}
           {...props}
         />

--- a/packages/wds/src/components/text-input/style.ts
+++ b/packages/wds/src/components/text-input/style.ts
@@ -12,6 +12,7 @@ const EXCLUDE_TYPE = ['date', 'month', 'week', 'datetime-local', 'time'];
 export const textInputWrapperStyle =
   ({
     invalid,
+    readOnly,
     type,
     disabled,
     width = 'initial',
@@ -21,7 +22,7 @@ export const textInputWrapperStyle =
     md,
     lg,
     xl,
-  }: TextInputProps & { type?: string }) =>
+  }: TextInputProps & { type?: string; readOnly?: boolean }) =>
   (theme: Theme) => css`
     display: flex;
     align-items: center;
@@ -110,7 +111,7 @@ export const textInputWrapperStyle =
               }
 
               [data-role='text-input-reset'] {
-                display: flex;
+                display: ${readOnly ? 'none' : 'flex'};
               }
 
               &:where(:has(input:placeholder-shown)) {
@@ -154,7 +155,7 @@ export const textInputWrapperStyle =
                 display: none;
               }
               [data-role='text-input-reset'] {
-                display: flex;
+                display: ${readOnly ? 'none' : 'flex'};
               }
             }
           }


### PR DESCRIPTION
## 작업 내용

- `readOnly={true}`일 때 기본 reset 버튼 미노출, 그 외 기능은 유지
- https://wantedx.slack.com/archives/C06RQUTEURL/p1729645806086399

## as-is, readOnly={true}
<img width="394" alt="스크린샷 2024-10-25 오전 11 33 44" src="https://github.com/user-attachments/assets/e109a08a-22cc-4ad3-bd0a-a083bf86d322">

## to-be, readOnly={true}
<img width="394" alt="스크린샷 2024-10-25 오전 11 34 30" src="https://github.com/user-attachments/assets/f2606c7b-d39f-45f9-8b6f-45dc5df7ebe5">

closes #129