### PR TITLE
feat(wds): progress indicator 피그마 연동 및 최적화, deprecated 처리

### DIFF
--- a/docs/src/docs/routes.ts
+++ b/docs/src/docs/routes.ts
@@ -118,12 +118,11 @@ export const routes: Array<Route> = [
       {
         title: 'ProgressIndicator',
         slug: '/docs/components/progress-indicator',
-        alpha: true,
       },
       {
         title: 'ProgressStepIndicator',
         slug: '/docs/components/progress-step-indicator',
-        alpha: true,
+        deprecated: true,
       },
       {
         title: 'ProgressTracker',

--- a/figma.config.json
+++ b/figma.config.json
@@ -38,6 +38,8 @@
       "<FIGMA_CHIP_FILTER>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=478-7077",
       "<FIGMA_CONTENT_BADGE>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=478-7657",
       "<FIGMA_PUSH_BADGE>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=669-7435",
+      "<FIGMA_PROGRESS_INDICATOR>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=2236-18465",
+      "<FIGMA_PROGRESS_STEP_INDICATOR>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=2236-18526",
       "<FIGMA_LOADING_CIRCULAR>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=2236-18495",
       "<FIGMA_LOADING_WANTED>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=23176-80602",
       "<FIGMA_SKELETON_TEXT>": "https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/0-Component?node-id=4950-32917",

--- a/figma/components/progress-indicator/index.figma.tsx
+++ b/figma/components/progress-indicator/index.figma.tsx
@@ -1,0 +1,14 @@
+import { figma } from '@figma/code-connect';
+
+import { ProgressIndicator } from '@wanteddev/wds';
+
+figma.connect(ProgressIndicator, '<FIGMA_PROGRESS_INDICATOR>', {
+  props: {
+    percent: figma.enum('Percent', {
+      '0%': 0,
+      '50%': 50,
+      '100%': 100,
+    }),
+  },
+  example: (props) => <ProgressIndicator {...props} />,
+});

--- a/figma/components/progress-step-indicator/index.figma.tsx
+++ b/figma/components/progress-step-indicator/index.figma.tsx
@@ -1,0 +1,24 @@
+import { figma } from '@figma/code-connect';
+
+import {
+  ProgressStepIndicator,
+  ProgressStepIndicatorItem,
+} from '@wanteddev/wds';
+
+figma.connect(ProgressStepIndicator, '<FIGMA_PROGRESS_STEP_INDICATOR>', {
+  props: {
+    size: figma.enum('Size', {
+      Medium: 'small',
+      Large: 'medium',
+    }),
+    divider: figma.boolean('Divider'),
+  },
+  example: (props) => (
+    <ProgressStepIndicator value="2" {...props}>
+      <ProgressStepIndicatorItem value="1" />
+      <ProgressStepIndicatorItem value="2" />
+      <ProgressStepIndicatorItem value="3" />
+      <ProgressStepIndicatorItem value="4" />
+    </ProgressStepIndicator>
+  ),
+});

--- a/figma/components/progress-step-indicator/index.figma.tsx
+++ b/figma/components/progress-step-indicator/index.figma.tsx
@@ -8,8 +8,8 @@ import {
 figma.connect(ProgressStepIndicator, '<FIGMA_PROGRESS_STEP_INDICATOR>', {
   props: {
     size: figma.enum('Size', {
-      Medium: 'small',
-      Large: 'medium',
+      Small: 'small',
+      Medium: 'medium',
     }),
     divider: figma.boolean('Divider'),
   },

--- a/packages/wds/src/components/progress-step-indicator/contexts.ts
+++ b/packages/wds/src/components/progress-step-indicator/contexts.ts
@@ -2,12 +2,12 @@ import { createContext } from '@radix-ui/react-context';
 
 import { PROGRESS_STEP_INDICATOR_NAME } from './constants';
 
+import type { ProgressStepIndicatorItemProps } from './types';
+
 type ProgressStepIndicatorContextValue = {
   value: string;
   onValueChange: (value: string) => void;
-  steps: Array<string>;
-  onStepAdd: (value: string) => void;
-  onStepRemove: (value: string) => void;
+  steps: Array<ProgressStepIndicatorItemProps>;
   getStepIndex: (value: string) => number;
   getActiveStepIndex: () => number;
 };

--- a/packages/wds/src/components/progress-step-indicator/index.tsx
+++ b/packages/wds/src/components/progress-step-indicator/index.tsx
@@ -1,7 +1,9 @@
 'use client';
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useMemo } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Box } from '@wanteddev/wds-engine';
+
+import { findComponentInChildren } from '../../utils/children';
 
 import {
   progressListStyle,
@@ -18,12 +20,14 @@ import {
 } from './constants';
 
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
-import type { CSSProperties } from 'react';
 import type {
   ProgressStepIndicatorItemProps,
   ProgressStepIndicatorProps,
 } from './types';
 
+/**
+ * @deprecated
+ */
 const ProgressStepIndicator = forwardRef<
   HTMLDivElement,
   DefaultComponentProps<ProgressStepIndicatorProps, 'div'>
@@ -50,31 +54,25 @@ const ProgressStepIndicator = forwardRef<
       defaultProp: defaultValue,
       onChange: onValueChange,
     });
-    const [steps, setSteps] = useState<Array<string>>([]);
+
+    const steps = useMemo(() => {
+      return findComponentInChildren<ProgressStepIndicatorItemProps>(
+        children,
+        'isProgressStepIndicatorItem',
+      );
+    }, [children]);
 
     return (
       <ProgressStepIndicatorProvider
         value={value}
         onValueChange={setValue}
         steps={steps}
-        onStepAdd={useCallback(
-          (step: string) => {
-            setSteps((prev) => [...prev, step]);
-          },
-          [setSteps],
-        )}
-        onStepRemove={useCallback(
-          (step: string) => {
-            setSteps((prev) => prev.filter((cur) => cur !== step));
-          },
-          [setSteps],
-        )}
         getStepIndex={useCallback(
-          (step: string) => steps.findIndex((cur) => cur === step),
+          (step: string) => steps.findIndex((cur) => cur.value === step),
           [steps],
         )}
         getActiveStepIndex={useCallback(
-          () => steps.findIndex((cur) => cur === value),
+          () => steps.findIndex((cur) => cur.value === value),
           [steps, value],
         )}
       >
@@ -87,12 +85,6 @@ const ProgressStepIndicator = forwardRef<
             progressStepWrapperStyle({ size, divider, xs, sm, md, lg, xl }),
             props.sx,
           ]}
-          style={
-            {
-              ...props.style,
-              '--wds-progress-step-indicator-width': `calc(100% / ${steps.length})`,
-            } as CSSProperties
-          }
         >
           <Box as="ol" sx={progressListWrapperStyle}>
             {children}
@@ -105,14 +97,15 @@ const ProgressStepIndicator = forwardRef<
 
 ProgressStepIndicator.displayName = PROGRESS_STEP_INDICATOR_NAME;
 
+/**
+ * @deprecated
+ */
 const ProgressStepIndicatorItem = forwardRef<
   HTMLLIElement,
   DefaultComponentProps<ProgressStepIndicatorItemProps, 'li'>
 >(({ value, ...props }, ref) => {
   const {
     value: contextValue,
-    onStepAdd,
-    onStepRemove,
     getStepIndex,
     getActiveStepIndex,
   } = useProgressStepIndicatorContext(PROGRESS_STEP_INDICATOR_ITEM_NAME);
@@ -121,31 +114,25 @@ const ProgressStepIndicatorItem = forwardRef<
   const index = getStepIndex(value);
   const activeIndex = getActiveStepIndex();
 
-  useEffect(() => {
-    onStepAdd(value);
-
-    return () => onStepRemove(value);
-  }, [onStepAdd, onStepRemove, value]);
+  const isCompleted = activeIndex !== -1 && activeIndex >= index;
 
   return (
     <Box
       as="li"
       ref={ref}
       wds-component="progress-step-indicator-item"
-      aria-current={isActive ? 'step' : undefined}
+      aria-label={`Step ${index}`}
       {...props}
+      data-is-completed={isCompleted}
+      aria-current={isActive ? 'step' : undefined}
       sx={[progressListStyle, props.sx]}
-      style={
-        {
-          ...props.style,
-          ['--wds-progress-step-indicator-inset']:
-            activeIndex >= index ? '0' : '0 0 0 -100%',
-        } as CSSProperties
-      }
     />
   );
 });
 
 ProgressStepIndicatorItem.displayName = PROGRESS_STEP_INDICATOR_ITEM_NAME;
+
+// @ts-expect-error
+ProgressStepIndicatorItem.isProgressStepIndicatorItem = true;
 
 export { ProgressStepIndicator, ProgressStepIndicatorItem };

--- a/packages/wds/src/components/progress-step-indicator/style.ts
+++ b/packages/wds/src/components/progress-step-indicator/style.ts
@@ -38,6 +38,9 @@ export const progressListWrapperStyle = css`
   display: flex;
   align-items: center;
   height: 100%;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
   & > li:first-of-type {
     border-top-left-radius: 999px;
@@ -51,7 +54,7 @@ export const progressListWrapperStyle = css`
 `;
 
 export const progressListStyle = (theme: Theme) => css`
-  width: var(--wds-progress-step-indicator-width);
+  flex: 1 1 0;
   height: 100%;
   position: relative;
   background-color: ${theme.palette.fill.normal};
@@ -63,8 +66,14 @@ export const progressListStyle = (theme: Theme) => css`
     height: 100%;
     background-color: ${theme.palette.primary.normal};
     position: absolute;
-    inset: var(--wds-progress-step-indicator-inset);
-    transition: left 500ms cubic-bezier(0.4, 0, 0.2, 1);
+    inset: 0 0 0 -100%;
+  }
+
+  &[data-is-completed='true'],
+  &[aria-current='step'] {
+    &::after {
+      inset: 0;
+    }
   }
 `;
 

--- a/packages/wds/src/components/progress-tracker/contexts.ts
+++ b/packages/wds/src/components/progress-tracker/contexts.ts
@@ -2,12 +2,12 @@ import { createContext } from '@radix-ui/react-context';
 
 import { PROGRESS_TRACKER_NAME } from './constants';
 
+import type { ProgressTrackerItemProps } from './types';
+
 type ProgressTrackerContextValue = {
   value: string;
   onValueChange: (value: string) => void;
-  steps: Array<string>;
-  onStepAdd: (value: string) => void;
-  onStepRemove: (value: string) => void;
+  steps: Array<ProgressTrackerItemProps>;
   getStepIndex: (value: string) => number;
   getActiveStepIndex: () => number;
   getTotalLength: () => number;

--- a/packages/wds/src/components/progress-tracker/index.tsx
+++ b/packages/wds/src/components/progress-tracker/index.tsx
@@ -1,11 +1,12 @@
 'use client';
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useMemo } from 'react';
 import { IconCheckThick } from '@wanteddev/wds-icon';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Box } from '@wanteddev/wds-engine';
 
 import Typography from '../typography';
 import FlexBox from '../flex-box';
+import { findComponentInChildren } from '../../utils/children';
 
 import {
   progressCircleStyle,
@@ -33,32 +34,26 @@ const ProgressTracker = forwardRef<
       defaultProp: defaultValue,
       onChange: onValueChange,
     });
-    const [steps, setSteps] = useState<Array<string>>([]);
+
+    const steps = useMemo(() => {
+      return findComponentInChildren<ProgressTrackerItemProps>(
+        children,
+        'isProgressTrackerItem',
+      );
+    }, [children]);
 
     return (
       <ProgressTrackerProvider
         value={value}
         onValueChange={setValue}
         steps={steps}
-        onStepAdd={useCallback(
-          (step: string) => {
-            setSteps((prev) => [...prev, step]);
-          },
-          [setSteps],
-        )}
         getTotalLength={useCallback(() => steps.length, [steps])}
-        onStepRemove={useCallback(
-          (step: string) => {
-            setSteps((prev) => prev.filter((cur) => cur !== step));
-          },
-          [setSteps],
-        )}
         getStepIndex={useCallback(
-          (step: string) => steps.findIndex((cur) => cur === step),
+          (step: string) => steps.findIndex((cur) => cur.value === step),
           [steps],
         )}
         getActiveStepIndex={useCallback(
-          () => steps.findIndex((cur) => cur === value),
+          () => steps.findIndex((cur) => cur.value === value),
           [steps, value],
         )}
       >
@@ -86,8 +81,6 @@ const ProgressTrackerItem = forwardRef<
 >(({ value, ...props }, ref) => {
   const {
     value: contextValue,
-    onStepAdd,
-    onStepRemove,
     getStepIndex,
     getActiveStepIndex,
     getTotalLength,
@@ -101,12 +94,6 @@ const ProgressTrackerItem = forwardRef<
 
   const isFirst = index === 0;
   const isLast = index === getTotalLength() - 1;
-
-  useEffect(() => {
-    onStepAdd(value);
-
-    return () => onStepRemove(value);
-  }, [onStepAdd, onStepRemove, value]);
 
   return (
     <>
@@ -149,5 +136,8 @@ const ProgressTrackerItem = forwardRef<
 });
 
 ProgressTrackerItem.displayName = PROGRESS_TRACKER_ITEM_NAME;
+
+// @ts-expect-error
+ProgressTrackerItem.isProgressTrackerItem = true;
 
 export { ProgressTracker, ProgressTrackerItem };

--- a/packages/wds/src/components/progress-tracker/style.ts
+++ b/packages/wds/src/components/progress-tracker/style.ts
@@ -8,6 +8,12 @@ export const progressTrackerWrapperStyle = css`
   width: 100%;
   height: fit-content;
   position: relative;
+
+  ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 `;
 
 export const progressTrackerItemStyle = (

--- a/packages/wds/src/utils/children.ts
+++ b/packages/wds/src/utils/children.ts
@@ -1,0 +1,29 @@
+import { Children, isValidElement } from 'react';
+
+export const findComponentInChildren = <T extends object>(
+  nodes: React.ReactNode,
+  key: string,
+) => {
+  return (
+    Children.toArray(nodes)
+      .map((node): Array<Partial<T>> | Partial<T> | null => {
+        if (!isValidElement(node) || !node.type) {
+          return null;
+        }
+
+        const {
+          type,
+          props: { children },
+        } = node as React.ReactElement & {
+          type: { [k in string]: boolean };
+        };
+
+        if (type[key]) {
+          return node.props as T;
+        }
+
+        return findComponentInChildren(children, key);
+      })
+      .flat(Infinity) as Array<Partial<T>>
+  ).filter((v) => Boolean(v)) as Array<T>;
+};


### PR DESCRIPTION
- progress step indicator
  - 최적화
  - figma 연동
  - deprecated
- progress indicator
  - figma 연동
- progress tracker
  - 최적화


최적화 부분은 원래 context에 item들을 add, remove하면서 현재값을 계산했는데, SSR일 때 context 값을 가져오지 못 해서
직접 children을 순회하면서 찾는 것으로 변경했습니다.