### PR TITLE
feat(wds): card-list 작성

### DIFF
--- a/docs/src/docs/components/card-list.mdx
+++ b/docs/src/docs/components/card-list.mdx
@@ -130,7 +130,7 @@ const Demo = () => {
         </CardListContent>
       }
     >
-      <CardThumbnailSkeleton width="120px" />
+      <CardThumbnailSkeleton />
       <CardContent>
         <CardTitle>제목</CardTitle>
         <CardCaption>(min-width: 768px), width: 480px</CardCaption>
@@ -161,7 +161,7 @@ const Demo = () => {
           </CardListContent>
         }
       >
-        <CardThumbnailSkeleton width="120px" />
+        <CardThumbnailSkeleton />
         <CardContent>
           <CardTitle>제목</CardTitle>
           <CardCaption>캡션</CardCaption>
@@ -210,7 +210,7 @@ const Demo = () => {
         platform: 'desktop'
       }}
     >
-      <CardThumbnailSkeleton width="120px" />
+      <CardThumbnailSkeleton />
       <CardContent>
         <CardTitle>제목</CardTitle>
         <CardCaption>(min-width: 768px), width: 480px</CardCaption>
@@ -242,7 +242,7 @@ const Demo = () => {
           </CardListContent>
         }
       >
-        <CardThumbnailSkeleton width="120px" />
+        <CardThumbnailSkeleton />
         <CardContent>
           <CardContentItem position="top" variant="badge">
             {new Array(3).fill(0).map((_, i) => (
@@ -290,7 +290,7 @@ const Demo = () => {
   return (
     <FlexBox flexDirection="column" gap="16px">
       <CardListSkeleton width="480px">
-        <CardThumbnailSkeleton width="120px" />
+        <CardThumbnailSkeleton />
         <CardContent>
           <CardTitleSkeleton />
           <CardCaptionSkeleton />
@@ -302,7 +302,7 @@ const Demo = () => {
         hasLeftContent 
         hasRightContent
       >
-        <CardThumbnailSkeleton width="120px" />
+        <CardThumbnailSkeleton />
         <CardContent>
           <CardContentItem position="top">
             <CardContentItemSkeleton />

--- a/docs/src/docs/components/card-list.mdx
+++ b/docs/src/docs/components/card-list.mdx
@@ -1,0 +1,280 @@
+---
+title: CardList
+description: CardList Component
+---
+
+# CardList
+
+- 표시할 양이 많은 정보를 묶어 표시할 때 사용합니다.
+- leftContent, rightContent에 요소를 추가 할 때는 `CardListContent` 로 감싸주세요.
+
+<Demo code={`import { FlexBox, CardList, Checkbox, CardListThumbnail, CardTitle, CardCaption, CardContent, Checkbox, CardListContent, ToggleIcon } from '@wanteddev/wds';
+import { IconBookmark, IconBookmarkFill } from '@wanteddev/wds-icon';
+import { useState } from 'react';
+
+const items = [
+  {
+    id: 1,
+    title: '제목',
+    caption: '캡션',
+  },
+  {
+    id: 2,
+    title: '제목',
+    caption: '캡션',
+  }
+];
+
+const Demo = () => {
+  const [idList, setIdList] = useState<Array<number>>([]);
+
+  return (
+    <FlexBox flexDirection="column" gap="16px">
+      {items.map((item) => (
+        <CardList
+          key={item.id}
+          as="a" 
+          href="https://wanted.co.kr"
+          target="_blank"
+          width="480px"
+          leftContent={
+            <CardListContent variant="checkbox">
+              <Checkbox 
+                checked={idList.includes(item.id)}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    setIdList((prevIdList) => [...prevIdList, item.id]);
+                  } else {
+                    setIdList((prevIdList) => prevIdList.filter((prevId) => prevId !== item.id));
+                  }
+                }}
+              />
+            </CardListContent>
+          }
+          rightContent={
+            <CardListContent variant="toggle-icon">
+              <ToggleIcon 
+                activeColor="palette.primary.normal" 
+              >
+                <IconBookmarkFill />
+              </ToggleIcon>
+            </CardListContent>
+          }
+        >
+          <CardListThumbnail
+            src="https://static.wanted.co.kr/images/company/79/elpzxpmgh94xesrf__1080_790.png"
+            alt="Wanted Company Image"
+            width="120px"
+            quality={95}
+          />
+          <CardContent>
+            <CardTitle>{item.title}</CardTitle>
+            <CardCaption>{item.caption}</CardCaption>
+          </CardContent>
+        </CardList>
+      ))}
+    </FlexBox>
+  );
+}
+
+export default Demo;`}
+/>
+
+## Components
+
+아래와 같이 조합하여 사용합니다.
+
+```tsx
+<CardList>
+  <CardListThumbnail />
+  <CardContent>
+    <CardExtraContent/>
+    <CardTitle />
+    <CardCaption />
+    <CardExtraContent />
+  </CardContent>
+</CardList>
+```
+
+### CardList
+
+<PropsTable component="CardList" />
+
+### CardListContent
+
+<PropsTable component="CardListContent" />
+
+## Examples
+
+### Width
+
+- `width`를 지정할 수 있고, 지정하지 않으면 100%의 너비를 사용해요.
+- ResponsiveProps를 사용하여 해당 breakpoint 이상일 때 width를 사용할 수 있어요.
+
+<Demo code={`import { CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardListContent } from '@wanteddev/wds';
+import { IconChevronRightTight } from '@wanteddev/wds-icon';
+import { useState } from 'react';
+
+const Demo = () => {
+  return (
+    <CardList
+      width="335px" 
+      sm={{ width: '480px' }} 
+      rightContent={
+        <CardListContent variant="icon">
+          <IconChevronRightTight />
+        </CardListContent>
+      }
+    >
+      <CardThumbnailSkeleton width="120px" />
+      <CardContent>
+        <CardTitle>제목</CardTitle>
+        <CardCaption>(min-width: 768px), width: 480px</CardCaption>
+        <CardCaption>(max-width: 767px), width: 335px</CardCaption>
+      </CardContent>
+    </CardList>
+  );
+}
+
+export default Demo;`}
+/>
+
+### Platform
+
+`platform`에 따라 콘텐츠 간격, 제목 크기가 달라요.
+
+<Demo code={`import { FlexBox, CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardListContent } from '@wanteddev/wds';
+import { IconChevronRightTight } from '@wanteddev/wds-icon';
+
+const Demo = () => {
+  return (
+    <FlexBox flexDirection="column" gap="16px">
+      <CardList
+        width="480px"
+        rightContent={
+          <CardListContent variant="icon">
+            <IconChevronRightTight />
+          </CardListContent>
+        }
+      >
+        <CardThumbnailSkeleton width="120px" />
+        <CardContent>
+          <CardTitle>제목</CardTitle>
+          <CardCaption>캡션</CardCaption>
+        </CardContent>
+      </CardList>
+      <CardList
+        width="335px"
+        platform="mobile"
+        rightContent={
+          <CardListContent variant="icon">
+            <IconChevronRightTight />
+          </CardListContent>
+        }
+      >
+        <CardThumbnailSkeleton width="96px" />
+        <CardContent>
+          <CardTitle>제목</CardTitle>
+          <CardCaption>캡션</CardCaption>
+        </CardContent>
+      </CardList>
+    </FlexBox>
+  );
+}
+
+export default Demo;`}
+/>
+
+- ResponsiveProps를 사용하여 해당 breakpoint 이상일 때 platform을 지정할 수 있어요.
+- `width`와 조합해서 사용할 수 있어요.
+
+<Demo code={`import { CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardListContent } from '@wanteddev/wds';
+import { IconChevronRightTight } from '@wanteddev/wds-icon';
+
+const Demo = () => {
+  return (
+    <CardList
+      width="335px"
+      platform="mobile"
+      rightContent={
+        <CardListContent variant="icon">
+          <IconChevronRightTight />
+        </CardListContent>
+      }
+      sm={{
+        width: '480px',
+        platform: 'desktop'
+      }}
+    >
+      <CardThumbnailSkeleton width="120px" />
+      <CardContent>
+        <CardTitle>제목</CardTitle>
+        <CardCaption>(min-width: 768px), width: 480px</CardCaption>
+        <CardCaption>(min-width: 768px), platform: desktop</CardCaption>
+      </CardContent>
+    </CardList>
+  );
+}
+
+export default Demo;`}
+/>
+
+### Top Content, Bottom Content
+
+- `CardExtraContent`의 `position`을 조정하여 top, bottom에 콘텐츠를 추가할 수 있어요.
+- 뱃지나 부가적인 내용을 추가할 때 사용해요.
+
+<Demo code={`import { ContentBadge, FlexBox, CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardExtraContent, CardListContent } from '@wanteddev/wds';
+import { IconChevronRightTight } from '@wanteddev/wds-icon';
+
+const Demo = () => {
+  return (
+    <FlexBox flexDirection="column" gap="16px">
+      <CardList
+        width="480px"
+        rightContent={
+          <CardListContent variant="icon">
+            <IconChevronRightTight />
+          </CardListContent>
+        }
+      >
+        <CardThumbnailSkeleton width="120px" />
+        <CardContent>
+          <CardExtraContent position="top" variant="badge">
+            {new Array(3).fill(0).map((_, i) => (
+              <ContentBadge key={i} color="neutral">텍스트</ContentBadge>
+            ))}
+          </CardExtraContent>
+          <CardTitle>제목</CardTitle>
+          <CardCaption>캡션</CardCaption>
+        </CardContent>
+      </CardList>
+      <CardList
+        width="480px"
+        rightContent={
+          <CardListContent variant="icon">
+            <IconChevronRightTight />
+          </CardListContent>
+        }
+      >
+        <CardThumbnailSkeleton width="96px" />
+        <CardContent>
+          <CardTitle>제목</CardTitle>
+          <CardCaption>캡션</CardCaption>
+          <CardExtraContent position="bottom" variant="badge">
+            {new Array(3).fill(0).map((_, i) => (
+              <ContentBadge key={i} color="neutral">텍스트</ContentBadge>
+            ))}
+          </CardExtraContent>
+        </CardContent>
+      </CardList>
+    </FlexBox>
+  );
+}
+
+export default Demo;`}
+/>
+
+### Skeleton
+
+CardList의 형태에 따라 스켈레톤을 조합하여 사용해요.

--- a/docs/src/docs/components/card-list.mdx
+++ b/docs/src/docs/components/card-list.mdx
@@ -145,7 +145,7 @@ export default Demo;`}
 
 ### Platform
 
-`platform`에 따라 콘텐츠 간격, 제목 크기가 달라요.
+`platform`에 따라 `CardListThumbnail`의 크기, 제목 크기, 콘텐츠 간격이 달라요.
 
 <Demo code={`import { FlexBox, CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardListContent } from '@wanteddev/wds';
 import { IconChevronRightTight } from '@wanteddev/wds-icon';
@@ -281,7 +281,8 @@ export default Demo;`}
 
 ### Skeleton
 
-CardList의 형태에 따라 스켈레톤을 조합하여 사용해요.
+- CardList의 형태에 따라 스켈레톤을 조합하여 사용해요.
+- CardList에 leftContent, rightContent가 있을 경우 `hasLeftContent`, `hasRightContent`로 영역을 조정할 수 있어요.
 
 <Demo code={`import { FlexBox, CardListSkeleton, CardThumbnailSkeleton, CardContent, CardContentItemSkeleton, CardContentItem, CardTitleSkeleton, CardCaptionSkeleton } from '@wanteddev/wds';
 
@@ -296,14 +297,18 @@ const Demo = () => {
         </CardContent>
       </CardListSkeleton>
 
-      <CardListSkeleton width="480px">
+      <CardListSkeleton 
+        width="480px" 
+        hasLeftContent 
+        hasRightContent
+      >
         <CardThumbnailSkeleton width="120px" />
         <CardContent>
           <CardContentItem position="top">
             <CardContentItemSkeleton />
           </CardContentItem>
           <CardTitleSkeleton />
-          <CardCaptionSkeleton variant="extra" />
+          <CardCaptionSkeleton type="extra" />
           <CardCaptionSkeleton />
           <CardContentItem position="top">
             <CardContentItemSkeleton />
@@ -311,7 +316,10 @@ const Demo = () => {
         </CardContent>
       </CardListSkeleton>
 
-      <CardListSkeleton width="335px" platform="mobile">
+      <CardListSkeleton 
+        width="335px" 
+        platform="mobile"
+      >
         <CardThumbnailSkeleton width="96px" />
         <CardContent>
           <CardTitleSkeleton />
@@ -319,14 +327,19 @@ const Demo = () => {
         </CardContent>
       </CardListSkeleton>
 
-      <CardListSkeleton width="335px" platform="mobile">
+      <CardListSkeleton 
+        width="335px" 
+        platform="mobile" 
+        hasLeftContent 
+        hasRightContent
+      >
         <CardThumbnailSkeleton width="96px" />
         <CardContent>
           <CardContentItem position="top">
             <CardContentItemSkeleton />
           </CardContentItem>
           <CardTitleSkeleton />
-          <CardCaptionSkeleton variant="extra" />
+          <CardCaptionSkeleton type="extra" />
           <CardCaptionSkeleton />
           <CardContentItem position="top">
             <CardContentItemSkeleton />

--- a/docs/src/docs/components/card-list.mdx
+++ b/docs/src/docs/components/card-list.mdx
@@ -88,10 +88,10 @@ export default Demo;`}
 <CardList>
   <CardListThumbnail />
   <CardContent>
-    <CardExtraContent/>
+    <CardContentItem />
     <CardTitle />
     <CardCaption />
-    <CardExtraContent />
+    <CardContentItem />
   </CardContent>
 </CardList>
 ```
@@ -225,10 +225,10 @@ export default Demo;`}
 
 ### Top Content, Bottom Content
 
-- `CardExtraContent`의 `position`을 조정하여 top, bottom에 콘텐츠를 추가할 수 있어요.
+- `CardContentItem`의 `position`을 조정하여 top, bottom에 콘텐츠를 추가할 수 있어요.
 - 뱃지나 부가적인 내용을 추가할 때 사용해요.
 
-<Demo code={`import { ContentBadge, FlexBox, CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardExtraContent, CardListContent } from '@wanteddev/wds';
+<Demo code={`import { ContentBadge, FlexBox, CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardContentItem, CardListContent } from '@wanteddev/wds';
 import { IconChevronRightTight } from '@wanteddev/wds-icon';
 
 const Demo = () => {
@@ -244,11 +244,11 @@ const Demo = () => {
       >
         <CardThumbnailSkeleton width="120px" />
         <CardContent>
-          <CardExtraContent position="top" variant="badge">
+          <CardContentItem position="top" variant="badge">
             {new Array(3).fill(0).map((_, i) => (
               <ContentBadge key={i} color="neutral">텍스트</ContentBadge>
             ))}
-          </CardExtraContent>
+          </CardContentItem>
           <CardTitle>제목</CardTitle>
           <CardCaption>캡션</CardCaption>
         </CardContent>
@@ -265,11 +265,11 @@ const Demo = () => {
         <CardContent>
           <CardTitle>제목</CardTitle>
           <CardCaption>캡션</CardCaption>
-          <CardExtraContent position="bottom" variant="badge">
+          <CardContentItem position="bottom" variant="badge">
             {new Array(3).fill(0).map((_, i) => (
               <ContentBadge key={i} color="neutral">텍스트</ContentBadge>
             ))}
-          </CardExtraContent>
+          </CardContentItem>
         </CardContent>
       </CardList>
     </FlexBox>
@@ -283,7 +283,7 @@ export default Demo;`}
 
 CardList의 형태에 따라 스켈레톤을 조합하여 사용해요.
 
-<Demo code={`import { FlexBox, CardListSkeleton, CardThumbnailSkeleton, CardContent, CardExtraContentSkeleton, CardExtraContent, CardTitleSkeleton, CardCaptionSkeleton } from '@wanteddev/wds';
+<Demo code={`import { FlexBox, CardListSkeleton, CardThumbnailSkeleton, CardContent, CardContentItemSkeleton, CardContentItem, CardTitleSkeleton, CardCaptionSkeleton } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
@@ -299,15 +299,15 @@ const Demo = () => {
       <CardListSkeleton width="480px">
         <CardThumbnailSkeleton width="120px" />
         <CardContent>
-          <CardExtraContent position="top">
-            <CardExtraContentSkeleton />
-          </CardExtraContent>
+          <CardContentItem position="top">
+            <CardContentItemSkeleton />
+          </CardContentItem>
           <CardTitleSkeleton />
           <CardCaptionSkeleton variant="extra" />
           <CardCaptionSkeleton />
-          <CardExtraContent position="top">
-            <CardExtraContentSkeleton />
-          </CardExtraContent>
+          <CardContentItem position="top">
+            <CardContentItemSkeleton />
+          </CardContentItem>
         </CardContent>
       </CardListSkeleton>
 
@@ -322,15 +322,15 @@ const Demo = () => {
       <CardListSkeleton width="335px" platform="mobile">
         <CardThumbnailSkeleton width="96px" />
         <CardContent>
-          <CardExtraContent position="top">
-            <CardExtraContentSkeleton />
-          </CardExtraContent>
+          <CardContentItem position="top">
+            <CardContentItemSkeleton />
+          </CardContentItem>
           <CardTitleSkeleton />
           <CardCaptionSkeleton variant="extra" />
           <CardCaptionSkeleton />
-          <CardExtraContent position="top">
-            <CardExtraContentSkeleton />
-          </CardExtraContent>
+          <CardContentItem position="top">
+            <CardContentItemSkeleton />
+          </CardContentItem>
         </CardContent>
       </CardListSkeleton>
     </FlexBox>

--- a/docs/src/docs/components/card-list.mdx
+++ b/docs/src/docs/components/card-list.mdx
@@ -104,6 +104,10 @@ export default Demo;`}
 
 <PropsTable component="CardListContent" />
 
+### CardListSkeleton
+
+<PropsTable component="CardListSkeleton" />
+
 ## Examples
 
 ### Width
@@ -278,3 +282,60 @@ export default Demo;`}
 ### Skeleton
 
 CardList의 형태에 따라 스켈레톤을 조합하여 사용해요.
+
+<Demo code={`import { FlexBox, CardListSkeleton, CardThumbnailSkeleton, CardContent, CardExtraContentSkeleton, CardExtraContent, CardTitleSkeleton, CardCaptionSkeleton } from '@wanteddev/wds';
+
+const Demo = () => {
+  return (
+    <FlexBox flexDirection="column" gap="16px">
+      <CardListSkeleton width="480px">
+        <CardThumbnailSkeleton width="120px" />
+        <CardContent>
+          <CardTitleSkeleton />
+          <CardCaptionSkeleton />
+        </CardContent>
+      </CardListSkeleton>
+
+      <CardListSkeleton width="480px">
+        <CardThumbnailSkeleton width="120px" />
+        <CardContent>
+          <CardExtraContent position="top">
+            <CardExtraContentSkeleton />
+          </CardExtraContent>
+          <CardTitleSkeleton />
+          <CardCaptionSkeleton variant="extra" />
+          <CardCaptionSkeleton />
+          <CardExtraContent position="top">
+            <CardExtraContentSkeleton />
+          </CardExtraContent>
+        </CardContent>
+      </CardListSkeleton>
+
+      <CardListSkeleton width="335px" platform="mobile">
+        <CardThumbnailSkeleton width="96px" />
+        <CardContent>
+          <CardTitleSkeleton />
+          <CardCaptionSkeleton />
+        </CardContent>
+      </CardListSkeleton>
+
+      <CardListSkeleton width="335px" platform="mobile">
+        <CardThumbnailSkeleton width="96px" />
+        <CardContent>
+          <CardExtraContent position="top">
+            <CardExtraContentSkeleton />
+          </CardExtraContent>
+          <CardTitleSkeleton />
+          <CardCaptionSkeleton variant="extra" />
+          <CardCaptionSkeleton />
+          <CardExtraContent position="top">
+            <CardExtraContentSkeleton />
+          </CardExtraContent>
+        </CardContent>
+      </CardListSkeleton>
+    </FlexBox>
+  );
+}
+
+export default Demo;`}
+/>

--- a/docs/src/docs/components/card-list.mdx
+++ b/docs/src/docs/components/card-list.mdx
@@ -8,7 +8,7 @@ description: CardList Component
 - 표시할 양이 많은 정보를 묶어 표시할 때 사용합니다.
 - leftContent, rightContent에 요소를 추가 할 때는 `CardListContent` 로 감싸주세요.
 
-<Demo code={`import { FlexBox, CardList, Checkbox, CardListThumbnail, CardTitle, CardCaption, CardContent, Checkbox, CardListContent, ToggleIcon } from '@wanteddev/wds';
+<Demo code={`import { FlexBox, CardList, Checkbox, CardThumbnail, CardTitle, CardCaption, CardContent, Checkbox, CardListContent, ToggleIcon } from '@wanteddev/wds';
 import { IconBookmark, IconBookmarkFill } from '@wanteddev/wds-icon';
 import { useState } from 'react';
 
@@ -61,7 +61,7 @@ const Demo = () => {
             </CardListContent>
           }
         >
-          <CardListThumbnail
+          <CardThumbnail
             src="https://static.wanted.co.kr/images/company/79/elpzxpmgh94xesrf__1080_790.png"
             alt="Wanted Company Image"
             width="120px"
@@ -86,7 +86,7 @@ export default Demo;`}
 
 ```tsx
 <CardList>
-  <CardListThumbnail />
+  <CardThumbnail />
   <CardContent>
     <CardContentItem />
     <CardTitle />
@@ -145,7 +145,7 @@ export default Demo;`}
 
 ### Platform
 
-`platform`에 따라 `CardListThumbnail`의 크기, 제목 크기, 콘텐츠 간격이 달라요.
+`platform`에 따라 `CardThumbnail`의 크기, 제목 크기, 콘텐츠 간격이 달라요.
 
 <Demo code={`import { FlexBox, CardList, CardThumbnailSkeleton, CardTitle, CardCaption, CardContent, CardListContent } from '@wanteddev/wds';
 import { IconChevronRightTight } from '@wanteddev/wds-icon';

--- a/docs/src/docs/components/card.mdx
+++ b/docs/src/docs/components/card.mdx
@@ -78,10 +78,10 @@ export default Demo;`}
 <Card>
   <CardThumbnail />
   <CardContent>
-    <CardExtraContent/>
+    <CardContentItem />
     <CardTitle />
     <CardCaption />
-    <CardExtraContent />
+    <CardContentItem />
   </CardContent>
 </Card>
 ```
@@ -102,9 +102,9 @@ export default Demo;`}
 
 <PropsTable component="CardContent" />
 
-### CardExtraContent
+### CardContentItem
 
-<PropsTable component="CardExtraContent" />
+<PropsTable component="CardContentItem" />
 
 ### CardTitle
 
@@ -128,11 +128,11 @@ export default Demo;`}
 
 <PropsTable component="CardThumbnailSkeleton" />
 
-### CardExtraContentSkeleton
+### CardContentItemSkeleton
 
 `Skeleton`과 동일한 props를 사용해요.
 
-<PropsTable component="CardExtraContentSkeleton" />
+<PropsTable component="CardContentItemSkeleton" />
 
 ### CardTitleSkeleton
 
@@ -353,10 +353,10 @@ export default Demo;`}
 
 ### Top Content, Bottom Content
 
-- `CardExtraContent`의 `position`을 조정하여 top, bottom에 콘텐츠를 추가할 수 있어요.
+- `CardContentItem`의 `position`을 조정하여 top, bottom에 콘텐츠를 추가할 수 있어요.
 - 뱃지나 부가적인 내용을 추가할 때 사용해요.
 
-<Demo code={`import { FlexBox, Card, CardTitle, CardCaption, CardContent, CardExtraContent, ContentBadge, CardThumbnailSkeleton } from '@wanteddev/wds';
+<Demo code={`import { FlexBox, Card, CardTitle, CardCaption, CardContent, CardContentItem, ContentBadge, CardThumbnailSkeleton } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
@@ -364,11 +364,11 @@ const Demo = () => {
       <Card width="240px">
         <CardThumbnailSkeleton width="240px" />
         <CardContent>
-          <CardExtraContent position="top" variant="badge">
+          <CardContentItem position="top" variant="badge">
             {new Array(3).fill(0).map((_, i) => (
               <ContentBadge key={i} color="neutral">텍스트</ContentBadge>
             ))}
-          </CardExtraContent>
+          </CardContentItem>
           <CardTitle>제목</CardTitle>
           <CardCaption>캡션</CardCaption>
         </CardContent>
@@ -378,11 +378,11 @@ const Demo = () => {
         <CardContent>
           <CardTitle>제목</CardTitle>
           <CardCaption>캡션</CardCaption>
-          <CardExtraContent position="bottom" variant="badge">
+          <CardContentItem position="bottom" variant="badge">
             {new Array(3).fill(0).map((_, i) => (
               <ContentBadge key={i} color="neutral">텍스트</ContentBadge>
             ))}
-          </CardExtraContent>
+          </CardContentItem>
         </CardContent>
       </Card>
     </FlexBox>
@@ -396,7 +396,7 @@ export default Demo;`}
 
 Card의 형태에 따라 스켈레톤을 조합하여 사용해요.
 
-<Demo code={`import { Grid, GridItem, CardSkeleton, CardThumbnailSkeleton, CardContent, CardExtraContentSkeleton, CardExtraContent, CardTitleSkeleton, CardCaptionSkeleton } from '@wanteddev/wds';
+<Demo code={`import { Grid, GridItem, CardSkeleton, CardThumbnailSkeleton, CardContent, CardContentItemSkeleton, CardContentItem, CardTitleSkeleton, CardCaptionSkeleton } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
@@ -425,15 +425,15 @@ const Demo = () => {
         <CardSkeleton>
           <CardThumbnailSkeleton width="152px" />
           <CardContent>
-            <CardExtraContent position="top">
-              <CardExtraContentSkeleton />
-            </CardExtraContent>
+            <CardContentItem position="top">
+              <CardContentItemSkeleton />
+            </CardContentItem>
             <CardTitleSkeleton />
             <CardCaptionSkeleton type="extra"/>
             <CardCaptionSkeleton />
-            <CardExtraContent position="bottom">
-              <CardExtraContentSkeleton />
-            </CardExtraContent>
+            <CardContentItem position="bottom">
+              <CardContentItemSkeleton />
+            </CardContentItem>
           </CardContent>
         </CardSkeleton>
       </GridItem>
@@ -442,15 +442,15 @@ const Demo = () => {
         <CardSkeleton platform="mobile">
           <CardThumbnailSkeleton width="152px" />
           <CardContent>
-            <CardExtraContent position="top">
-              <CardExtraContentSkeleton />
-            </CardExtraContent>
+            <CardContentItem position="top">
+              <CardContentItemSkeleton />
+            </CardContentItem>
             <CardTitleSkeleton />
             <CardCaptionSkeleton type="extra"/>
             <CardCaptionSkeleton />
-            <CardExtraContent position="bottom">
-              <CardExtraContentSkeleton />
-            </CardExtraContent>
+            <CardContentItem position="bottom">
+              <CardContentItemSkeleton />
+            </CardContentItem>
           </CardContent>
         </CardSkeleton>
       </GridItem>

--- a/docs/src/docs/components/card.mdx
+++ b/docs/src/docs/components/card.mdx
@@ -410,6 +410,7 @@ const Demo = () => {
           </CardContent>
         </CardSkeleton>
       </GridItem>
+
       <GridItem columns={5}>
         <CardSkeleton platform="mobile">
           <CardThumbnailSkeleton width="152px" />
@@ -419,6 +420,7 @@ const Demo = () => {
           </CardContent>
         </CardSkeleton>
       </GridItem>
+
       <GridItem columns={7}>
         <CardSkeleton>
           <CardThumbnailSkeleton width="152px" />
@@ -435,6 +437,7 @@ const Demo = () => {
           </CardContent>
         </CardSkeleton>
       </GridItem>
+      
       <GridItem columns={5}>
         <CardSkeleton platform="mobile">
           <CardThumbnailSkeleton width="152px" />

--- a/docs/src/docs/components/card.mdx
+++ b/docs/src/docs/components/card.mdx
@@ -362,7 +362,7 @@ const Demo = () => {
   return (
     <FlexBox gap="24px" justifyContent="center">
       <Card width="240px">
-        <CardThumbnailSkeleton width="240px" />
+        <CardThumbnailSkeleton />
         <CardContent>
           <CardContentItem position="top" variant="badge">
             {new Array(3).fill(0).map((_, i) => (
@@ -374,7 +374,7 @@ const Demo = () => {
         </CardContent>
       </Card>
       <Card width="240px">
-        <CardThumbnailSkeleton width="152px" />
+        <CardThumbnailSkeleton />
         <CardContent>
           <CardTitle>제목</CardTitle>
           <CardCaption>캡션</CardCaption>
@@ -403,7 +403,7 @@ const Demo = () => {
     <Grid spacing={20} sx={{ maxWidth: '426px', margin: 'auto' }}>
       <GridItem columns={7}>
         <CardSkeleton>
-          <CardThumbnailSkeleton width="240px" />
+          <CardThumbnailSkeleton />
           <CardContent>
             <CardTitleSkeleton />
             <CardCaptionSkeleton />
@@ -413,7 +413,7 @@ const Demo = () => {
 
       <GridItem columns={5}>
         <CardSkeleton platform="mobile">
-          <CardThumbnailSkeleton width="152px" />
+          <CardThumbnailSkeleton />
           <CardContent>
             <CardTitleSkeleton />
             <CardCaptionSkeleton />
@@ -423,7 +423,7 @@ const Demo = () => {
 
       <GridItem columns={7}>
         <CardSkeleton>
-          <CardThumbnailSkeleton width="152px" />
+          <CardThumbnailSkeleton />
           <CardContent>
             <CardContentItem position="top">
               <CardContentItemSkeleton />
@@ -440,7 +440,7 @@ const Demo = () => {
       
       <GridItem columns={5}>
         <CardSkeleton platform="mobile">
-          <CardThumbnailSkeleton width="152px" />
+          <CardThumbnailSkeleton />
           <CardContent>
             <CardContentItem position="top">
               <CardContentItemSkeleton />

--- a/docs/src/docs/components/card.mdx
+++ b/docs/src/docs/components/card.mdx
@@ -6,14 +6,15 @@ description: Card Component
 # Card
 
 - 일반적인 상황에서 정보를 묶어 표시할 때 사용합니다.
-- leftContent, rightContent에 요소를 추가 할 때는 `CardThumbnailContent` 로 감싸주세요.
-  - Card와 leftContent, rightContent 모두 onClick 이벤트가 있는 경우, `e.stopPropagation()`과 `e.preventDefault()`를 추가하여 Card의 이벤트 전파를 막을 수 있습니다.
+- `CardThumbnail`의 leftContent, rightContent에 요소를 추가 할 때는 `CardThumbnailContent` 로 감싸 주세요.
+  - Card와 leftContent, rightContent에 onClick 이벤트가 있는 경우, `e.stopPropagation()`과 `e.preventDefault()`를 추가하여 이벤트 전파를 막을 수 있습니다.
 
-<Demo code={`import { ToggleIcon, Card, CardThumbnail, CardTitle, CardCaption, CardContent, CardThumbnailContent } from '@wanteddev/wds';
+<Demo code={`import { useToast, ToggleIcon, Card, CardThumbnail, CardTitle, CardCaption, CardContent, CardThumbnailContent } from '@wanteddev/wds';
 import { IconBookmark, IconBookmarkFill } from '@wanteddev/wds-icon';
 import { useState } from 'react';
 
 const Demo = () => {
+  const toast = useToast();
   const [isBookmarked, setIsBookmarked] = useState(false);
 
   return (
@@ -41,12 +42,11 @@ const Demo = () => {
               active={isBookmarked} 
               onActiveChange={setIsBookmarked} 
               activeColor="palette.primary.normal" 
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-
+              onClick={() => {
                 if (!isBookmarked) {
-                  alert('북마크에 저장되었습니다.');
+                  toast({ 
+                    content: '북마크에 저장되었습니다.',
+                  });
                 }
                 setIsBookmarked((prevIsBookmarked) => !prevIsBookmarked);
               }}

--- a/docs/src/docs/routes.ts
+++ b/docs/src/docs/routes.ts
@@ -56,6 +56,10 @@ export const routes: Array<Route> = [
         title: 'Card',
         slug: '/docs/components/card',
       },
+      {
+        title: 'CardList',
+        slug: '/docs/components/card-list',
+      },
       { title: 'Checkbox', slug: '/docs/components/checkbox' },
       { title: 'ChipAction', slug: '/docs/components/chip-action' },
       { title: 'ChipFilter', slug: '/docs/components/chip-filter' },

--- a/packages/wds/src/components/card-list/constants.ts
+++ b/packages/wds/src/components/card-list/constants.ts
@@ -1,0 +1,5 @@
+export const CARD_LIST_NAME = 'CardList';
+
+export const CARD_LIST_THUMBNAIL_NAME = 'CardListThumbnail';
+
+export const CARD_LIST_CONTENT_NAME = 'CardListContent';

--- a/packages/wds/src/components/card-list/constants.ts
+++ b/packages/wds/src/components/card-list/constants.ts
@@ -1,7 +1,5 @@
 export const CARD_LIST_NAME = 'CardList';
 
-export const CARD_LIST_THUMBNAIL_NAME = 'CardListThumbnail';
-
 export const CARD_LIST_CONTENT_NAME = 'CardListContent';
 
 export const CARD_LIST_SKELETON_NAME = 'CardListSkeleton';

--- a/packages/wds/src/components/card-list/constants.ts
+++ b/packages/wds/src/components/card-list/constants.ts
@@ -3,3 +3,5 @@ export const CARD_LIST_NAME = 'CardList';
 export const CARD_LIST_THUMBNAIL_NAME = 'CardListThumbnail';
 
 export const CARD_LIST_CONTENT_NAME = 'CardListContent';
+
+export const CARD_LIST_SKELETON_NAME = 'CardListSkeleton';

--- a/packages/wds/src/components/card-list/index.tsx
+++ b/packages/wds/src/components/card-list/index.tsx
@@ -12,6 +12,7 @@ import { Thumbnail } from '../thumbnail';
 import {
   CARD_LIST_CONTENT_NAME,
   CARD_LIST_NAME,
+  CARD_LIST_SKELETON_NAME,
   CARD_LIST_THUMBNAIL_NAME,
 } from './constants';
 import { cardListContentStyle, cardListStyle } from './style';
@@ -20,6 +21,7 @@ import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type {
   CardListContentProps,
   CardListProps,
+  CardListSkeletonProps,
   CardListThumbnailProps,
 } from './types';
 import type { ElementRef, ForwardedRef } from 'react';
@@ -121,4 +123,32 @@ const CardListContent = forwardRef(
 
 CardListContent.displayName = CARD_LIST_CONTENT_NAME;
 
-export { CardList, CardListThumbnail, CardListContent };
+const CardListSkeleton = forwardRef(
+  <E extends ElementType = 'div'>(
+    {
+      platform = 'desktop',
+      width,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      sx,
+      ...props
+    }: PolymorphicProps<CardListSkeletonProps, E>,
+    ref: ForwardedRef<ElementRef<E>>,
+  ) => {
+    return (
+      <FlexBox
+        ref={ref}
+        alignItems="center"
+        {...props}
+        sx={[cardListStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
+      />
+    );
+  },
+) as PolymorphicComponent<CardListSkeletonProps, 'div'>;
+
+CardListSkeleton.displayName = CARD_LIST_SKELETON_NAME;
+
+export { CardList, CardListThumbnail, CardListContent, CardListSkeleton };

--- a/packages/wds/src/components/card-list/index.tsx
+++ b/packages/wds/src/components/card-list/index.tsx
@@ -15,7 +15,11 @@ import {
   CARD_LIST_SKELETON_NAME,
   CARD_LIST_THUMBNAIL_NAME,
 } from './constants';
-import { cardListContentStyle, cardListStyle } from './style';
+import {
+  cardListContentStyle,
+  cardListSkeletonStyle,
+  cardListStyle,
+} from './style';
 
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type {
@@ -128,6 +132,8 @@ const CardListSkeleton = forwardRef(
     {
       platform = 'desktop',
       width,
+      hasLeftContent,
+      hasRightContent,
       xs,
       sm,
       md,
@@ -143,7 +149,20 @@ const CardListSkeleton = forwardRef(
         ref={ref}
         alignItems="center"
         {...props}
-        sx={[cardListStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
+        sx={[
+          cardListSkeletonStyle({
+            platform,
+            hasLeftContent,
+            hasRightContent,
+            width,
+            xs,
+            sm,
+            md,
+            lg,
+            xl,
+          }),
+          sx,
+        ]}
       />
     );
   },

--- a/packages/wds/src/components/card-list/index.tsx
+++ b/packages/wds/src/components/card-list/index.tsx
@@ -1,0 +1,124 @@
+import { forwardRef } from 'react';
+import {
+  Box,
+  type PolymorphicComponent,
+  type PolymorphicProps,
+} from '@wanteddev/wds-engine';
+import { composeEventHandlers } from '@radix-ui/primitive';
+
+import FlexBox from '../flex-box';
+import { Thumbnail } from '../thumbnail';
+
+import {
+  CARD_LIST_CONTENT_NAME,
+  CARD_LIST_NAME,
+  CARD_LIST_THUMBNAIL_NAME,
+} from './constants';
+import { cardListContentStyle, cardListStyle } from './style';
+
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+import type {
+  CardListContentProps,
+  CardListProps,
+  CardListThumbnailProps,
+} from './types';
+import type { ElementRef, ForwardedRef } from 'react';
+import type { ElementType } from 'react';
+
+const CardList = forwardRef(
+  <E extends ElementType = 'div'>(
+    {
+      platform = 'desktop',
+      width,
+      leftContent,
+      rightContent,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      sx,
+      children,
+      ...props
+    }: PolymorphicProps<CardListProps, E>,
+    ref: ForwardedRef<ElementRef<E>>,
+  ) => {
+    return (
+      <FlexBox
+        ref={ref}
+        alignItems="center"
+        {...props}
+        sx={[cardListStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
+      >
+        {Boolean(leftContent) && leftContent}
+        {children}
+        {Boolean(rightContent) && rightContent}
+      </FlexBox>
+    );
+  },
+) as PolymorphicComponent<CardListProps, 'div'>;
+
+CardList.displayName = CARD_LIST_NAME;
+
+const CardListThumbnail = forwardRef<HTMLDivElement, CardListThumbnailProps>(
+  ({ width, ...props }, ref) => {
+    return (
+      <Box ref={ref} wds-component="card-list-thumbnail" {...props}>
+        <Thumbnail width={width} radius border {...props} />
+      </Box>
+    );
+  },
+) as PolymorphicComponent<CardListThumbnailProps, 'div'>;
+
+CardListThumbnail.displayName = CARD_LIST_THUMBNAIL_NAME;
+
+const CardListContent = forwardRef(
+  (
+    {
+      variant = 'custom',
+      sx,
+      ...props
+    }: DefaultComponentProps<CardListContentProps, 'div'>,
+    ref: ForwardedRef<ElementRef<'div'>>,
+  ) => {
+    switch (variant) {
+      case 'checkbox':
+      case 'toggle-icon':
+        return (
+          <FlexBox
+            ref={ref}
+            justifyContent="center"
+            alignItems="center"
+            {...props}
+            sx={[cardListContentStyle, sx]}
+            onClick={composeEventHandlers(props.onClick, (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            })}
+          />
+        );
+      case 'icon':
+        return (
+          <FlexBox
+            ref={ref}
+            justifyContent="center"
+            alignItems="center"
+            {...props}
+            sx={(theme) => [
+              cardListContentStyle,
+              {
+                color: theme.palette.label.assistive,
+              },
+              sx,
+            ]}
+          />
+        );
+      case 'custom':
+        return <FlexBox ref={ref} {...props} sx={[cardListContentStyle, sx]} />;
+    }
+  },
+);
+
+CardListContent.displayName = CARD_LIST_CONTENT_NAME;
+
+export { CardList, CardListThumbnail, CardListContent };

--- a/packages/wds/src/components/card-list/index.tsx
+++ b/packages/wds/src/components/card-list/index.tsx
@@ -1,19 +1,16 @@
 import { forwardRef } from 'react';
 import {
-  Box,
   type PolymorphicComponent,
   type PolymorphicProps,
 } from '@wanteddev/wds-engine';
 import { composeEventHandlers } from '@radix-ui/primitive';
 
 import FlexBox from '../flex-box';
-import { Thumbnail } from '../thumbnail';
 
 import {
   CARD_LIST_CONTENT_NAME,
   CARD_LIST_NAME,
   CARD_LIST_SKELETON_NAME,
-  CARD_LIST_THUMBNAIL_NAME,
 } from './constants';
 import {
   cardListContentStyle,
@@ -26,7 +23,6 @@ import type {
   CardListContentProps,
   CardListProps,
   CardListSkeletonProps,
-  CardListThumbnailProps,
 } from './types';
 import type { ElementRef, ForwardedRef } from 'react';
 import type { ElementType } from 'react';
@@ -65,18 +61,6 @@ const CardList = forwardRef(
 ) as PolymorphicComponent<CardListProps, 'div'>;
 
 CardList.displayName = CARD_LIST_NAME;
-
-const CardListThumbnail = forwardRef<HTMLDivElement, CardListThumbnailProps>(
-  ({ width, ...props }, ref) => {
-    return (
-      <Box ref={ref} wds-component="card-list-thumbnail" {...props}>
-        <Thumbnail width={width} radius border {...props} />
-      </Box>
-    );
-  },
-) as PolymorphicComponent<CardListThumbnailProps, 'div'>;
-
-CardListThumbnail.displayName = CARD_LIST_THUMBNAIL_NAME;
 
 const CardListContent = forwardRef(
   (
@@ -170,4 +154,4 @@ const CardListSkeleton = forwardRef(
 
 CardListSkeleton.displayName = CARD_LIST_SKELETON_NAME;
 
-export { CardList, CardListThumbnail, CardListContent, CardListSkeleton };
+export { CardList, CardListContent, CardListSkeleton };

--- a/packages/wds/src/components/card-list/style.ts
+++ b/packages/wds/src/components/card-list/style.ts
@@ -70,7 +70,10 @@ export const cardListStyle =
       theme,
     )(
       (params) => css`
-        width: ${params?.width};
+        ${params?.width !== undefined &&
+        css`
+          width: ${params.width};
+        `}
         ${cardListPlatformStyle({ platform: params?.platform })}
         ${params?.sx}
       `,
@@ -144,6 +147,7 @@ export const cardListSkeletonStyle =
   (theme: Theme) => css`
     width: ${width ?? '100%'};
     max-width: 100%;
+
     ${cardListSkeletonPlatformStyle({
       platform,
       hasLeftContent,
@@ -160,8 +164,15 @@ export const cardListSkeletonStyle =
       theme,
     )(
       (params) => css`
-        width: ${params?.width};
-        ${cardListPlatformStyle({ platform: params?.platform })}
+        ${params?.width !== undefined &&
+        css`
+          width: ${params.width};
+        `}
+        ${cardListSkeletonPlatformStyle({
+          platform: params?.platform,
+          hasLeftContent,
+          hasRightContent,
+        })}
         ${params?.sx}
       `,
     )}

--- a/packages/wds/src/components/card-list/style.ts
+++ b/packages/wds/src/components/card-list/style.ts
@@ -154,15 +154,6 @@ export const cardListSkeletonStyle =
     [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
       aspect-ratio: 3 / 2;
     }
-    // skeleton
-    /* [wds-component='card-caption-skeleton'] {
-      &[data-type='extra'] {
-        width: 50%;
-      }
-      &[data-type='normal'] {
-        width: 25%;
-      }
-    } */
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },

--- a/packages/wds/src/components/card-list/style.ts
+++ b/packages/wds/src/components/card-list/style.ts
@@ -1,0 +1,83 @@
+import { css } from '@wanteddev/wds-engine';
+
+import {
+  createResponsiveStyle,
+  ellipsisTypographyStyle,
+  typographyStyle,
+} from '../..';
+
+import type { Theme } from '@wanteddev/wds-engine';
+import type { CardProps } from '../card/types';
+
+const cardListPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
+  switch (platform) {
+    case 'desktop':
+      return css`
+        gap: 16px;
+
+        // thumbnail
+        [wds-component='thumbnail'],
+        [wds-component='thumbnail-skeleton'] {
+          width: 120px;
+        }
+        // text
+        [wds-component='card-title'] {
+          ${typographyStyle('body1_normal', 'bold')}
+        }
+        [wds-component='card-caption'] {
+          ${typographyStyle('label2', 'medium')}
+        }
+      `;
+    case 'mobile':
+      return css`
+        gap: 12px;
+
+        // thumbnail
+        [wds-component='thumbnail'],
+        [wds-component='thumbnail-skeleton'] {
+          width: 96px;
+        }
+        // text
+        [wds-component='card-title'] {
+          ${typographyStyle('body2_normal', 'bold')}
+        }
+      `;
+  }
+};
+
+export const cardListStyle =
+  ({ xs, sm, md, lg, xl, width, platform }: CardProps) =>
+  (theme: Theme) => css`
+    width: ${width ?? '100%'};
+    max-width: 100%;
+    ${cardListPlatformStyle({ platform })}
+
+    // thumbnail
+    [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
+      aspect-ratio: 3 / 2;
+    }
+    // text
+    [wds-component='card-title'] {
+      ${ellipsisTypographyStyle(1)}
+    }
+    [wds-component='card-caption'] {
+      ${ellipsisTypographyStyle(1)}
+    }
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        width: ${params?.width};
+        ${cardListPlatformStyle({ platform: params?.platform })}
+        ${params?.sx}
+      `,
+    )}
+  `;
+
+export const cardListContentStyle = css`
+  width: 24px;
+  height: 24px;
+  font-size: 24px;
+`;

--- a/packages/wds/src/components/card-list/style.ts
+++ b/packages/wds/src/components/card-list/style.ts
@@ -6,6 +6,7 @@ import {
   typographyStyle,
 } from '../..';
 
+import type { CardListSkeletonProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';
 import type { CardProps } from '../card/types';
 
@@ -81,3 +82,111 @@ export const cardListContentStyle = css`
   height: 24px;
   font-size: 24px;
 `;
+
+const cardListSkeletonPlatformStyle = ({
+  platform,
+  hasLeftContent,
+  hasRightContent,
+}: Pick<
+  CardListSkeletonProps,
+  'platform' | 'hasLeftContent' | 'hasRightContent'
+>) => {
+  switch (platform) {
+    case 'desktop':
+      return css`
+        gap: 16px;
+        padding-left: ${hasLeftContent ? '40px' : '0'};
+        padding-right: ${hasRightContent ? '40px' : '0'};
+        // thumbnail
+        [wds-component='thumbnail'],
+        [wds-component='thumbnail-skeleton'] {
+          width: 120px;
+        }
+        // skeleton
+        [wds-component='card-title-skeleton'] {
+          width: 75%;
+          height: 24px;
+        }
+        [wds-component='card-caption-skeleton'] {
+          &[data-type='extra'] {
+            width: 50%;
+            height: 18px;
+          }
+          &[data-type='normal'] {
+            width: 25%;
+            height: 18px;
+          }
+        }
+      `;
+    case 'mobile':
+      return css`
+        gap: 12px;
+        padding-left: ${hasLeftContent ? '36px' : '0'};
+        padding-right: ${hasRightContent ? '36px' : '0'};
+        // thumbnail
+        [wds-component='thumbnail'],
+        [wds-component='thumbnail-skeleton'] {
+          width: 96px;
+        }
+        // skeleton
+        [wds-component='card-title-skeleton'] {
+          width: 75%;
+          height: 22px;
+        }
+      `;
+  }
+};
+
+export const cardListSkeletonStyle =
+  ({
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+    width,
+    platform,
+    hasLeftContent,
+    hasRightContent,
+  }: CardListSkeletonProps) =>
+  (theme: Theme) => css`
+    width: ${width ?? '100%'};
+    max-width: 100%;
+    ${cardListSkeletonPlatformStyle({
+      platform,
+      hasLeftContent,
+      hasRightContent,
+    })}
+
+    // thumbnail
+    [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
+      aspect-ratio: 3 / 2;
+    }
+    // skeleton
+    [wds-component='card-content-item-skeleton'] {
+      max-width: 48px;
+      width: 100%;
+      height: 20px;
+    }
+    [wds-component='card-caption-skeleton'] {
+      &[data-type='extra'] {
+        width: 50%;
+        height: 18px;
+      }
+      &[data-type='normal'] {
+        width: 25%;
+        height: 18px;
+      }
+    }
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        width: ${params?.width};
+        ${cardListPlatformStyle({ platform: params?.platform })}
+        ${params?.sx}
+      `,
+    )}
+  `;

--- a/packages/wds/src/components/card-list/style.ts
+++ b/packages/wds/src/components/card-list/style.ts
@@ -97,6 +97,7 @@ const cardListSkeletonPlatformStyle = ({
         gap: 16px;
         padding-left: ${hasLeftContent ? '40px' : '0'};
         padding-right: ${hasRightContent ? '40px' : '0'};
+
         // thumbnail
         [wds-component='thumbnail'],
         [wds-component='thumbnail-skeleton'] {
@@ -107,22 +108,13 @@ const cardListSkeletonPlatformStyle = ({
           width: 75%;
           height: 24px;
         }
-        [wds-component='card-caption-skeleton'] {
-          &[data-type='extra'] {
-            width: 50%;
-            height: 18px;
-          }
-          &[data-type='normal'] {
-            width: 25%;
-            height: 18px;
-          }
-        }
       `;
     case 'mobile':
       return css`
         gap: 12px;
         padding-left: ${hasLeftContent ? '36px' : '0'};
         padding-right: ${hasRightContent ? '36px' : '0'};
+
         // thumbnail
         [wds-component='thumbnail'],
         [wds-component='thumbnail-skeleton'] {
@@ -163,21 +155,14 @@ export const cardListSkeletonStyle =
       aspect-ratio: 3 / 2;
     }
     // skeleton
-    [wds-component='card-content-item-skeleton'] {
-      max-width: 48px;
-      width: 100%;
-      height: 20px;
-    }
-    [wds-component='card-caption-skeleton'] {
+    /* [wds-component='card-caption-skeleton'] {
       &[data-type='extra'] {
         width: 50%;
-        height: 18px;
       }
       &[data-type='normal'] {
         width: 25%;
-        height: 18px;
       }
-    }
+    } */
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },

--- a/packages/wds/src/components/card-list/types.ts
+++ b/packages/wds/src/components/card-list/types.ts
@@ -1,0 +1,21 @@
+import type { FlexBoxProps } from '../flex-box/types';
+import type { Merge } from '@wanteddev/wds-engine';
+import type { ReactNode } from 'react';
+import type { CardDefaultProps, CardThumbnailBasicProps } from '../card/types';
+
+type CardListDefaultProps = {
+  leftContent?: ReactNode;
+  rightContent?: ReactNode;
+};
+export type CardListProps = Merge<CardDefaultProps, CardListDefaultProps>;
+
+export type CardListThumbnailProps = CardThumbnailBasicProps &
+  CardListDefaultProps;
+
+type CardListContentDefaultProps = {
+  variant?: 'checkbox' | 'icon' | 'toggle-icon' | 'custom';
+};
+export type CardListContentProps = Merge<
+  CardListContentDefaultProps,
+  FlexBoxProps
+>;

--- a/packages/wds/src/components/card-list/types.ts
+++ b/packages/wds/src/components/card-list/types.ts
@@ -19,3 +19,5 @@ export type CardListContentProps = Merge<
   CardListContentDefaultProps,
   FlexBoxProps
 >;
+
+export type CardListSkeletonProps = Merge<CardDefaultProps, FlexBoxProps>;

--- a/packages/wds/src/components/card-list/types.ts
+++ b/packages/wds/src/components/card-list/types.ts
@@ -1,7 +1,11 @@
 import type { FlexBoxProps } from '../flex-box/types';
 import type { Merge } from '@wanteddev/wds-engine';
 import type { ReactNode } from 'react';
-import type { CardDefaultProps, CardThumbnailBasicProps } from '../card/types';
+import type {
+  CardDefaultProps,
+  CardProps,
+  CardThumbnailBasicProps,
+} from '../card/types';
 
 type CardListDefaultProps = {
   leftContent?: ReactNode;
@@ -20,4 +24,11 @@ export type CardListContentProps = Merge<
   FlexBoxProps
 >;
 
-export type CardListSkeletonProps = Merge<CardDefaultProps, FlexBoxProps>;
+export type CardListSkeletonDefaultProps = {
+  hasLeftContent?: boolean;
+  hasRightContent?: boolean;
+};
+export type CardListSkeletonProps = Merge<
+  CardListSkeletonDefaultProps,
+  CardProps
+>;

--- a/packages/wds/src/components/card/constants.ts
+++ b/packages/wds/src/components/card/constants.ts
@@ -4,7 +4,7 @@ export const CARD_THUMBNAIL_NAME = 'CardThumbnail';
 export const CARD_THUMBNAIL_CONTENT_NAME = 'CardThumbnailContent';
 
 export const CARD_CONTENT_NAME = 'CardContent';
-export const CARD_EXTRA_CONTENT_NAME = 'CardExtraContent';
+export const CARD_CONTENT_ITEM_NAME = 'CardContentItem';
 export const CARD_TITLE_NAME = 'CardTitle';
 export const CARD_CAPTION_NAME = 'CardCaption';
 
@@ -12,6 +12,6 @@ export const CARD_SKELETON_NAME = 'CardSkeleton';
 
 export const CARD_THUMBNAIL_SKELETON_NAME = 'CardThumbnailSkeleton';
 
-export const CARD_EXTRA_CONTENT_SKELETON_NAME = 'CardExtraContentSkeleton';
+export const CARD_CONTENT_ITEM_SKELETON_NAME = 'CardContentItemSkeleton';
 export const CARD_TITLE_SKELETON_NAME = 'CardTitleSkeleton';
 export const CARD_CAPTION_SKELETON_NAME = 'CardCaptionSkeleton';

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -323,14 +323,12 @@ const CardCaptionSkeleton = forwardRef(
   (
     {
       type = 'normal',
+      width = type === 'normal' ? '25%' : '50%',
       height = '18px',
       ...props
     }: DefaultComponentProps<CardCaptionSkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
-    const width: CardCaptionSkeletonProps['width'] =
-      props.width ?? type === 'normal' ? '25%' : '50%';
-
     return (
       <Skeleton
         ref={ref}

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -4,6 +4,7 @@ import {
   type DefaultComponentProps,
   type PolymorphicProps,
 } from '@wanteddev/wds-engine';
+import { composeEventHandlers } from '@radix-ui/primitive';
 
 import FlexBox from '../flex-box';
 import Typography from '../typography';
@@ -34,13 +35,13 @@ import {
   cardThumbnailStyle,
 } from './style';
 
+import type { FlexBoxProps } from '../flex-box/types';
 import type { TypographyProps } from '../typography/types';
 import type { SkeletonProps } from '../skeleton/types';
 import type { ThumbnailSkeletonProps } from '../thumbnail/types';
 import type { PolymorphicComponent } from '@wanteddev/wds-engine';
 import type {
   CardCaptionSkeletonProps,
-  CardContentProps,
   CardExtraContentProps,
   CardProps,
   CardThumbnailContentProps,
@@ -145,6 +146,10 @@ const CardThumbnailContent = forwardRef(
             as="span"
             data-role="card-thumbnail-content-toggle-icon"
             {...props}
+            onClick={composeEventHandlers(props.onClick, (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            })}
             sx={[cardThumbnailContentToggleIconStyle, sx]}
           />
         );
@@ -159,7 +164,7 @@ CardThumbnailContent.displayName = CARD_THUMBNAIL_CONTENT_NAME;
 
 const CardContent = forwardRef(
   (
-    props: DefaultComponentProps<CardContentProps, 'div'>,
+    { sx, ...props }: DefaultComponentProps<FlexBoxProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
     return (
@@ -167,8 +172,10 @@ const CardContent = forwardRef(
         wds-component="card-content"
         ref={ref}
         flexDirection="column"
+        flex="1"
         gap="4px"
         {...props}
+        sx={[{ overflow: 'hidden' }, sx]}
       />
     );
   },
@@ -225,6 +232,7 @@ const CardCaption = forwardRef(
     return (
       <Typography
         ref={ref}
+        wds-component="card-caption"
         variant="label2"
         weight="medium"
         color="palette.label.alternative"

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -14,9 +14,9 @@ import Skeleton from '../skeleton';
 import {
   CARD_CAPTION_NAME,
   CARD_CAPTION_SKELETON_NAME,
+  CARD_CONTENT_ITEM_NAME,
+  CARD_CONTENT_ITEM_SKELETON_NAME,
   CARD_CONTENT_NAME,
-  CARD_EXTRA_CONTENT_NAME,
-  CARD_EXTRA_CONTENT_SKELETON_NAME,
   CARD_NAME,
   CARD_SKELETON_NAME,
   CARD_THUMBNAIL_CONTENT_NAME,
@@ -26,7 +26,7 @@ import {
   CARD_TITLE_SKELETON_NAME,
 } from './constants';
 import {
-  cardExtraContentStyle,
+  cardContentItemStyle,
   cardStyle,
   cardThumbnailContentTextStyle,
   cardThumbnailContentToggleIconStyle,
@@ -42,7 +42,7 @@ import type { ThumbnailSkeletonProps } from '../thumbnail/types';
 import type { PolymorphicComponent } from '@wanteddev/wds-engine';
 import type {
   CardCaptionSkeletonProps,
-  CardExtraContentProps,
+  CardContentItemProps,
   CardProps,
   CardThumbnailContentProps,
   CardThumbnailProps,
@@ -183,27 +183,28 @@ const CardContent = forwardRef(
 
 CardContent.displayName = CARD_CONTENT_NAME;
 
-const CardExtraContent = forwardRef(
+const CardContentItem = forwardRef(
   (
     {
       sx,
       position,
       variant,
       ...props
-    }: DefaultComponentProps<CardExtraContentProps, 'div'>,
+    }: DefaultComponentProps<CardContentItemProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
     return (
       <FlexBox
         ref={ref}
+        wds-component="card-content-item"
         {...props}
-        sx={[cardExtraContentStyle({ position, variant }), sx]}
+        sx={[cardContentItemStyle({ position, variant }), sx]}
       />
     );
   },
 );
 
-CardExtraContent.displayName = CARD_EXTRA_CONTENT_NAME;
+CardContentItem.displayName = CARD_CONTENT_ITEM_NAME;
 
 const CardTitle = forwardRef(
   <E extends ElementType = 'span'>(
@@ -259,7 +260,7 @@ const CardThumbnailSkeleton = forwardRef(
 
 CardThumbnailSkeleton.displayName = CARD_THUMBNAIL_SKELETON_NAME;
 
-const CardExtraContentSkeleton = forwardRef(
+const CardContentItemSkeleton = forwardRef(
   (
     props: DefaultComponentProps<SkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
@@ -267,6 +268,7 @@ const CardExtraContentSkeleton = forwardRef(
     return (
       <Skeleton
         ref={ref}
+        wds-component="card-content-item-skeleton"
         variant="rectangle"
         radius="3px"
         width="48px"
@@ -277,14 +279,22 @@ const CardExtraContentSkeleton = forwardRef(
   },
 );
 
-CardExtraContentSkeleton.displayName = CARD_EXTRA_CONTENT_SKELETON_NAME;
+CardContentItemSkeleton.displayName = CARD_CONTENT_ITEM_SKELETON_NAME;
 
 const CardTitleSkeleton = forwardRef(
   (
     props: DefaultComponentProps<SkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
-    return <Skeleton ref={ref} width="100%" height="24px" {...props} />;
+    return (
+      <Skeleton
+        ref={ref}
+        wds-component="card-title-skeleton"
+        width="100%"
+        height="24px"
+        {...props}
+      />
+    );
   },
 );
 
@@ -301,6 +311,7 @@ const CardCaptionSkeleton = forwardRef(
     return (
       <Skeleton
         ref={ref}
+        wds-component="card-caption-skeleton"
         width={type === 'extra' ? '114px' : '57px'}
         height={type === 'extra' ? '18px' : '16px'}
         {...props}
@@ -318,10 +329,10 @@ export {
   CardContent,
   CardTitle,
   CardCaption,
-  CardExtraContent,
+  CardContentItem,
   CardSkeleton,
   CardThumbnailSkeleton,
-  CardExtraContentSkeleton,
+  CardContentItemSkeleton,
   CardTitleSkeleton,
   CardCaptionSkeleton,
 };

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -27,6 +27,7 @@ import {
 } from './constants';
 import {
   cardContentItemStyle,
+  cardSkeletonStyle,
   cardStyle,
   cardThumbnailContentTextStyle,
   cardThumbnailContentToggleIconStyle,
@@ -245,7 +246,32 @@ const CardCaption = forwardRef(
 
 CardCaption.displayName = CARD_CAPTION_NAME;
 
-const CardSkeleton = Card;
+const CardSkeleton = forwardRef(
+  <E extends ElementType = 'div'>(
+    {
+      platform = 'desktop',
+      width,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      sx,
+      ...props
+    }: PolymorphicProps<CardProps, E>,
+    ref: ForwardedRef<ElementRef<E>>,
+  ) => {
+    return (
+      <FlexBox
+        ref={ref}
+        flexDirection="column"
+        gap="12px"
+        {...props}
+        sx={[cardSkeletonStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
+      />
+    );
+  },
+) as PolymorphicComponent<CardProps, 'div'>;
 
 CardSkeleton.displayName = CARD_SKELETON_NAME;
 
@@ -270,9 +296,7 @@ const CardContentItemSkeleton = forwardRef(
         ref={ref}
         wds-component="card-content-item-skeleton"
         variant="rectangle"
-        radius="3px"
-        width="48px"
-        height="20px"
+        radius="3px" // TODO: list도 같은지 확인
         {...props}
       />
     );
@@ -287,13 +311,7 @@ const CardTitleSkeleton = forwardRef(
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
     return (
-      <Skeleton
-        ref={ref}
-        wds-component="card-title-skeleton"
-        width="100%"
-        height="24px"
-        {...props}
-      />
+      <Skeleton ref={ref} wds-component="card-title-skeleton" {...props} />
     );
   },
 );
@@ -311,9 +329,8 @@ const CardCaptionSkeleton = forwardRef(
     return (
       <Skeleton
         ref={ref}
+        data-type={type}
         wds-component="card-caption-skeleton"
-        width={type === 'extra' ? '114px' : '57px'}
-        height={type === 'extra' ? '18px' : '16px'}
         {...props}
       />
     );

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -86,12 +86,7 @@ const CardThumbnail = forwardRef<HTMLDivElement, CardThumbnailProps>(
     const hasContent = hasLeftContent || hasRightContent;
 
     return (
-      <Box
-        ref={ref}
-        wds-component="card-thumbnail"
-        {...props}
-        sx={[cardThumbnailStyle, sx]}
-      >
+      <Box ref={ref} {...props} sx={[cardThumbnailStyle, sx]}>
         {overlay && (
           <Box
             data-role="card-thumbnail-overlay"

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -288,7 +288,11 @@ CardThumbnailSkeleton.displayName = CARD_THUMBNAIL_SKELETON_NAME;
 
 const CardContentItemSkeleton = forwardRef(
   (
-    props: DefaultComponentProps<SkeletonProps, 'div'>,
+    {
+      width = '48px',
+      height = '20px',
+      ...props
+    }: DefaultComponentProps<SkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
     return (
@@ -296,7 +300,9 @@ const CardContentItemSkeleton = forwardRef(
         ref={ref}
         wds-component="card-content-item-skeleton"
         variant="rectangle"
-        radius="3px" // TODO: list도 같은지 확인
+        radius="3px"
+        width={width}
+        height={height}
         {...props}
       />
     );
@@ -322,15 +328,21 @@ const CardCaptionSkeleton = forwardRef(
   (
     {
       type = 'normal',
+      height = '18px',
       ...props
     }: DefaultComponentProps<CardCaptionSkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
+    const width: CardCaptionSkeletonProps['width'] =
+      props.width ?? type === 'normal' ? '25%' : '50%';
+
     return (
       <Skeleton
         ref={ref}
         data-type={type}
         wds-component="card-caption-skeleton"
+        width={width}
+        height={height}
         {...props}
       />
     );

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -226,21 +226,6 @@ export const cardSkeletonStyle =
     [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
       width: 100%;
     }
-    // skeleton
-    /* [wds-component='card-content-item-skeleton'] {
-      width: 48px;
-      height: 20px;
-    }
-    [wds-component='card-caption-skeleton'] {
-      &[data-type='extra'] {
-        width: 50%;
-        height: 18px;
-      }
-      &[data-type='normal'] {
-        width: 25%;
-        height: 18px;
-      }
-    } */
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -8,7 +8,7 @@ import {
 } from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
-import type { CardExtraContentProps, CardProps } from './types';
+import type { CardContentItemProps, CardProps } from './types';
 
 const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
   switch (platform) {
@@ -154,10 +154,10 @@ export const cardThumbnailOverlayStyle = (theme: Theme) => css`
   z-index: var(--wds-card-thumbnail-overlay-z-index);
 `;
 
-export const cardExtraContentStyle = ({
+export const cardContentItemStyle = ({
   variant,
   position,
-}: Pick<CardExtraContentProps, 'position' | 'variant'>) => css`
+}: Pick<CardContentItemProps, 'position' | 'variant'>) => css`
   gap: ${variant === 'badge' ? '6px' : 0};
 
   ${(() => {

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -233,7 +233,7 @@ export const cardSkeletonStyle =
     )(
       (params) => css`
         width: ${params?.width};
-        ${cardPlatformStyle({ platform: params?.platform })}
+        ${cardSkeletonPlatformStyle({ platform: params?.platform })}
         ${params?.sx}
       `,
     )}

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -113,7 +113,10 @@ export const cardStyle =
       theme,
     )(
       (params) => css`
-        width: ${params?.width};
+        ${params?.width !== undefined &&
+        css`
+          width: ${params.width};
+        `}
         ${cardPlatformStyle({ platform: params?.platform })}
         ${params?.sx}
       `,
@@ -232,7 +235,10 @@ export const cardSkeletonStyle =
       theme,
     )(
       (params) => css`
-        width: ${params?.width};
+        ${params?.width !== undefined &&
+        css`
+          width: ${params.width};
+        `}
         ${cardSkeletonPlatformStyle({ platform: params?.platform })}
         ${params?.sx}
       `,

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -173,3 +173,102 @@ export const cardContentItemStyle = ({
     }
   })()};
 `;
+
+const cardSkeletonPlatformStyle = ({
+  platform,
+}: Pick<CardProps, 'platform'>) => {
+  switch (platform) {
+    case 'desktop':
+      return css`
+        // thumbnail
+        [wds-component='thumbnail'],
+        [wds-component='thumbnail-skeleton'] {
+          width: 100%;
+          aspect-ratio: 3 / 2;
+        }
+
+        // content
+        [wds-component='card-content'] {
+          padding: 0 6px;
+        }
+        // skeleton
+        [wds-component='card-title-skeleton'] {
+          width: 100%;
+          height: 24px;
+        }
+        [wds-component='card-caption-skeleton'] {
+          &[data-type='extra'] {
+            max-width: 114px;
+            width: 100%;
+            height: 18px;
+          }
+          &[data-type='normal'] {
+            max-width: 57px;
+            width: 100%;
+            height: 18px;
+          }
+        }
+      `;
+
+    case 'mobile':
+      return css`
+        // thumbnail
+        [wds-component='thumbnail'],
+        [wds-component='thumbnail-skeleton'] {
+          width: 100%;
+          aspect-ratio: 4 / 3;
+        }
+
+        // content
+        [wds-component='card-content'] {
+          padding: 0;
+        }
+        // skeleton
+        [wds-component='card-title-skeleton'] {
+          width: 100%;
+          height: 22px;
+        }
+        [wds-component='card-caption-skeleton'] {
+          &[data-type='extra'] {
+            max-width: 76px;
+            width: 100%;
+            height: 18px;
+          }
+          &[data-type='normal'] {
+            max-width: 38px;
+            width: 100%;
+            height: 18px;
+          }
+        }
+      `;
+  }
+};
+
+export const cardSkeletonStyle =
+  ({ xs, sm, md, lg, xl, width, platform }: CardProps) =>
+  (theme: Theme) => css`
+    width: ${width ?? '100%'};
+    ${cardSkeletonPlatformStyle({ platform })}
+
+    // thumbnail
+    [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
+      width: 100%;
+    }
+    // skeleton
+    [wds-component='card-content-item-skeleton'] {
+      max-width: 48px;
+      width: 100%;
+      height: 20px;
+    }
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        width: ${params?.width};
+        ${cardPlatformStyle({ platform: params?.platform })}
+        ${params?.sx}
+      `,
+    )}
+  `;

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -1,13 +1,16 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle, gradient, typographyStyle } from '../../utils';
+import {
+  createResponsiveStyle,
+  ellipsisTypographyStyle,
+  gradient,
+  typographyStyle,
+} from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { CardExtraContentProps, CardProps } from './types';
 
-export const cardPlatformStyle = ({
-  platform,
-}: Pick<CardProps, 'platform'>) => {
+const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
   switch (platform) {
     case 'desktop':
       return css`
@@ -94,6 +97,18 @@ export const cardStyle =
 
     width: ${width ?? '100%'};
     ${cardPlatformStyle({ platform })}
+
+    // thumbnail
+    [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
+      width: 100%;
+    }
+    // text
+    [wds-component='card-title'] {
+      ${ellipsisTypographyStyle(2)}
+    }
+    [wds-component='card-caption'] {
+      ${ellipsisTypographyStyle()}
+    }
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -37,7 +37,6 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
             font-size: 24px;
           }
         }
-
         // content
         [wds-component='card-content'] {
           padding: 0 6px;
@@ -76,7 +75,6 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
             font-size: 20px;
           }
         }
-
         // content
         [wds-component='card-content'] {
           padding: 0;
@@ -186,7 +184,6 @@ const cardSkeletonPlatformStyle = ({
           width: 100%;
           aspect-ratio: 3 / 2;
         }
-
         // content
         [wds-component='card-content'] {
           padding: 0 6px;
@@ -195,18 +192,6 @@ const cardSkeletonPlatformStyle = ({
         [wds-component='card-title-skeleton'] {
           width: 100%;
           height: 24px;
-        }
-        [wds-component='card-caption-skeleton'] {
-          &[data-type='extra'] {
-            max-width: 114px;
-            width: 100%;
-            height: 18px;
-          }
-          &[data-type='normal'] {
-            max-width: 57px;
-            width: 100%;
-            height: 18px;
-          }
         }
       `;
 
@@ -218,7 +203,6 @@ const cardSkeletonPlatformStyle = ({
           width: 100%;
           aspect-ratio: 4 / 3;
         }
-
         // content
         [wds-component='card-content'] {
           padding: 0;
@@ -227,18 +211,6 @@ const cardSkeletonPlatformStyle = ({
         [wds-component='card-title-skeleton'] {
           width: 100%;
           height: 22px;
-        }
-        [wds-component='card-caption-skeleton'] {
-          &[data-type='extra'] {
-            max-width: 76px;
-            width: 100%;
-            height: 18px;
-          }
-          &[data-type='normal'] {
-            max-width: 38px;
-            width: 100%;
-            height: 18px;
-          }
         }
       `;
   }
@@ -255,11 +227,20 @@ export const cardSkeletonStyle =
       width: 100%;
     }
     // skeleton
-    [wds-component='card-content-item-skeleton'] {
-      max-width: 48px;
-      width: 100%;
+    /* [wds-component='card-content-item-skeleton'] {
+      width: 48px;
       height: 20px;
     }
+    [wds-component='card-caption-skeleton'] {
+      &[data-type='extra'] {
+        width: 50%;
+        height: 18px;
+      }
+      &[data-type='normal'] {
+        width: 25%;
+        height: 18px;
+      }
+    } */
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },

--- a/packages/wds/src/components/card/types.ts
+++ b/packages/wds/src/components/card/types.ts
@@ -15,7 +15,7 @@ export type CardProps = Merge<
   FlexBoxProps
 >;
 
-type CardThumbnailBasicProps = Merge<
+export type CardThumbnailBasicProps = Merge<
   Omit<ThumbnailDefaultProps, 'border' | 'radius'>,
   ComponentPropsWithoutRef<typeof ImageLoader>
 >;
@@ -36,7 +36,6 @@ export type CardThumbnailContentProps = Merge<
   FlexBoxProps
 >;
 
-export type CardContentProps = FlexBoxProps;
 export type CardExtraContentDefaultProps = {
   variant?: 'badge' | 'custom';
   position?: 'top' | 'bottom';

--- a/packages/wds/src/components/card/types.ts
+++ b/packages/wds/src/components/card/types.ts
@@ -36,12 +36,12 @@ export type CardThumbnailContentProps = Merge<
   FlexBoxProps
 >;
 
-export type CardExtraContentDefaultProps = {
+export type CardContentItemDefaultProps = {
   variant?: 'badge' | 'custom';
   position?: 'top' | 'bottom';
 };
-export type CardExtraContentProps = Merge<
-  CardExtraContentDefaultProps,
+export type CardContentItemProps = Merge<
+  CardContentItemDefaultProps,
   FlexBoxProps
 >;
 

--- a/packages/wds/src/components/empty-state/index.tsx
+++ b/packages/wds/src/components/empty-state/index.tsx
@@ -129,12 +129,13 @@ const EmptyStateText = forwardRef(
 EmptyStateText.displayName = EMPTY_STATE_TEXT_NAME;
 
 const EmptyStateButton = forwardRef(
-  (
-    props: DefaultComponentProps<ButtonProps, 'button'>,
-    ref: ForwardedRef<HTMLButtonElement>,
+  <E extends ElementType = 'button'>(
+    { as, ...props }: PolymorphicProps<ButtonProps, E>,
+    ref: ForwardedRef<ElementRef<E>>,
   ) => {
     return (
       <Button
+        as={(as || 'button') as ElementType}
         ref={ref}
         wds-component="empty-state-button"
         variant="outlined"
@@ -143,7 +144,7 @@ const EmptyStateButton = forwardRef(
       />
     );
   },
-);
+) as PolymorphicComponent<ButtonProps, 'button'>;
 
 EmptyStateButton.displayName = EMPTY_STATE_BUTTON_NAME;
 

--- a/packages/wds/src/components/index.ts
+++ b/packages/wds/src/components/index.ts
@@ -6,6 +6,7 @@ export { default as AvatarGroup } from './avatar-group';
 export * from './bottom-navigation';
 export { default as Button } from './button';
 export * from './card';
+export * from './card-list';
 export { default as Checkbox } from './checkbox';
 export { default as ChipAction } from './chip-action';
 export { default as ChipFilter } from './chip-filter';

--- a/packages/wds/src/components/loading/style.ts
+++ b/packages/wds/src/components/loading/style.ts
@@ -8,16 +8,8 @@ import type { Theme } from '@wanteddev/wds-engine';
 export const loadingStyle =
   ({ size, xl, lg, md, sm, xs }: LoadingProps) =>
   (theme: Theme) => css`
-    --wds-loading-wanted-padding: 16px;
-    --wds-loading-wanted-size: ${size};
-
-    width: calc(
-      var(--wds-loading-wanted-size) + var(--wds-loading-wanted-padding) * 2
-    );
-    height: calc(
-      var(--wds-loading-wanted-size) + var(--wds-loading-wanted-padding) * 2
-    );
-    padding: var(--wds-loading-wanted-padding);
+    width: ${size};
+    height: ${size};
     margin: 0 auto;
 
     ${createResponsiveStyle(
@@ -25,7 +17,11 @@ export const loadingStyle =
       theme,
     )(
       (params) => css`
-        --wds-loading-wanted-size: ${params?.size};
+        ${params?.size !== undefined &&
+        css`
+          width: ${params.size};
+          height: ${params.size};
+        `}
         ${params?.sx}
       `,
     )}

--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -28,7 +28,10 @@ export const skeletonStyle =
       theme,
     )(
       (params) => css`
-        ${skeletonSizeStyle(params || {})}
+        ${skeletonSizeStyle({
+          ...params,
+          variant: props.variant,
+        })}
         ${params?.sx}
       `,
     )}

--- a/packages/wds/src/components/thumbnail/style.ts
+++ b/packages/wds/src/components/thumbnail/style.ts
@@ -17,7 +17,7 @@ export const thumbnailStyle =
     md,
     lg,
     xl,
-  }: ThumbnailProps & { width: string | number }) =>
+  }: ThumbnailProps & { width?: string | number }) =>
   (theme: Theme) => css`
     width: ${width};
 

--- a/packages/wds/src/components/thumbnail/types.ts
+++ b/packages/wds/src/components/thumbnail/types.ts
@@ -30,8 +30,9 @@ export type ThumbnailProps = Merge<
 export type ThumbnailSkeletonDefaultProps = Omit<
   SkeletonProps,
   'width' | 'radius'
-> &
-  Pick<ImageLoaderProps, 'width'>;
+> & {
+  width?: ImageLoaderProps['width'];
+};
 
 export type ThumbnailSkeletonProps = Merge<
   ThumbnailProps,


### PR DESCRIPTION
## 작업 내용

- `CardList` 컴포넌트 및 문서 작성
  - `CardListContent`: CardList의 leftContent, rightContent 래핑
- `CardExtraContent` --> `CardContentItem` 네이밍 변경: CardContent 내부에서 top, bottom을 다루는데 extra라는 이름이 관계가 역전되는 거 같아 변경했습니다. (ModalContentItem 참고)
- card skeleton 재사용 처리 및 스타일링 변경
- `Skeleton`에서 responsive 미작동 오류 수정
- `ThumbnailSkeleton` width 옵셔널로 변경

## 참고

- https://wantedlab.atlassian.net/browse/PI-69421
- https://wantedlab.atlassian.net/browse/PI-68745
- https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=3331-4029&node-type=instance&m=dev