### PR TITLE
fix(wds): menu, select, select-multiple 리액트 환경에서 옵션으로 포커스 되지 않는 이슈

### DIFF
--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -108,22 +108,21 @@ const MenuContent = forwardRef<
     ref,
   ) => {
     return (
-      <PopoverContent
-        ref={ref}
-        position={position}
-        offset={offset}
-        container={container}
-        disablePortal={disablePortal}
-        trappedContent
-        {...props}
-        sx={[menuPopoverContentStyle, sx]}
-      >
-        <RovingFocusGroup orientation="vertical" dir="ltr" asChild>
+      <RovingFocusGroup orientation="vertical" dir="ltr" asChild>
+        <PopoverContent
+          ref={ref}
+          position={position}
+          offset={offset}
+          container={container}
+          disablePortal={disablePortal}
+          {...props}
+          sx={[menuPopoverContentStyle, sx]}
+        >
           <ScrollArea zIndex={11} sx={menuScrollAreaStyle} size="small">
             {children}
           </ScrollArea>
-        </RovingFocusGroup>
-      </PopoverContent>
+        </PopoverContent>
+      </RovingFocusGroup>
     );
   },
 );


### PR DESCRIPTION
`RovingFocusGroupItem` 이 useEffect로 개수가 증가되는 형식인데, FocusScope의 useEffect가 먼저 실행되어서
포커스할 당시 `RovingFocusGroupItem` 이 없는 것으로 판단되는 현상 수정했습니다.


Fixed #166