### PR TITLE
feat(wds): card-thumbnail, card-thumbnail-skeleton ratio 커스텀 기능 추가

### DIFF
--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -32,6 +32,7 @@ import {
   cardThumbnailContentTextStyle,
   cardThumbnailContentToggleIconStyle,
   cardThumbnailContentWrapperStyle,
+  cardThumbnailSkeletonStyle,
   cardThumbnailStyle,
 } from './style';
 
@@ -284,10 +285,26 @@ CardSkeleton.displayName = CARD_SKELETON_NAME;
 
 const CardThumbnailSkeleton = forwardRef(
   (
-    props: DefaultComponentProps<ThumbnailSkeletonProps, 'div'>,
+    {
+      ratio,
+      xl,
+      lg,
+      md,
+      sm,
+      xs,
+      sx,
+      ...props
+    }: DefaultComponentProps<ThumbnailSkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
-    return <ThumbnailSkeleton ref={ref} radius {...props} />;
+    return (
+      <ThumbnailSkeleton
+        ref={ref}
+        radius
+        sx={[cardThumbnailSkeletonStyle({ ratio, xs, sm, md, lg, xl }), sx]}
+        {...props}
+      />
+    );
   },
 );
 

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -79,13 +79,32 @@ const Card = forwardRef(
 Card.displayName = CARD_NAME;
 
 const CardThumbnail = forwardRef<HTMLDivElement, CardThumbnailProps>(
-  ({ leftContent, rightContent, width, sx, ...props }, ref) => {
+  (
+    {
+      leftContent,
+      rightContent,
+      width,
+      ratio,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      sx,
+      ...props
+    },
+    ref,
+  ) => {
     const hasLeftContent = Boolean(leftContent);
     const hasRightContent = Boolean(rightContent);
     const hasContent = hasLeftContent || hasRightContent;
 
     return (
-      <Box ref={ref} {...props} sx={[cardThumbnailStyle, sx]}>
+      <Box
+        ref={ref}
+        {...props}
+        sx={[cardThumbnailStyle({ ratio, xs, sm, md, lg, xl }), sx]}
+      >
         {hasContent && (
           <FlexBox
             gap="4px"

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -8,7 +8,12 @@ import {
 } from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
-import type { CardContentItemProps, CardProps } from './types';
+import type {
+  CardContentItemProps,
+  CardProps,
+  CardThumbnailProps,
+  CardThumbnailResponsiveProps,
+} from './types';
 
 const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
   switch (platform) {
@@ -124,18 +129,55 @@ export const cardStyle =
     )}
   `;
 
-export const cardThumbnailStyle = css`
-  position: relative;
-
-  [wds-component='thumbnail'] {
-    overflow: hidden;
-
-    img {
-      will-change: transform;
-      transition: transform 0.2s ease;
-    }
+const cardThumbnailRatioStyle = ({
+  ratio,
+}: Pick<CardThumbnailProps, 'ratio'>) => {
+  if (!ratio) {
+    return;
   }
-`;
+
+  const [width, height] = ratio.split(':');
+  const parsedRatio = `${width} / ${height}`;
+
+  return css`
+    & [wds-component='thumbnail'] {
+      aspect-ratio: ${parsedRatio};
+    }
+  `;
+};
+
+export const cardThumbnailStyle =
+  ({
+    ratio,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+  }: Pick<CardThumbnailProps, 'ratio'> & CardThumbnailResponsiveProps) =>
+  (theme: Theme) => css`
+    position: relative;
+
+    ${cardThumbnailRatioStyle({ ratio })}
+    [wds-component='thumbnail'] {
+      overflow: hidden;
+
+      img {
+        will-change: transform;
+        transition: transform 0.2s ease;
+      }
+    }
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        ${cardThumbnailRatioStyle({ ratio: params?.ratio })}
+        ${params?.sx}
+      `,
+    )}
+  `;
 
 export const cardThumbnailContentWrapperStyle = (theme: Theme) => css`
   position: absolute;

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -7,12 +7,12 @@ import {
   typographyStyle,
 } from '../../utils';
 
+import type { ThumbnailSkeletonProps } from '../thumbnail/types';
 import type { Theme } from '@wanteddev/wds-engine';
 import type {
   CardContentItemProps,
   CardProps,
   CardThumbnailProps,
-  CardThumbnailResponsiveProps,
 } from './types';
 
 const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
@@ -140,7 +140,8 @@ const cardThumbnailRatioStyle = ({
   const parsedRatio = `${width} / ${height}`;
 
   return css`
-    & [wds-component='thumbnail'] {
+    & [wds-component='thumbnail'],
+    &[wds-component='thumbnail-skeleton'] {
       aspect-ratio: ${parsedRatio};
     }
   `;
@@ -154,11 +155,10 @@ export const cardThumbnailStyle =
     md,
     lg,
     xl,
-  }: Pick<CardThumbnailProps, 'ratio'> & CardThumbnailResponsiveProps) =>
+  }: Omit<CardThumbnailProps, 'src' | 'width' | 'alt'>) =>
   (theme: Theme) => css`
     position: relative;
 
-    ${cardThumbnailRatioStyle({ ratio })}
     [wds-component='thumbnail'] {
       overflow: hidden;
 
@@ -168,6 +168,22 @@ export const cardThumbnailStyle =
       }
     }
 
+    ${cardThumbnailRatioStyle({ ratio })}
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        ${cardThumbnailRatioStyle({ ratio: params?.ratio })}
+        ${params?.sx}
+      `,
+    )}
+  `;
+
+export const cardThumbnailSkeletonStyle =
+  ({ ratio, xs, sm, md, lg, xl }: ThumbnailSkeletonProps) =>
+  (theme: Theme) => css`
+    ${cardThumbnailRatioStyle({ ratio })}
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
       theme,

--- a/packages/wds/src/components/card/types.ts
+++ b/packages/wds/src/components/card/types.ts
@@ -23,9 +23,12 @@ export type CardThumbnailDefaultProps = {
   leftContent?: ReactNode;
   rightContent?: ReactNode;
 };
+export type CardThumbnailResponsiveProps = ResponsiveProps<
+  Pick<CardThumbnailBasicProps, 'ratio'>
+>;
 export type CardThumbnailProps = Merge<
-  CardThumbnailDefaultProps,
-  CardThumbnailBasicProps
+  Merge<CardThumbnailDefaultProps, CardThumbnailBasicProps>,
+  CardThumbnailResponsiveProps
 >;
 
 export type CardThumbnailContentProps = Merge<


### PR DESCRIPTION
## 작업 내용

- `Card/CardList` 가이드에서, Card의 width와 thumbnail의 ratio를 커스텀 할 수 있는 기능이 있는데, 누락되어 추가합니다.
  - `Card/CardList`의 platform에 따라 ratio가 영향을 받는데, ratio prop을 추가할 경우 덮어씌우도록 수정했습니다.

