### PR TITLE
feat(wds): list-text 기본 텍스트 color prop 추가

### DIFF
--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -334,7 +334,13 @@ ListCell.displayName = LIST_CELL_NAME;
 
 const ListText = forwardRef(
   <E extends ElementType = 'p'>(
-    { caption, bold, children, ...props }: PolymorphicProps<ListTextProps, E>,
+    {
+      caption,
+      bold,
+      children,
+      color,
+      ...props
+    }: PolymorphicProps<ListTextProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
     const { active, disabled } = useListItemContext(LIST_TEXT_NAME);
@@ -347,7 +353,7 @@ const ListText = forwardRef(
     const weight: TypographyWeight =
       bold ?? menuItemBold ? 'medium' : 'regular';
 
-    const getParagraphColor = (): ThemeColorsToken => {
+    const getTextColor = (): ThemeColorsToken => {
       if (disabled) {
         return 'palette.label.disable';
       }
@@ -355,7 +361,7 @@ const ListText = forwardRef(
         return 'palette.primary.normal';
       }
 
-      return 'palette.label.normal';
+      return color ?? 'palette.label.normal';
     };
 
     return (
@@ -370,7 +376,7 @@ const ListText = forwardRef(
       >
         <Typography
           variant="body1_normal"
-          color={getParagraphColor()}
+          color={getTextColor()}
           weight={weight}
           sx={listTextStyle}
         >

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -1,4 +1,8 @@
-import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
+import type {
+  Merge,
+  ResponsiveProps,
+  ThemeColorsToken,
+} from '@wanteddev/wds-engine';
 import type { ReactNode } from 'react';
 import type { FlexBoxProps } from '../flex-box/types';
 
@@ -50,4 +54,5 @@ export type ListCellProps = Merge<
 export type ListTextProps = {
   caption?: ReactNode;
   bold?: boolean;
+  color?: ThemeColorsToken;
 };


### PR DESCRIPTION
## 작업내용

- `ListText`에서 text color 커스텀할 수 있는 Prop 추가 (캡션은 제외)
- 스퀘어에서 List와 흡사한 UI에서 사용하다보니, color를 커스텀 하고싶은 니즈가 있을 거 같아 추가했습니다. 기존 가이드와 맞지 않다고 생각하시면 말씀 부탁드립니다!

as-is
```tsx
<ListText
  bold
  sx={(theme) => ({
    '> span': {
      color: theme.palette.accent.purple,
    },
  })}
>
```