### PR TITLE
fix(wds): popover에서 disabled 처리가 올바르게 되지 않음

### DIFF
--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -65,8 +65,8 @@ const PopoverTrigger = forwardRef<
         aria-controls={contentId}
         id={triggerId}
         ref={ref}
-        onClick={composeEventHandlers(props.onClick, () => {
-          if (!open) {
+        onClick={composeEventHandlers(props.onClick, (e) => {
+          if (!open && e.currentTarget.ariaDisabled !== 'true') {
             onOpenChange(true);
           }
         })}

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -66,7 +66,7 @@ const PopoverTrigger = forwardRef<
         id={triggerId}
         ref={ref}
         onClick={composeEventHandlers(props.onClick, (e) => {
-          if (!open && e.currentTarget.ariaDisabled !== 'true') {
+          if (!open && e.currentTarget.ariaDisabled?.toString() !== 'true') {
             onOpenChange(true);
           }
         })}


### PR DESCRIPTION
- popover의 경우 button, div 등 다양한 요소가 올 수 있는데, disabled 속성을 지원하지 않는 태그를 사용할 때 popover가 열리는 현상이 있어서 popover에만 예외적으로 aria-disabled를 확인하도록 추가했습니다.