### PR TITLE
fix(*): d.ts를 올바르게 생성하지 못 하는 현상 수정

### DIFF
--- a/.tsup/define-configuration.ts
+++ b/.tsup/define-configuration.ts
@@ -1,9 +1,8 @@
 import { esbuildPluginFilePathExtensions } from './esbuild-plugin-file-path-extensions';
 import { Options } from 'tsup';
 
-export const defineConfiguration = (opts: Pick<Options, 'entry'>): Options => {
+export const defineConfiguration = (opts: Partial<Options>): Options => {
   return {
-    entry: opts.entry,
     format: ['cjs', 'esm'],
     target: ['chrome91', 'firefox90', 'edge91', 'safari15', 'ios15', 'opera77'],
     outDir: 'dist',
@@ -12,7 +11,13 @@ export const defineConfiguration = (opts: Pick<Options, 'entry'>): Options => {
     treeshake: true,
     bundle: true,
     silent: true,
-    external: ['react', 'react-dom', 'next', 'react-hook-form', '@wanteddev/wds-engine'],
+    external: [
+      'react',
+      'react-dom',
+      'next',
+      'react-hook-form',
+    ],
     esbuildPlugins: [esbuildPluginFilePathExtensions({ cjsExtension: 'js' })],
+    ...opts,
   };
 };

--- a/packages/wds-engine/package.json
+++ b/packages/wds-engine/package.json
@@ -40,7 +40,9 @@
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.4",
     "@emotion/serialize": "^1.1.3",
+    "@emotion/utils": "^1.2.1",
     "@wanteddev/wds-theme": "workspace:*",
+    "csstype": "^3.1.3",
     "react": "^18.2.0"
   },
   "peerDependencies": {

--- a/packages/wds-engine/src/hooks/use-theme.ts
+++ b/packages/wds-engine/src/hooks/use-theme.ts
@@ -2,6 +2,8 @@ import { useContext } from 'react';
 
 import ThemeContext from '../context';
 
-const useTheme = () => useContext(ThemeContext);
+import type { Theme } from '@wanteddev/wds-theme';
+
+const useTheme = (): Theme => useContext(ThemeContext);
 
 export default useTheme;

--- a/packages/wds-engine/tsup.config.ts
+++ b/packages/wds-engine/tsup.config.ts
@@ -3,9 +3,10 @@ import { defineConfig } from 'tsup';
 import { defineConfiguration } from '../../.tsup/define-configuration';
 import { injectUseClient } from '../../.tsup/inject-use-client';
 
-export default defineConfig([
-  {
-    ...defineConfiguration({ entry: ['src/**/*.ts', 'src/**/*.tsx'] }),
+export default defineConfig(
+  defineConfiguration({
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
+    dts: 'src/index.ts',
     onSuccess: () =>
       injectUseClient([
         './dist/box/**/index.{js,mjs}',
@@ -14,5 +15,5 @@ export default defineConfig([
         './dist/hooks/*/*.{js,mjs}',
         './dist/global/**/index.{js,mjs}',
       ]),
-  },
-]);
+  }),
+);

--- a/packages/wds-icon/tsup.config.ts
+++ b/packages/wds-icon/tsup.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsup';
 
 import { defineConfiguration } from '../../.tsup/define-configuration';
 
-export default defineConfig([
-  defineConfiguration({ entry: ['src/**/*.ts', 'src/**/*.tsx'] }),
-]);
+export default defineConfig(
+  defineConfiguration({
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
+    dts: 'src/index.ts',
+  }),
+);

--- a/packages/wds-lottie/tsup.config.ts
+++ b/packages/wds-lottie/tsup.config.ts
@@ -3,9 +3,10 @@ import { defineConfig } from 'tsup';
 import { defineConfiguration } from '../../.tsup/define-configuration';
 import { injectUseClient } from '../../.tsup/inject-use-client';
 
-export default defineConfig([
-  {
-    ...defineConfiguration({ entry: ['src/**/*.ts', 'src/**/*.tsx'] }),
+export default defineConfig(
+  defineConfiguration({
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
+    dts: 'src/index.ts',
     onSuccess: () => injectUseClient(['./dist/loading/index.{js,mjs}']),
-  },
-]);
+  }),
+);

--- a/packages/wds-nextjs/tsup.config.ts
+++ b/packages/wds-nextjs/tsup.config.ts
@@ -3,9 +3,10 @@ import { defineConfig } from 'tsup';
 import { defineConfiguration } from '../../.tsup/define-configuration';
 import { injectUseClient } from '../../.tsup/inject-use-client';
 
-export default defineConfig([
-  {
-    ...defineConfiguration({ entry: ['src/**/*.ts', 'src/**/*.tsx'] }),
+export default defineConfig(
+  defineConfiguration({
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
+    dts: 'src/index.ts',
     onSuccess: () => injectUseClient(['./dist/!(index)*.{js,mjs}']),
-  },
-]);
+  }),
+);

--- a/packages/wds-theme/tsup.config.ts
+++ b/packages/wds-theme/tsup.config.ts
@@ -2,9 +2,9 @@ import { defineConfig } from 'tsup';
 
 import { defineConfiguration } from '../../.tsup/define-configuration';
 
-export default defineConfig([
-  {
-    ...defineConfiguration({ entry: ['src/**/*.ts', 'src/**/*.tsx'] }),
+export default defineConfig(
+  defineConfiguration({
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
     dts: 'src/index.ts',
-  },
-]);
+  }),
+);

--- a/packages/wds/src/components/nested-checkbox/types.ts
+++ b/packages/wds/src/components/nested-checkbox/types.ts
@@ -1,7 +1,7 @@
-import type Checkbox from '../checkbox';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { CheckboxProps } from '../checkbox/types';
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 
 export type NestedCheckboxProps = Omit<
-  ComponentPropsWithoutRef<typeof Checkbox>,
-  'indeterminate' | 'indeterminateIcon'
+  DefaultComponentProps<CheckboxProps, 'button'>,
+  'onChange' | 'value' | 'indeterminate' | 'indeterminateIcon'
 >;

--- a/packages/wds/src/components/round-checkbox/types.ts
+++ b/packages/wds/src/components/round-checkbox/types.ts
@@ -1,4 +1,7 @@
-import type Checkbox from '../checkbox';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+import type { CheckboxProps } from '../checkbox/types';
 
-export type RoundCheckboxProps = ComponentPropsWithoutRef<typeof Checkbox>;
+export type RoundCheckboxProps = Omit<
+  DefaultComponentProps<CheckboxProps, 'button'>,
+  'onChange' | 'value'
+>;

--- a/packages/wds/tsup.config.ts
+++ b/packages/wds/tsup.config.ts
@@ -3,9 +3,9 @@ import { defineConfig } from 'tsup';
 import { defineConfiguration } from '../../.tsup/define-configuration';
 import { injectUseClient } from '../../.tsup/inject-use-client';
 
-export default defineConfig([
-  {
-    ...defineConfiguration({ entry: ['src/**/*.ts', 'src/**/*.tsx'] }),
+export default defineConfig(
+  defineConfiguration({
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
     dts: 'src/index.ts',
     onSuccess: () =>
       injectUseClient([
@@ -14,5 +14,5 @@ export default defineConfig([
         './dist/stores/*.{js,mjs}',
         './dist/theme-provider/*.{js,mjs}',
       ]),
-  },
-]);
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,9 +333,15 @@ importers:
       '@emotion/serialize':
         specifier: ^1.1.3
         version: 1.1.3
+      '@emotion/utils':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@wanteddev/wds-theme':
         specifier: workspace:*
         version: link:../wds-theme
+      csstype:
+        specifier: ^3.1.3
+        version: 3.1.3
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
간혹 이렇게 타입이 이상하게 빌드되는 파일들이 있습니다.
이 경우를 해결하고자 index.d.ts <- 파일 하나에 타입이 모두 들어가게 수정했습니다.

또한 any로 잡히는 타입들을 막아주기 위해 명시적 타입 선언, 패키지 추가 설치 등을 진행했습니다.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/6a75c529-d4a6-4567-bb65-e2faab147a94">
