### PR TITLE
feat(wds): skeleton 개선

### DIFF
--- a/docs/src/docs/components/skeleton.mdx
+++ b/docs/src/docs/components/skeleton.mdx
@@ -5,7 +5,7 @@ description: Skeleton Component
 
 # Skeleton
 
-스켈레톤을 구성할 때 사용해요.
+자리를 일시적으로 표시할 때 사용합니다.
 
 ## 활용
 
@@ -26,10 +26,46 @@ export default Demo;`}
 
 ## Variant
 
+### Text
+
+텍스트 자리를 일시적으로 표시할 때 사용합니다.
+
+- padding 값이 포함되어 텍스트 영역에 로딩 스켈레톤을 구성해요.
+- `text` 에서만 `align` prop으로 가로 정렬을 조정할 수 있어요.
+
+<Demo code={`import { Skeleton, FlexBox } from '@wanteddev/wds';
+
+const Demo = () => {
+  return (
+    <FlexBox gap="24px" justifyContent="space-between">
+      <FlexBox flexDirection="column" gap="16px" flex="1">
+        <Skeleton align="left" />
+        <Skeleton width="75%" align="left" />
+        <Skeleton width="50%" align="left" />
+        <Skeleton width="25%" align="left" />
+      </FlexBox>
+      <FlexBox flexDirection="column" gap="16px" flex="1">
+        <Skeleton align="center" />
+        <Skeleton width="75%" align="center" />
+        <Skeleton width="50%" align="center" />
+        <Skeleton width="25%" align="center" />
+      </FlexBox>
+      <FlexBox flexDirection="column" gap="16px" flex="1">
+        <Skeleton align="right" />
+        <Skeleton width="75%" align="right" />
+        <Skeleton width="50%" align="right" />
+        <Skeleton width="25%" align="right" />
+      </FlexBox>
+    </FlexBox>
+  )
+}
+
+export default Demo;`}
+/>
+
 ### Rectangle
 
-`rectangle` 에서만 `radius` prop으로 border radius를 조정해서 사용할 수 있어요.
-썸네일 영역 로딩 표시 등에서 사용해요.
+네모난 모양을 가진 자리에 사용합니다.
 
 <Demo code={`import { Skeleton } from '@wanteddev/wds';
 
@@ -42,24 +78,9 @@ const Demo = () => {
 export default Demo;`}
 />
 
-### Text
-
-padding 값이 포함되어 텍스트 영역에 로딩 스켈레톤을 구성할 때 사용해요.
-
-<Demo code={`import { Skeleton } from '@wanteddev/wds';
-
-const Demo = () => {
-  return (
-    <Skeleton variant="text" height="22px" />
-  )
-}
-
-export default Demo;`}
-/>
-
 ### Circle
 
-원형 스켈레톤에 사용해요.
+동그란 모양을 가진 자리에 사용합니다.
 
 <Demo code={`import { Skeleton } from '@wanteddev/wds';
 

--- a/docs/src/docs/components/skeleton.mdx
+++ b/docs/src/docs/components/skeleton.mdx
@@ -5,7 +5,8 @@ description: Skeleton Component
 
 # Skeleton
 
-자리를 일시적으로 표시할 때 사용합니다.
+- 자리를 일시적으로 표시할 때 사용합니다.
+- `text`, `rectangle`에서 `radius` prop으로 border radius를 조정할 수 있어요.
 
 ## 활용
 
@@ -31,7 +32,7 @@ export default Demo;`}
 텍스트 자리를 일시적으로 표시할 때 사용합니다.
 
 - padding 값이 포함되어 텍스트 영역에 로딩 스켈레톤을 구성해요.
-- `text` 에서만 `align` prop으로 가로 정렬을 조정할 수 있어요.
+- `text`에서만 `align` prop으로 가로 정렬을 조정할 수 있어요.
 
 <Demo code={`import { Skeleton, FlexBox } from '@wanteddev/wds';
 
@@ -71,7 +72,7 @@ export default Demo;`}
 
 const Demo = () => {
   return (
-    <Skeleton variant="rectangle" />
+    <Skeleton variant="rectangle" width="64px" height="64px" />
   )
 }
 
@@ -86,7 +87,7 @@ export default Demo;`}
 
 const Demo = () => {
   return (
-    <Skeleton variant="circle" width="50px" height="50px" />
+    <Skeleton variant="circle" width="64px" height="64px" />
   )
 }
 

--- a/packages/wds/src/components/skeleton/index.tsx
+++ b/packages/wds/src/components/skeleton/index.tsx
@@ -14,9 +14,11 @@ import type { SkeletonProps } from './types';
 const Skeleton = forwardRef(
   <E extends ElementType = 'div'>(
     {
-      variant = 'rectangle',
+      variant = 'text',
       width = '100%',
       height = '22px',
+      align = 'left',
+      opacity = 'inherit',
       radius,
       xs,
       sm,
@@ -34,8 +36,10 @@ const Skeleton = forwardRef(
         sx={[
           skeletonStyle({
             radius,
+            opacity,
             variant,
             width,
+            align,
             height,
             xs,
             sm,

--- a/packages/wds/src/components/skeleton/index.tsx
+++ b/packages/wds/src/components/skeleton/index.tsx
@@ -19,7 +19,7 @@ const Skeleton = forwardRef(
       height,
       align = 'left',
       color,
-      opacity = 'inherit',
+      opacity = 'opacity.100',
       radius,
       xs,
       sm,

--- a/packages/wds/src/components/skeleton/index.tsx
+++ b/packages/wds/src/components/skeleton/index.tsx
@@ -15,8 +15,8 @@ const Skeleton = forwardRef(
   <E extends ElementType = 'div'>(
     {
       variant = 'text',
-      width = '100%',
-      height = '22px',
+      width,
+      height,
       align = 'left',
       opacity = 'inherit',
       radius,

--- a/packages/wds/src/components/skeleton/index.tsx
+++ b/packages/wds/src/components/skeleton/index.tsx
@@ -18,6 +18,7 @@ const Skeleton = forwardRef(
       width,
       height,
       align = 'left',
+      color,
       opacity = 'inherit',
       radius,
       xs,
@@ -36,6 +37,7 @@ const Skeleton = forwardRef(
         sx={[
           skeletonStyle({
             radius,
+            color,
             opacity,
             variant,
             width,

--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@wanteddev/wds-engine';
+import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import { createResponsiveStyle } from '../../utils/responsive-props';
 
@@ -70,10 +70,13 @@ const skeletonVariantStyle = (
     variant,
     opacity,
     align,
+    color,
     radius = 'initial',
-  }: Pick<SkeletonProps, 'variant' | 'radius' | 'opacity' | 'align'>,
+  }: Pick<SkeletonProps, 'variant' | 'radius' | 'opacity' | 'align' | 'color'>,
   theme: Theme,
 ) => {
+  const customColor = color ? getColorByToken(theme, color) : color;
+
   switch (variant) {
     case 'text':
       return css`
@@ -83,7 +86,7 @@ const skeletonVariantStyle = (
 
         & > span {
           display: inline-block;
-          background-color: ${theme.palette.fill.normal};
+          background-color: ${customColor ?? theme.palette.fill.normal};
           opacity: ${opacity};
         }
       `;
@@ -92,7 +95,7 @@ const skeletonVariantStyle = (
         border-radius: ${radius};
 
         & > span {
-          background-color: ${theme.palette.fill.alternative};
+          background-color: ${customColor ?? theme.palette.fill.alternative};
           opacity: ${opacity};
         }
       `;
@@ -101,7 +104,7 @@ const skeletonVariantStyle = (
         border-radius: 50%;
 
         & > span {
-          background-color: ${theme.palette.fill.normal};
+          background-color: ${customColor ?? theme.palette.fill.normal};
           opacity: ${opacity};
         }
       `;

--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -1,4 +1,5 @@
 import { css, getColorByToken } from '@wanteddev/wds-engine';
+import objectPath from 'object-path';
 
 import { createResponsiveStyle } from '../../utils/responsive-props';
 
@@ -68,14 +69,17 @@ const skeletonSizeStyle = ({
 const skeletonVariantStyle = (
   {
     variant,
-    opacity,
     align,
-    color,
+    color: colorProp,
+    opacity: opacityProp,
     radius = 'initial',
   }: Pick<SkeletonProps, 'variant' | 'radius' | 'opacity' | 'align' | 'color'>,
   theme: Theme,
 ) => {
-  const customColor = color ? getColorByToken(theme, color) : color;
+  const color = colorProp ? getColorByToken(theme, colorProp) : colorProp;
+  const opacity = opacityProp
+    ? objectPath.get(theme, opacityProp)
+    : opacityProp;
 
   switch (variant) {
     case 'text':
@@ -86,7 +90,7 @@ const skeletonVariantStyle = (
 
         & > span {
           display: inline-block;
-          background-color: ${customColor ?? theme.palette.fill.normal};
+          background-color: ${color ?? theme.palette.fill.normal};
           opacity: ${opacity};
         }
       `;
@@ -95,7 +99,7 @@ const skeletonVariantStyle = (
         border-radius: ${radius};
 
         & > span {
-          background-color: ${customColor ?? theme.palette.fill.alternative};
+          background-color: ${color ?? theme.palette.fill.alternative};
           opacity: ${opacity};
         }
       `;
@@ -104,7 +108,7 @@ const skeletonVariantStyle = (
         border-radius: 50%;
 
         & > span {
-          background-color: ${customColor ?? theme.palette.fill.normal};
+          background-color: ${color ?? theme.palette.fill.normal};
           opacity: ${opacity};
         }
       `;

--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -10,10 +10,11 @@ export const skeletonStyle =
   (theme: Theme) => css`
     position: relative;
     flex-shrink: 0;
+    width: 100%;
 
     & > span {
       border-radius: inherit;
-      display: block;
+      display: inline-block;
       width: 100%;
       height: 100%;
     }
@@ -38,7 +39,9 @@ const skeletonSizeStyle = ({
 }: Pick<SkeletonProps, 'width' | 'height'>) => css`
   ${Boolean(width) &&
   css`
-    width: ${width};
+    > span {
+      width: ${width};
+    }
   `}
 
   ${Boolean(height) &&
@@ -48,7 +51,12 @@ const skeletonSizeStyle = ({
 `;
 
 const skeletonVariantStyle = (
-  { variant, radius = 'initial' }: Pick<SkeletonProps, 'variant' | 'radius'>,
+  {
+    variant,
+    opacity,
+    align,
+    radius = 'initial',
+  }: Pick<SkeletonProps, 'variant' | 'radius' | 'opacity' | 'align'>,
   theme: Theme,
 ) => {
   switch (variant) {
@@ -56,9 +64,11 @@ const skeletonVariantStyle = (
       return css`
         padding: 2px 0px;
         border-radius: 3px;
+        text-align: ${align};
 
         & > span {
           background-color: ${theme.palette.fill.normal};
+          opacity: ${opacity};
         }
       `;
     case 'circle':
@@ -67,6 +77,7 @@ const skeletonVariantStyle = (
 
         & > span {
           background-color: ${theme.palette.fill.alternative};
+          opacity: ${opacity};
         }
       `;
     case 'rectangle':
@@ -75,6 +86,7 @@ const skeletonVariantStyle = (
 
         & > span {
           background-color: ${theme.palette.fill.alternative};
+          opacity: ${opacity};
         }
       `;
   }

--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -14,7 +14,7 @@ export const skeletonStyle =
 
     & > span {
       border-radius: inherit;
-      display: inline-block;
+      display: block;
       width: 100%;
       height: 100%;
     }
@@ -34,21 +34,36 @@ export const skeletonStyle =
   `;
 
 const skeletonSizeStyle = ({
+  variant,
   width,
   height,
-}: Pick<SkeletonProps, 'width' | 'height'>) => css`
-  ${Boolean(width) &&
-  css`
-    > span {
-      width: ${width};
-    }
-  `}
+}: Pick<SkeletonProps, 'width' | 'height' | 'variant'>) => {
+  switch (variant) {
+    case 'text':
+      return css`
+        height: ${height ?? '22px'};
 
-  ${Boolean(height) &&
-  css`
-    height: ${height};
-  `}
-`;
+        > span {
+          ${Boolean(width) &&
+          css`
+            width: ${width};
+          `}
+        }
+      `;
+    case 'rectangle':
+    case 'circle':
+      return css`
+        ${Boolean(width) &&
+        css`
+          width: ${width};
+        `}
+        ${Boolean(height) &&
+        css`
+          height: ${height};
+        `}
+      `;
+  }
+};
 
 const skeletonVariantStyle = (
   {
@@ -67,16 +82,8 @@ const skeletonVariantStyle = (
         text-align: ${align};
 
         & > span {
+          display: inline-block;
           background-color: ${theme.palette.fill.normal};
-          opacity: ${opacity};
-        }
-      `;
-    case 'circle':
-      return css`
-        border-radius: 50%;
-
-        & > span {
-          background-color: ${theme.palette.fill.alternative};
           opacity: ${opacity};
         }
       `;
@@ -86,6 +93,15 @@ const skeletonVariantStyle = (
 
         & > span {
           background-color: ${theme.palette.fill.alternative};
+          opacity: ${opacity};
+        }
+      `;
+    case 'circle':
+      return css`
+        border-radius: 50%;
+
+        & > span {
+          background-color: ${theme.palette.fill.normal};
           opacity: ${opacity};
         }
       `;

--- a/packages/wds/src/components/skeleton/types.ts
+++ b/packages/wds/src/components/skeleton/types.ts
@@ -1,11 +1,16 @@
 import type { CSSProperties } from 'react';
-import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
+import type {
+  Merge,
+  ResponsiveProps,
+  ThemeColorsToken,
+} from '@wanteddev/wds-engine';
 
 type SkeletonDefaultProps = {
   variant?: 'text' | 'circle' | 'rectangle';
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
   radius?: CSSProperties['borderRadius'];
+  color?: ThemeColorsToken;
   opacity?: CSSProperties['opacity'];
   align?: 'left' | 'center' | 'right';
 };

--- a/packages/wds/src/components/skeleton/types.ts
+++ b/packages/wds/src/components/skeleton/types.ts
@@ -3,6 +3,7 @@ import type {
   Merge,
   ResponsiveProps,
   ThemeColorsToken,
+  ThemeOpacityToken,
 } from '@wanteddev/wds-engine';
 
 type SkeletonDefaultProps = {
@@ -11,7 +12,7 @@ type SkeletonDefaultProps = {
   height?: CSSProperties['height'];
   radius?: CSSProperties['borderRadius'];
   color?: ThemeColorsToken;
-  opacity?: CSSProperties['opacity'];
+  opacity?: ThemeOpacityToken;
   align?: 'left' | 'center' | 'right';
 };
 

--- a/packages/wds/src/components/skeleton/types.ts
+++ b/packages/wds/src/components/skeleton/types.ts
@@ -6,6 +6,8 @@ type SkeletonDefaultProps = {
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
   radius?: CSSProperties['borderRadius'];
+  opacity?: CSSProperties['opacity'];
+  align?: 'left' | 'center' | 'right';
 };
 
 type SkeletonResponsiveProps = ResponsiveProps<


### PR DESCRIPTION
## 작업 내용
- variant 스타일 조정 및 docs 수정
- variant="text"에 `align` prop을 추가하기 위해 스타일 조정
- `opacity` prop으로 addHexOpacity를 사용해 color에 opacity를 입히려 했으나, 이미 입혀진 palette color들이 있어서 값 그대로 넣었습니다. 더 좋은 방법이 있다면 공유 부탁드립니다..!

## 참고
- https://wantedlab.atlassian.net/browse/PI-68809
- https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=3331-6957&node-type=instance&m=dev