### PR TITLE
fix(wds): always tooltip을 모달 위에서 사용할 경우 escape keydown이 동작하지 않음

### DIFF
--- a/packages/wds/src/components/component-or-fragment/index.tsx
+++ b/packages/wds/src/components/component-or-fragment/index.tsx
@@ -1,0 +1,30 @@
+import { Fragment } from 'react';
+
+import type { Merge } from '@wanteddev/wds-engine';
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
+
+export type ComponentOrFragmentProps<E extends ElementType> = Merge<
+  {
+    flag: boolean;
+    children: ReactNode;
+    component: E;
+  },
+  ComponentPropsWithoutRef<E>
+>;
+
+const ComponentOrFragment = <E extends ElementType>({
+  children,
+  flag,
+  component,
+  ...props
+}: ComponentOrFragmentProps<E>) => {
+  const Comp = component;
+
+  return flag ? (
+    <Comp {...(props as any)}>{children}</Comp>
+  ) : (
+    <Fragment>{children}</Fragment>
+  );
+};
+
+export default ComponentOrFragment;

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -13,6 +13,7 @@ import NoSsr from '../no-ssr';
 import { addOpacity } from '../../utils';
 import IconButton from '../icon-button';
 import useTransitionStatus from '../../hooks/use-transition-status';
+import ComponentOrFragment from '../component-or-fragment';
 
 import { TooltipProvider, useTooltipContext } from './contexts';
 import {
@@ -154,7 +155,9 @@ const TooltipContent = forwardRef<
 
     const composedRef = useComposedRefs(ref, containerRef);
 
-    const Wrapper = mode === 'always' ? NoSsr : Fragment;
+    const isAlways = mode === 'always';
+
+    const Wrapper = isAlways ? NoSsr : Fragment;
 
     const theme = useTheme();
 
@@ -162,7 +165,9 @@ const TooltipContent = forwardRef<
 
     return !hasExited ? (
       <Wrapper>
-        <DismissableLayer
+        <ComponentOrFragment
+          component={DismissableLayer}
+          flag={!isAlways}
           asChild
           disableOutsidePointerEvents={false}
           onFocusOutside={(event) => event.preventDefault()}
@@ -233,7 +238,7 @@ const TooltipContent = forwardRef<
               </FlexBox>
             )}
           </PopperContent>
-        </DismissableLayer>
+        </ComponentOrFragment>
       </Wrapper>
     ) : null;
   },


### PR DESCRIPTION
Fixed: #167 