### PR TITLE
feat(wds): cell 업데이트

### DIFF
--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -110,7 +110,7 @@ export default Demo;`}
 
 ### Padding, Active
 
-padding, fillWidth으로 간격을 조정하고, Active, disabled 로 상태를 표시해요.
+padding, fillWidth으로 간격을 조정하고, active, disabled 로 상태를 표시해요.
 
 <Demo code={`import { List, ListCell, ListText } from '@wanteddev/wds';
 

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -208,6 +208,13 @@ const Demo = () => {
       </ListCell>
       <ListCell
         rightContent={
+          <ListItemContent variant="chevron" />
+        }
+      >
+        <ListText>텍스트, Normal</ListText>
+      </ListCell>
+      <ListCell
+        rightContent={
           <ListItemContent variant="chevron" chevron={false}>
             값
           </ListItemContent>
@@ -313,7 +320,6 @@ const Demo = () => {
         <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
       </ListCell>
       <ListCell
-        alignItems="center"
         leftContent={
           <ListItemContent height="large" variant="custom">
             <Thumbnail

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -151,10 +151,10 @@ export default Demo;`}
 ### LeftContent, RightContent
 
 - 기본적으로 leftContent, rightContent는 `ListItemContent` 로 래핑해서 사용해요.
-- size로 콘텐츠 크기를 조정할 수 있어요.
+- height로 콘텐츠 높이를 조정할 수 있어요.
 
-<Demo code={`import { Avatar, List, ListCell, ListText, ListItemContent, IconButton, NestedCheckbox, TextButton, ContentBadge, Switch } from '@wanteddev/wds';
-import { IconPlusThick, IconApps, IconBlank } from '@wanteddev/wds-icon';
+<Demo code={`import { RadioGroupItem, Checkbox, Thumbnail, Avatar, List, ListCell, ListText, ListItemContent, IconButton, NestedCheckbox, TextButton, ContentBadge, Switch } from '@wanteddev/wds';
+import { IconBlank } from '@wanteddev/wds-icon';
 
 const Demo = () => {
   return (
@@ -162,7 +162,7 @@ const Demo = () => {
       <ListCell
         rightContent={
           <ListItemContent variant="icon">
-            <IconApps />
+            <IconBlank />
           </ListItemContent>
         }
       >
@@ -216,9 +216,28 @@ const Demo = () => {
         <ListText>텍스트, Normal</ListText>
       </ListCell>
       <ListCell
+        leftContent={
+          <ListItemContent variant="icon">
+            <IconBlank />
+          </ListItemContent>
+        }
         rightContent={
-          <ListItemContent variant="custom">
-            커스텀 요소
+          <ListItemContent variant="chevron" chevron={false}>
+            값
+          </ListItemContent>
+        }
+      >
+        <ListText>텍스트, Normal</ListText>
+      </ListCell>
+      <ListCell
+        leftContent={
+          <ListItemContent variant="checkbox">
+            <Checkbox />
+          </ListItemContent>
+        }
+        rightContent={
+          <ListItemContent variant="chevron" chevron={false}>
+            값
           </ListItemContent>
         }
       >
@@ -227,17 +246,36 @@ const Demo = () => {
 
       <ListCell
         leftContent={
-          <ListItemContent size="medium" variant="avatar">
+          <ListItemContent height="medium" variant="avatar">
             <Avatar variant="person" size="medium" />
           </ListItemContent>
         }
+        rightContent={
+          <ListItemContent variant="chevron" chevron={false}>
+            값
+          </ListItemContent>
+        }
+      >
+        <ListText>텍스트, Medium</ListText>
+      </ListCell>
+      <ListCell
         alignItems="center"
+        leftContent={
+          <ListItemContent height="medium" variant="avatar">
+            <Avatar variant="person" size="medium" />
+          </ListItemContent>
+        }
+        rightContent={
+          <ListItemContent variant="checkbox">
+            <NestedCheckbox />
+          </ListItemContent>
+        }
       >
         <ListText>텍스트, Medium</ListText>
       </ListCell>
       <ListCell
         rightContent={
-          <ListItemContent size="medium" variant="switch">
+          <ListItemContent height="medium" variant="switch">
             <Switch />
           </ListItemContent>
         }
@@ -247,24 +285,54 @@ const Demo = () => {
 
       <ListCell
         leftContent={
-          <ListItemContent size="large" variant="large-icon">
-            <IconBlank  />
+          <ListItemContent height="large" variant="large-icon">
+            <IconBlank />
           </ListItemContent>
         }
-        alignItems="center"
+        rightContent={
+          <ListItemContent variant="chevron" chevron={false}>
+            값
+          </ListItemContent>
+        }
       >
-        <ListText>텍스트, Large</ListText>
+        <ListText caption="캡션">텍스트, Large</ListText>
       </ListCell>
       <ListCell
+        alignItems="center"
+        leftContent={
+          <ListItemContent height="large" variant="large-icon">
+            <IconBlank />
+          </ListItemContent>
+        }
         rightContent={
-          <ListItemContent size="large" variant="icon-button">
-            <IconButton>
-              <IconPlusThick />
-            </IconButton>
+          <ListItemContent variant="checkbox">
+            <NestedCheckbox />
           </ListItemContent>
         }
       >
-        <ListText>텍스트, Large</ListText>
+        <ListText caption="캡션">텍스트, Large</ListText>
+      </ListCell>
+      <ListCell
+        alignItems="center"
+        leftContent={
+          <ListItemContent height="large" variant="custom">
+            <Thumbnail
+              src="https://static.wanted.co.kr/images/company/79/elpzxpmgh94xesrf__1080_790.png"
+              alt="Wanted Company Image"
+              width="400px"
+              ratio="1:1"
+              quality={95}
+              sx={{ width: '56px' }}
+            />
+          </ListItemContent>
+        }
+        rightContent={
+          <ListItemContent variant="checkbox">
+            <NestedCheckbox />
+          </ListItemContent>
+        }
+      >
+        <ListText caption="캡션">텍스트, Large</ListText>
       </ListCell>
     </List>
   )

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -569,7 +569,7 @@ const Demo = () => {
               disableInteraction
               rightContent={
                 <FormControl>
-                  <ListItemContent variant="switch">
+                  <ListItemContent variant="switch" height="medium">
                     <Switch
                       {...field}
                       checked={field.value} 
@@ -592,7 +592,7 @@ const Demo = () => {
               disableInteraction
               rightContent={
                 <FormControl>
-                  <ListItemContent variant="switch">
+                  <ListItemContent variant="switch" height="medium">
                     <Switch
                       {...field}
                       checked={field.value}

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -347,6 +347,67 @@ const Demo = () => {
 export default Demo;`}
 />
 
+### Ellipsis
+
+- ellipsis가 false일 때 수직 정렬은 상단으로 조정 됩니다.
+- ellipsis가 true일 때 수직 정렬은 중앙으로 조정 됩니다.
+
+<Demo code={`import { List, ListCell, ListText, ListItemContent } from '@wanteddev/wds';
+import { IconBlank } from '@wanteddev/wds-icon';
+
+const Demo = () => {
+  return (
+    <List gap="16px" sx={{ width: '50%' }}>
+      <ListCell
+        leftContent={
+          <ListItemContent height="large" variant="large-icon">
+            <IconBlank />
+          </ListItemContent>
+        }
+        rightContent={
+          <ListItemContent variant="chevron">
+            값
+          </ListItemContent>
+        }
+      >
+        <ListText 
+          caption="캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션
+            캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션"
+        >
+          텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트
+          텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트
+          텍스트텍스트텍스트텍스트
+        </ListText>
+      </ListCell>
+      <ListCell
+        ellipsis
+        leftContent={
+          <ListItemContent height="large" variant="large-icon">
+            <IconBlank />
+          </ListItemContent>
+        }
+        rightContent={
+          <ListItemContent variant="chevron">
+            값
+          </ListItemContent>
+        }
+      >
+        <ListText 
+          caption="캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션
+            캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션캡션"
+        >
+          텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트
+          텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트텍스트
+          텍스트텍스트텍스트텍스트
+        </ListText>
+      </ListCell>
+    </List>
+  )
+}
+
+export default Demo;`}
+/>
+
 ### Checkbox
 
 <Demo code={`import { List, Checkbox, ListCell, ListItemContent, ListText } from '@wanteddev/wds';

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -32,7 +32,7 @@ const Demo = () => {
           <Checkbox />
         </ListItemContent>
       )}>
-        <ListText caption="캡션">텍스트</ListText>
+        <ListText caption={{ children: "캡션" }}>텍스트</ListText>
       </ListCell>
     </List>
   )
@@ -295,7 +295,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText caption="캡션">텍스트, Large</ListText>
+        <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
       </ListCell>
       <ListCell
         alignItems="center"
@@ -310,7 +310,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText caption="캡션">텍스트, Large</ListText>
+        <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
       </ListCell>
       <ListCell
         alignItems="center"
@@ -332,7 +332,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText caption="캡션">텍스트, Large</ListText>
+        <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
       </ListCell>
     </List>
   )

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -150,7 +150,8 @@ export default Demo;`}
 
 ### LeftContent, RightContent
 
-기본적으로 leftContent, rightContent는 `ListItemContent` 로 래핑해서 사용해요.
+- 기본적으로 leftContent, rightContent는 `ListItemContent` 로 래핑해서 사용해요.
+- size로 콘텐츠 크기를 조정할 수 있어요.
 
 <Demo code={`import { Avatar, List, ListCell, ListText, ListItemContent, IconButton, NestedCheckbox, TextButton, ContentBadge, Switch } from '@wanteddev/wds';
 import { IconPlusThick, IconApps, IconBlank } from '@wanteddev/wds-icon';
@@ -159,62 +160,13 @@ const Demo = () => {
   return (
     <List gap="16px">
       <ListCell
-        leftContent={
-          <ListItemContent variant="avatar">
-            <Avatar variant="person" size="medium" />
-          </ListItemContent>
-        }
-        alignItems="center"
-      >
-        <ListText>텍스트</ListText>
-      </ListCell>
-      <ListCell
-        leftContent={
-          <ListItemContent variant="large-icon">
-            <IconBlank  />
-          </ListItemContent>
-        }
-        alignItems="center"
-      >
-        <ListText>텍스트</ListText>
-      </ListCell>
-      <ListCell
-        rightContent={
-          <ListItemContent variant="chevron">
-            값
-          </ListItemContent>
-        }
-      >
-        <ListText>텍스트</ListText>
-      </ListCell>
-      <ListCell
-        rightContent={
-          <ListItemContent variant="chevron" chevron={false}>
-            값
-          </ListItemContent>
-        }
-      >
-        <ListText>텍스트</ListText>
-      </ListCell>
-      <ListCell
         rightContent={
           <ListItemContent variant="icon">
             <IconApps />
           </ListItemContent>
         }
       >
-        <ListText>텍스트</ListText>
-      </ListCell>
-      <ListCell
-        rightContent={
-          <ListItemContent variant="icon-button">
-            <IconButton>
-              <IconPlusThick />
-            </IconButton>
-          </ListItemContent>
-        }
-      >
-        <ListText>텍스트</ListText>
+        <ListText>텍스트, Normal</ListText>
       </ListCell>
       <ListCell
         rightContent={
@@ -223,7 +175,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText>텍스트</ListText>
+        <ListText>텍스트, Normal</ListText>
       </ListCell>
       <ListCell
         rightContent={
@@ -234,16 +186,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText>텍스트</ListText>
-      </ListCell>
-      <ListCell
-        rightContent={
-          <ListItemContent variant="switch">
-            <Switch />
-          </ListItemContent>
-        }
-      >
-        <ListText>텍스트</ListText>
+        <ListText>텍스트, Normal</ListText>
       </ListCell>
       <ListCell
         rightContent={
@@ -252,7 +195,25 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText>텍스트</ListText>
+        <ListText>텍스트, Normal</ListText>
+      </ListCell>
+      <ListCell
+        rightContent={
+          <ListItemContent variant="chevron">
+            값
+          </ListItemContent>
+        }
+      >
+        <ListText>텍스트, Normal</ListText>
+      </ListCell>
+      <ListCell
+        rightContent={
+          <ListItemContent variant="chevron" chevron={false}>
+            값
+          </ListItemContent>
+        }
+      >
+        <ListText>텍스트, Normal</ListText>
       </ListCell>
       <ListCell
         rightContent={
@@ -261,7 +222,49 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText>텍스트</ListText>
+        <ListText>텍스트, Normal</ListText>
+      </ListCell>
+
+      <ListCell
+        leftContent={
+          <ListItemContent size="medium" variant="avatar">
+            <Avatar variant="person" size="medium" />
+          </ListItemContent>
+        }
+        alignItems="center"
+      >
+        <ListText>텍스트, Medium</ListText>
+      </ListCell>
+      <ListCell
+        rightContent={
+          <ListItemContent size="medium" variant="switch">
+            <Switch />
+          </ListItemContent>
+        }
+      >
+        <ListText>텍스트, Medium</ListText>
+      </ListCell>
+
+      <ListCell
+        leftContent={
+          <ListItemContent size="large" variant="large-icon">
+            <IconBlank  />
+          </ListItemContent>
+        }
+        alignItems="center"
+      >
+        <ListText>텍스트, Large</ListText>
+      </ListCell>
+      <ListCell
+        rightContent={
+          <ListItemContent size="large" variant="icon-button">
+            <IconButton>
+              <IconPlusThick />
+            </IconButton>
+          </ListItemContent>
+        }
+      >
+        <ListText>텍스트, Large</ListText>
       </ListCell>
     </List>
   )
@@ -269,7 +272,6 @@ const Demo = () => {
 
 export default Demo;`}
 />
-
 
 ### Checkbox
 

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -32,7 +32,7 @@ const Demo = () => {
           <Checkbox />
         </ListItemContent>
       )}>
-        <ListText caption={{ children: "캡션" }}>텍스트</ListText>
+        <ListText caption="캡션">텍스트</ListText>
       </ListCell>
     </List>
   )
@@ -302,7 +302,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
+        <ListText caption="캡션">텍스트, Large</ListText>
       </ListCell>
       <ListCell
         alignItems="center"
@@ -317,7 +317,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
+        <ListText caption="캡션">텍스트, Large</ListText>
       </ListCell>
       <ListCell
         leftContent={
@@ -338,7 +338,7 @@ const Demo = () => {
           </ListItemContent>
         }
       >
-        <ListText caption={{ children: '캡션' }}>텍스트, Large</ListText>
+        <ListText caption="캡션">텍스트, Large</ListText>
       </ListCell>
     </List>
   )

--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -499,7 +499,7 @@ AutocompleteList.displayName = AUTOCOMPLETE_LIST_NAME;
 const AutocompleteOption = forwardRef<
   HTMLLIElement,
   DefaultComponentProps<AutocompleteOptionProps, 'li'>
->(({ bold, caption, disabled, value, children, ...props }, forwardedRef) => {
+>(({ caption, disabled, value, children, ...props }, forwardedRef) => {
   const ref = useRef<HTMLLIElement>(null);
   const composedRefs = useComposedRefs(forwardedRef, ref);
 
@@ -560,9 +560,7 @@ const AutocompleteOption = forwardRef<
         })}
         onClick={composeEventHandlers(props.onClick, (e) => e.preventDefault())}
       >
-        <ListText caption={caption} bold={bold ?? active}>
-          {children}
-        </ListText>
+        <ListText caption={caption}>{children}</ListText>
       </ListCell>
     </Collection.ItemSlot>
   );

--- a/packages/wds/src/components/autocomplete/types.ts
+++ b/packages/wds/src/components/autocomplete/types.ts
@@ -33,7 +33,7 @@ export type AutocompleteListProps = ComponentPropsWithoutRef<
 export type AutocompleteOptionProps = Merge<
   { value: string },
   Omit<
-    ListCellProps & Pick<ListTextProps, 'bold' | 'caption'>,
+    ListCellProps & Pick<ListTextProps, 'caption'>,
     'rightContent' | 'leftContent'
   >
 >;

--- a/packages/wds/src/components/list/contexts.ts
+++ b/packages/wds/src/components/list/contexts.ts
@@ -2,10 +2,11 @@ import { createContext } from '@radix-ui/react-context';
 
 import { LIST_ITEM_NAME } from './constants';
 
-type ListItemContextType = {
-  active: boolean;
-  disabled: boolean;
-};
+import type { ListItemProps } from './types';
+
+type ListItemContextType = Required<
+  Pick<ListItemProps, 'active' | 'disabled' | 'ellipsis' | 'alignItems'>
+>;
 
 export const [ListItemProvider, useListItemContext] =
   createContext<ListItemContextType>(LIST_ITEM_NAME);

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -142,9 +142,7 @@ const ListItem = forwardRef(
         >
           {Boolean(leftContent) && leftContent}
           {children}
-          <FlexBox sx={{ margin: 'auto 0' }}>
-            {Boolean(rightContent) && rightContent}
-          </FlexBox>
+          {Boolean(rightContent) && rightContent}
         </FlexBox>
       </ListItemProvider>
     );
@@ -160,7 +158,7 @@ const ListItemContent = forwardRef<
   (
     {
       variant = 'custom',
-      size = 'normal',
+      height = 'normal',
       children,
       chevron = true,
       xl,
@@ -182,7 +180,7 @@ const ListItemContent = forwardRef<
             ref={ref}
             {...props}
             sx={[
-              listItemContentStyle({ size, xl, lg, md, sm, xs }),
+              listItemContentStyle({ height, xl, lg, md, sm, xs }),
               listItemContentIconStyle,
               sx,
             ]}
@@ -198,7 +196,7 @@ const ListItemContent = forwardRef<
             alignItems="center"
             ref={ref}
             {...props}
-            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
           >
             <FlexBox sx={listItemContentLargeIconBoxStyle}>{children}</FlexBox>
           </FlexBox>
@@ -211,7 +209,7 @@ const ListItemContent = forwardRef<
             alignItems="center"
             ref={ref}
             {...props}
-            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
           >
             <TextButtonProvider assistive="palette.label.alternative">
               {children}
@@ -226,7 +224,7 @@ const ListItemContent = forwardRef<
             alignItems="center"
             ref={ref}
             {...props}
-            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
           >
             <IconButtonProvider normal="palette.label.alternative">
               {children}
@@ -244,7 +242,7 @@ const ListItemContent = forwardRef<
             ref={ref}
             tabIndex={props.onClick ? 0 : -1}
             {...props}
-            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
           >
             {Boolean(children) && (
               <Typography
@@ -274,7 +272,7 @@ const ListItemContent = forwardRef<
             ref={ref}
             {...props}
             sx={[
-              listItemContentStyle({ variant, size, xl, lg, md, sm, xs }),
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
               sx,
             ]}
           >

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -23,8 +23,8 @@ import {
 import {
   listCellDividerStyle,
   listCellStyle,
-  listItemContentLargeIconStyle,
-  listItemContentPaddingStyle,
+  listItemContentIconStyle,
+  listItemContentLargeIconBoxStyle,
   listItemContentStyle,
   listItemStyle,
   listStyle,
@@ -156,139 +156,134 @@ ListItem.displayName = LIST_ITEM_NAME;
 const ListItemContent = forwardRef<
   HTMLDivElement,
   DefaultComponentProps<ListItemContentProps, 'div'>
->(({ variant = 'custom', children, chevron = true, ...props }, ref) => {
-  switch (variant) {
-    case 'icon':
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          ref={ref}
-          alignItems="center"
-          {...props}
-          sx={[
-            listItemContentStyle,
-            (theme) => ({
-              fontSize: '24px',
-              color: theme.palette.label.assistive,
-            }),
-            props.sx,
-          ]}
-        >
-          {children}
-        </FlexBox>
-      );
-    case 'icon-button':
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          ref={ref}
-          alignItems="center"
-          {...props}
-          sx={[listItemContentStyle, props.sx]}
-        >
-          <IconButtonProvider normal="palette.label.alternative">
+>(
+  (
+    {
+      variant = 'custom',
+      size = 'normal',
+      children,
+      chevron = true,
+      xl,
+      lg,
+      md,
+      sm,
+      xs,
+      sx,
+      ...props
+    },
+    ref,
+  ) => {
+    switch (variant) {
+      case 'icon':
+        return (
+          <FlexBox
+            wds-component="list-item-content"
+            alignItems="center"
+            ref={ref}
+            {...props}
+            sx={[
+              listItemContentStyle({ size, xl, lg, md, sm, xs }),
+              listItemContentIconStyle,
+              sx,
+            ]}
+          >
             {children}
-          </IconButtonProvider>
-        </FlexBox>
-      );
+          </FlexBox>
+        );
 
-    case 'radio':
-    case 'checkbox':
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          ref={ref}
-          alignItems="center"
-          {...props}
-          sx={[listItemContentStyle, props.sx]}
-        >
-          {children}
-        </FlexBox>
-      );
-    case 'large-icon':
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          ref={ref}
-          alignItems="center"
-          {...props}
-          sx={[listItemContentLargeIconStyle, props.sx]}
-        >
-          {children}
-        </FlexBox>
-      );
-    case 'avatar':
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          ref={ref}
-          alignItems="center"
-          {...props}
-          sx={[listItemContentPaddingStyle, props.sx]}
-        >
-          {children}
-        </FlexBox>
-      );
-    case 'button':
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          ref={ref}
-          alignItems="center"
-          {...props}
-          sx={[listItemContentStyle, props.sx]}
-        >
-          <TextButtonProvider assistive="palette.label.alternative">
-            {children}
-          </TextButtonProvider>
-        </FlexBox>
-      );
-    case 'chevron':
-      return (
-        <FlexBox
-          role="button"
-          alignItems="center"
-          wds-component="list-item-content"
-          gap="8px"
-          ref={ref}
-          tabIndex={props.onClick ? 0 : -1}
-          {...props}
-          sx={[listItemContentStyle, props.sx]}
-        >
-          {Boolean(children) && (
-            <Typography
-              variant="body1_normal"
-              color="palette.label.alternative"
-            >
+      case 'large-icon':
+        return (
+          <FlexBox
+            wds-component="list-item-content"
+            alignItems="center"
+            ref={ref}
+            {...props}
+            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+          >
+            <FlexBox sx={listItemContentLargeIconBoxStyle}>{children}</FlexBox>
+          </FlexBox>
+        );
+
+      case 'button':
+        return (
+          <FlexBox
+            wds-component="list-item-content"
+            alignItems="center"
+            ref={ref}
+            {...props}
+            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+          >
+            <TextButtonProvider assistive="palette.label.alternative">
               {children}
-            </Typography>
-          )}
+            </TextButtonProvider>
+          </FlexBox>
+        );
 
-          {chevron && (
-            <IconChevronRightTightSmall
-              sx={(theme) => ({
-                color: theme.palette.label.assistive,
-              })}
-            />
-          )}
-        </FlexBox>
-      );
-    case 'switch':
-    case 'custom':
-    default:
-      return (
-        <FlexBox
-          wds-component="list-item-content"
-          alignItems="center"
-          ref={ref}
-          {...props}
-          sx={[listItemContentStyle, props.sx]}
-        >
-          {children}
-        </FlexBox>
-      );
-  }
-});
+      case 'icon-button':
+        return (
+          <FlexBox
+            wds-component="list-item-content"
+            alignItems="center"
+            ref={ref}
+            {...props}
+            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+          >
+            <IconButtonProvider normal="palette.label.alternative">
+              {children}
+            </IconButtonProvider>
+          </FlexBox>
+        );
+
+      case 'chevron':
+        return (
+          <FlexBox
+            role="button"
+            alignItems="center"
+            wds-component="list-item-content"
+            gap="8px"
+            ref={ref}
+            tabIndex={props.onClick ? 0 : -1}
+            {...props}
+            sx={[listItemContentStyle({ size, xl, lg, md, sm, xs }), sx]}
+          >
+            {Boolean(children) && (
+              <Typography
+                variant="body1_normal"
+                color="palette.label.alternative"
+              >
+                {children}
+              </Typography>
+            )}
+
+            {chevron && (
+              <IconChevronRightTightSmall
+                sx={(theme) => ({
+                  color: theme.palette.label.assistive,
+                })}
+              />
+            )}
+          </FlexBox>
+        );
+
+      case 'custom':
+      default:
+        return (
+          <FlexBox
+            wds-component="list-item-content"
+            alignItems="center"
+            ref={ref}
+            {...props}
+            sx={[
+              listItemContentStyle({ variant, size, xl, lg, md, sm, xs }),
+              sx,
+            ]}
+          >
+            {children}
+          </FlexBox>
+        );
+    }
+  },
+);
 
 ListItemContent.displayName = LIST_ITEM_CONTENT_NAME;
 

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -349,24 +349,18 @@ ListCell.displayName = LIST_CELL_NAME;
 
 const ListText = forwardRef(
   <E extends ElementType = 'p'>(
-    {
-      caption,
-      bold,
-      children,
-      color,
-      ...props
-    }: PolymorphicProps<ListTextProps, E>,
+    { caption, children, color, ...props }: PolymorphicProps<ListTextProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
     const { active, disabled } = useListItemContext(LIST_TEXT_NAME);
-    const { bold: menuItemBold } = useMenuItemContext() || {};
+    const { active: menuItemActive } = useMenuItemContext() || {};
 
     if (!children) {
       return null;
     }
 
     const weight: TypographyWeight =
-      bold ?? menuItemBold ? 'medium' : 'regular';
+      active || menuItemActive ? 'medium' : 'regular';
 
     const getTextColor = (): ThemeColorsToken => {
       if (disabled) {
@@ -390,6 +384,7 @@ const ListText = forwardRef(
         sx={[{ overflow: 'hidden' }, props.sx]}
       >
         <Typography
+          data-role="list-text-title"
           variant="body1_normal"
           color={getTextColor()}
           weight={weight}
@@ -400,9 +395,9 @@ const ListText = forwardRef(
 
         {Boolean(caption) && (
           <Typography
+            data-role="list-text-caption"
             variant="label1_normal"
             color="palette.label.alternative"
-            weight={weight}
             sx={{ overflowWrap: 'anywhere', wordBreak: 'keep-all' }}
           >
             {caption}

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -29,7 +29,7 @@ import {
   listItemContentStyle,
   listItemStyle,
   listStyle,
-  listTextStyle,
+  listTextEllipsisStyle,
 } from './style';
 import { ListItemProvider, useListItemContext } from './contexts';
 
@@ -349,7 +349,14 @@ ListCell.displayName = LIST_CELL_NAME;
 
 const ListText = forwardRef(
   <E extends ElementType = 'p'>(
-    { caption, children, color, ...props }: PolymorphicProps<ListTextProps, E>,
+    {
+      color,
+      ellipsis = false,
+      children,
+      caption,
+      sx,
+      ...props
+    }: PolymorphicProps<ListTextProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
     const { active, disabled } = useListItemContext(LIST_TEXT_NAME);
@@ -381,27 +388,25 @@ const ListText = forwardRef(
         flex="1"
         as="p"
         {...props}
-        sx={[{ overflow: 'hidden' }, props.sx]}
+        sx={{ overflow: 'hidden' }}
       >
         <Typography
-          data-role="list-text-title"
           variant="body1_normal"
           color={getTextColor()}
           weight={weight}
-          sx={listTextStyle}
+          sx={[ellipsis && listTextEllipsisStyle, sx]}
+          {...props}
         >
           {children}
         </Typography>
 
         {Boolean(caption) && (
           <Typography
-            data-role="list-text-caption"
             variant="label1_normal"
             color="palette.label.alternative"
-            sx={{ overflowWrap: 'anywhere', wordBreak: 'keep-all' }}
-          >
-            {caption}
-          </Typography>
+            {...caption}
+            sx={[ellipsis && listTextEllipsisStyle, caption?.sx]}
+          />
         )}
       </FlexBox>
     );

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -24,8 +24,6 @@ import {
 import {
   listCellDividerStyle,
   listCellStyle,
-  listItemContentIconStyle,
-  listItemContentLargeIconBoxStyle,
   listItemContentStyle,
   listItemStyle,
   listStyle,
@@ -179,12 +177,11 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="center"
+            alignItems="flex-start"
             ref={ref}
             {...props}
             sx={[
-              listItemContentStyle({ height, xl, lg, md, sm, xs }),
-              listItemContentIconStyle,
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
               sx,
             ]}
           >
@@ -196,12 +193,15 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="center"
+            alignItems="flex-start"
             ref={ref}
             {...props}
-            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
+            sx={[
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
+              sx,
+            ]}
           >
-            <FlexBox sx={listItemContentLargeIconBoxStyle}>{children}</FlexBox>
+            <FlexBox>{children}</FlexBox>
           </FlexBox>
         );
 
@@ -209,10 +209,13 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="center"
+            alignItems="flex-start"
             ref={ref}
             {...props}
-            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
+            sx={[
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
+              sx,
+            ]}
           >
             <TextButtonProvider assistive="palette.label.alternative">
               {children}
@@ -224,10 +227,13 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="center"
+            alignItems="flex-start"
             ref={ref}
             {...props}
-            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
+            sx={[
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
+              sx,
+            ]}
           >
             <IconButtonProvider normal="palette.label.alternative">
               {children}
@@ -239,12 +245,11 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="center"
+            alignItems="flex-start"
             ref={ref}
             {...props}
             sx={[
               listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
-              { paddingRight: '8px' },
               sx,
             ]}
           >
@@ -262,7 +267,10 @@ const ListItemContent = forwardRef<
             ref={ref}
             tabIndex={props.onClick ? 0 : -1}
             {...props}
-            sx={[listItemContentStyle({ height, xl, lg, md, sm, xs }), sx]}
+            sx={[
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
+              sx,
+            ]}
           >
             {Boolean(children) && (
               <Typography
@@ -288,7 +296,7 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="center"
+            alignItems="flex-start"
             ref={ref}
             {...props}
             sx={[

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -315,6 +315,7 @@ const ListCell = forwardRef(
       children,
       disabled,
       disableInteraction,
+      interactionPadding = fillWidth ? undefined : '12px',
       xs,
       sm,
       md,
@@ -332,7 +333,16 @@ const ListCell = forwardRef(
           disabled={disabled}
           {...props}
           sx={[
-            listCellStyle({ padding, fillWidth, xs, sm, md, lg, xl }),
+            listCellStyle({
+              padding,
+              fillWidth,
+              interactionPadding,
+              xs,
+              sm,
+              md,
+              lg,
+              xl,
+            }),
             props.sx,
           ]}
         >

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -7,6 +7,7 @@ import {
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { IconChevronRightTightSmall } from '@wanteddev/wds-icon';
+import { Slot } from '@radix-ui/react-slot';
 
 import { Divider, FlexBox, Typography, WithInteraction } from '..';
 import { useMenuItemContext } from '../menu/contexts';
@@ -142,7 +143,9 @@ const ListItem = forwardRef(
         >
           {Boolean(leftContent) && leftContent}
           {children}
-          {Boolean(rightContent) && rightContent}
+          {Boolean(rightContent) && (
+            <Slot data-role="list-item-right-content">{rightContent}</Slot>
+          )}
         </FlexBox>
       </ListItemProvider>
     );
@@ -229,6 +232,23 @@ const ListItemContent = forwardRef<
             <IconButtonProvider normal="palette.label.alternative">
               {children}
             </IconButtonProvider>
+          </FlexBox>
+        );
+
+      case 'avatar':
+        return (
+          <FlexBox
+            wds-component="list-item-content"
+            alignItems="center"
+            ref={ref}
+            {...props}
+            sx={[
+              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
+              { padding: '8px' },
+              sx,
+            ]}
+          >
+            {children}
           </FlexBox>
         );
 

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -364,6 +364,7 @@ const ListText = forwardRef(
       color,
       children,
       caption,
+      captionProps,
       sx,
       ...props
     }: PolymorphicProps<ListTextProps, E>,
@@ -414,9 +415,11 @@ const ListText = forwardRef(
           <Typography
             variant="label1_normal"
             color="palette.label.alternative"
-            {...caption}
-            sx={[ellipsis && listTextEllipsisStyle, caption?.sx]}
-          />
+            {...captionProps}
+            sx={[ellipsis && listTextEllipsisStyle, captionProps?.sx]}
+          >
+            {caption}
+          </Typography>
         )}
       </FlexBox>
     );

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -244,7 +244,7 @@ const ListItemContent = forwardRef<
             {...props}
             sx={[
               listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
-              { padding: '8px' },
+              { paddingRight: '8px' },
               sx,
             ]}
           >
@@ -370,7 +370,7 @@ const ListText = forwardRef(
 
     const getTextColor = (): ThemeColorsToken => {
       if (disabled) {
-        return 'palette.label.disable';
+        return 'palette.label.alternative';
       }
       if (active) {
         return 'palette.primary.normal';
@@ -401,9 +401,7 @@ const ListText = forwardRef(
         {Boolean(caption) && (
           <Typography
             variant="label1_normal"
-            color={
-              disabled ? 'palette.label.disable' : 'palette.label.alternative'
-            }
+            color="palette.label.alternative"
             weight={weight}
             sx={{ overflowWrap: 'anywhere', wordBreak: 'keep-all' }}
           >

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -107,7 +107,7 @@ const ListItem = forwardRef(
           gap="8px"
           aria-disabled={disabled}
           disabled={disabled}
-          tabIndex={clickable ? 0 : -1}
+          tabIndex={clickable ? 0 : undefined}
           {...props}
           onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
             if (
@@ -147,7 +147,7 @@ const ListItem = forwardRef(
               }
             }
           })}
-          sx={[listItemStyle({ active, disabled, clickable }), props.sx]}
+          sx={[listItemStyle({ active, disabled }), props.sx]}
         >
           {Boolean(leftContent) && leftContent}
           {children}
@@ -336,6 +336,8 @@ const ListCell = forwardRef(
             listCellStyle({
               padding,
               fillWidth,
+              disabled,
+              disableInteraction,
               interactionPadding,
               xs,
               sm,

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -72,6 +72,8 @@ const ListItem = forwardRef(
       rightContent,
       active = false,
       disabled = false,
+      ellipsis = false,
+      alignItems: alignItemsProp,
       children,
       ...props
     }: PolymorphicProps<ListItemProps, E>,
@@ -87,13 +89,21 @@ const ListItem = forwardRef(
     );
     const clickable = Boolean(props.onClick || controllable) && !disabled;
 
+    const alignItems = alignItemsProp ?? ellipsis ? 'center' : 'flex-start';
+
     return (
-      <ListItemProvider active={active} disabled={disabled}>
+      <ListItemProvider
+        active={active}
+        disabled={disabled}
+        ellipsis={ellipsis}
+        alignItems={alignItems}
+      >
         <FlexBox
           as={(as || 'li') as E}
           role="listitem"
           ref={composedRefs}
           flexDirection="row"
+          alignItems={alignItems}
           gap="8px"
           aria-disabled={disabled}
           disabled={disabled}
@@ -172,28 +182,14 @@ const ListItemContent = forwardRef<
     },
     ref,
   ) => {
-    switch (variant) {
-      case 'icon':
-        return (
-          <FlexBox
-            wds-component="list-item-content"
-            alignItems="flex-start"
-            ref={ref}
-            {...props}
-            sx={[
-              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
-              sx,
-            ]}
-          >
-            {children}
-          </FlexBox>
-        );
+    const { alignItems } = useListItemContext(LIST_ITEM_CONTENT_NAME);
 
+    switch (variant) {
       case 'large-icon':
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="flex-start"
+            alignItems={alignItems}
             ref={ref}
             {...props}
             sx={[
@@ -209,7 +205,7 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="flex-start"
+            alignItems={alignItems}
             ref={ref}
             {...props}
             sx={[
@@ -227,7 +223,7 @@ const ListItemContent = forwardRef<
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="flex-start"
+            alignItems={alignItems}
             ref={ref}
             {...props}
             sx={[
@@ -241,62 +237,59 @@ const ListItemContent = forwardRef<
           </FlexBox>
         );
 
-      case 'avatar':
-        return (
-          <FlexBox
-            wds-component="list-item-content"
-            alignItems="flex-start"
-            ref={ref}
-            {...props}
-            sx={[
-              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
-              sx,
-            ]}
-          >
-            {children}
-          </FlexBox>
-        );
-
       case 'chevron':
         return (
           <FlexBox
             role="button"
-            alignItems="center"
+            alignItems={alignItems}
             wds-component="list-item-content"
             gap="8px"
             ref={ref}
             tabIndex={props.onClick ? 0 : -1}
             {...props}
-            sx={[
-              listItemContentStyle({ variant, height, xl, lg, md, sm, xs }),
-              sx,
-            ]}
+            sx={sx}
           >
             {Boolean(children) && (
-              <Typography
-                variant="body1_normal"
-                color="palette.label.alternative"
+              <FlexBox
+                justifyContent="flex-end"
+                alignItems={alignItems}
+                sx={listItemContentStyle({
+                  variant,
+                  height,
+                  xl,
+                  lg,
+                  md,
+                  sm,
+                  xs,
+                })}
               >
                 {children}
-              </Typography>
+              </FlexBox>
             )}
-
             {chevron && (
-              <IconChevronRightTightSmall
-                sx={(theme) => ({
-                  color: theme.palette.label.assistive,
-                })}
-              />
+              <FlexBox alignItems="center" sx={{ height: '24px' }}>
+                <IconChevronRightTightSmall
+                  sx={(theme) => ({
+                    color: theme.palette.label.assistive,
+                  })}
+                />
+              </FlexBox>
             )}
           </FlexBox>
         );
 
+      case 'icon':
+      case 'avatar':
+      case 'badge':
+      case 'checkbox':
+      case 'radio':
+      case 'switch':
       case 'custom':
       default:
         return (
           <FlexBox
             wds-component="list-item-content"
-            alignItems="flex-start"
+            alignItems={alignItems}
             ref={ref}
             {...props}
             sx={[
@@ -359,7 +352,6 @@ const ListText = forwardRef(
   <E extends ElementType = 'p'>(
     {
       color,
-      ellipsis = false,
       children,
       caption,
       sx,
@@ -367,7 +359,7 @@ const ListText = forwardRef(
     }: PolymorphicProps<ListTextProps, E>,
     ref: ForwardedRef<ElementRef<E>>,
   ) => {
-    const { active, disabled } = useListItemContext(LIST_TEXT_NAME);
+    const { active, disabled, ellipsis } = useListItemContext(LIST_TEXT_NAME);
     const { active: menuItemActive } = useMenuItemContext() || {};
 
     if (!children) {

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -41,7 +41,7 @@ export const listItemStyle =
         `}
   `;
 
-export const listTextStyle = css`
+export const listTextEllipsisStyle = css`
   ${ellipsisTypographyStyle(1)}
   white-space: nowrap;
   overflow-wrap: anywhere;

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -21,13 +21,7 @@ export const listStyle = css`
 `;
 
 export const listItemStyle =
-  ({
-    active,
-    disabled,
-    clickable,
-  }: ListItemProps & {
-    clickable: boolean;
-  }) =>
+  ({ active, disabled }: ListItemProps) =>
   (theme: Theme) => css`
     width: 100%;
 
@@ -39,7 +33,6 @@ export const listItemStyle =
           opacity: ${theme.opacity[43]};
         `
       : css`
-          cursor: ${clickable ? 'pointer' : 'initial'};
           color: ${active
             ? theme.palette.primary.normal
             : theme.palette.label.normal};
@@ -57,6 +50,8 @@ export const listCellStyle =
   ({
     padding,
     fillWidth,
+    disabled,
+    disableInteraction,
     interactionPadding,
     xs,
     sm,
@@ -65,6 +60,12 @@ export const listCellStyle =
     xl,
   }: ListCellProps) =>
   (theme: Theme) => css`
+    ${!disabled &&
+    !disableInteraction &&
+    css`
+      cursor: pointer;
+    `}
+
     ${listCellPaddingStyle({ padding })}
     ${listCellFillWidthStyle({ fillWidth })}
     ${listCellInteractionPaddingStyle({ fillWidth, interactionPadding })}

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -1,6 +1,10 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle, ellipsisTypographyStyle } from '../../utils';
+import {
+  createResponsiveStyle,
+  ellipsisTypographyStyle,
+  typographyStyle,
+} from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type {
@@ -51,13 +55,11 @@ export const listTextEllipsisStyle = css`
 export const listCellStyle =
   ({ padding, fillWidth, xs, sm, md, lg, xl }: ListCellProps) =>
   (theme: Theme) => css`
-    border-radius: 12px;
-
     ${listCellPaddingStyle({ padding })}
     ${listCellFillWidthStyle({ fillWidth })}
 
-
     & > [wds-component='with-interaction'] {
+      border-radius: inherit;
       display: var(--wds-list-cell-interaction-display, block);
     }
 
@@ -127,6 +129,7 @@ const listCellFillWidthStyle = ({
       return css`
         padding-right: 0px;
         padding-left: 0px;
+        border-radius: 12px;
 
         & > [wds-component='with-interaction'] {
           width: calc(100% + 24px);
@@ -214,6 +217,13 @@ const listItemContentVariantStyle =
             font-size: 32px;
             overflow-y: clip;
           }
+        `;
+
+      case 'chevron':
+        return css`
+          ${typographyStyle('body1_normal', 'regular')}
+          color: ${theme.palette.label.alternative};
+          overflow-y: clip;
         `;
 
       default:

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -3,7 +3,11 @@ import { css } from '@wanteddev/wds-engine';
 import { createResponsiveStyle, ellipsisTypographyStyle } from '../../utils';
 
 import type { Theme } from '@wanteddev/wds-engine';
-import type { ListCellProps, ListItemProps } from './types';
+import type {
+  ListCellProps,
+  ListItemContentProps,
+  ListItemProps,
+} from './types';
 
 export const listStyle = css`
   list-style: none;
@@ -142,33 +146,75 @@ export const listCellDividerStyle = css`
   width: 100%;
 `;
 
-export const listItemContentStyle = css`
-  max-height: 24px;
-  flex-shrink: 0;
-  width: fit-content;
-  height: fit-content;
-  position: relative;
+const listItemContentSizeStyle = ({
+  size,
+}: Pick<ListItemContentProps, 'size'>) => {
+  switch (size) {
+    case 'medium':
+      return css`
+        min-width: 40px;
+        max-width: max-content;
+        height: 40px;
+        max-height: 40px;
+        overflow-y: clip;
+      `;
 
-  [wds-component='with-interaction'] {
-    z-index: 1;
+    case 'large':
+      return css`
+        min-width: 56px;
+        max-width: max-content;
+        height: 56px;
+        max-height: 56px;
+        overflow-y: clip;
+      `;
+
+    case 'normal':
+    default:
+      return css`
+        min-width: 24px;
+        max-width: max-content;
+        height: 24px;
+        max-height: 24px;
+        overflow-y: clip;
+      `;
   }
-`;
+};
 
-export const listItemContentPaddingStyle = css`
-  flex-shrink: 0;
-  width: fit-content;
-  height: fit-content;
-  padding-right: 8px;
-`;
+export const listItemContentStyle =
+  ({ size, xl, lg, md, sm, xs }: ListItemContentProps) =>
+  (theme: Theme) => css`
+    flex-shrink: 0;
+    position: relative;
 
-export const listItemContentLargeIconStyle = (theme: Theme) => css`
+    [wds-component='with-interaction'] {
+      z-index: 1;
+    }
+
+    ${listItemContentSizeStyle({ size })}
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        ${listItemContentSizeStyle({ size: params?.size })}
+        ${params?.sx}
+      `,
+    )}
+  `;
+
+export const listItemContentLargeIconBoxStyle = (theme: Theme) => css`
   flex-shrink: 0;
   width: fit-content;
   height: fit-content;
   border-radius: 12px;
   padding: 8px;
-  margin-right: 8px;
   color: ${theme.palette.primary.normal};
   background-color: ${theme.palette.fill.normal};
   font-size: 32px;
+`;
+
+export const listItemContentIconStyle = (theme: Theme) => css`
+  color: ${theme.palette.label.alternative};
+  font-size: 24px;
 `;

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -3,6 +3,7 @@ import { css } from '@wanteddev/wds-engine';
 import {
   createResponsiveStyle,
   ellipsisTypographyStyle,
+  getPreviousValue,
   typographyStyle,
 } from '../../utils';
 
@@ -53,11 +54,21 @@ export const listTextEllipsisStyle = css`
 `;
 
 export const listCellStyle =
-  ({ padding, fillWidth, xs, sm, md, lg, xl }: ListCellProps) =>
+  ({
+    padding,
+    fillWidth,
+    interactionPadding,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+  }: ListCellProps) =>
   (theme: Theme) => css`
     ${listCellPaddingStyle({ padding })}
     ${listCellFillWidthStyle({ fillWidth })}
-
+    ${listCellInteractionPaddingStyle({ fillWidth, interactionPadding })}
+    
     & > [wds-component='with-interaction'] {
       border-radius: inherit;
       display: var(--wds-list-cell-interaction-display, block);
@@ -67,13 +78,44 @@ export const listCellStyle =
       { xs, sm, md, lg, xl },
       theme,
     )(
-      (params) => css`
+      (params, breakpoint) => css`
         ${listCellPaddingStyle({ padding: params?.padding })}
-        ${listCellFillWidthStyle({ fillWidth: params?.fillWidth })}
+        ${listCellFillWidthStyle({
+          fillWidth: params?.fillWidth,
+        })}
+        ${listCellInteractionPaddingStyle({
+          fillWidth: getPreviousValue(
+            { xs, sm, md, lg, xl },
+            'fillWidth',
+            fillWidth,
+            breakpoint!,
+          ),
+          interactionPadding: params?.interactionPadding,
+        })}
         ${params?.sx}
       `,
     )}
   `;
+
+const listCellInteractionPaddingStyle = ({
+  fillWidth,
+  interactionPadding,
+}: Pick<ListCellProps, 'fillWidth' | 'interactionPadding'>) => {
+  if (fillWidth) {
+    return css`
+      & > [wds-component='with-interaction'] {
+        width: 100%;
+      }
+    `;
+  }
+  return css`
+    --wds-list-cell-interaction-padding: ${interactionPadding ?? '12px'};
+
+    & > [wds-component='with-interaction'] {
+      width: calc(100% + (var(--wds-list-cell-interaction-padding) * 2));
+    }
+  `;
+};
 
 const listCellPaddingStyle = ({ padding }: Pick<ListCellProps, 'padding'>) => {
   switch (padding) {
@@ -117,10 +159,6 @@ const listCellFillWidthStyle = ({
         padding-right: 20px;
         padding-left: 20px;
 
-        & > [wds-component='with-interaction'] {
-          width: 100%;
-        }
-
         & > [data-role='list-cell-divider'] {
           width: calc(100% - 40px);
         }
@@ -130,10 +168,6 @@ const listCellFillWidthStyle = ({
         padding-right: 0px;
         padding-left: 0px;
         border-radius: 12px;
-
-        & > [wds-component='with-interaction'] {
-          width: calc(100% + 24px);
-        }
 
         & > [data-role='list-cell-divider'] {
           width: 100%;

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -29,8 +29,9 @@ export const listItemStyle =
     ${disabled
       ? css`
           cursor: initial;
-          color: ${theme.palette.label.disable};
           pointer-events: none;
+          color: ${theme.palette.label.alternative};
+          opacity: ${theme.opacity[43]};
         `
       : css`
           cursor: ${clickable ? 'pointer' : 'initial'};

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -157,7 +157,6 @@ const listItemContentSizeStyle = ({
         max-width: max-content;
         height: 40px;
         max-height: 40px;
-        overflow-y: clip;
       `;
 
     case 'large':
@@ -166,7 +165,6 @@ const listItemContentSizeStyle = ({
         max-width: max-content;
         height: 56px;
         max-height: 56px;
-        overflow-y: clip;
       `;
 
     case 'normal':
@@ -176,13 +174,57 @@ const listItemContentSizeStyle = ({
         max-width: max-content;
         height: 24px;
         max-height: 24px;
-        overflow-y: clip;
       `;
   }
 };
 
+const listItemContentVariantStyle =
+  ({ variant }: Pick<ListItemContentProps, 'variant'>) =>
+  (theme: Theme) => {
+    switch (variant) {
+      case 'button':
+      case 'radio':
+      case 'checkbox':
+      case 'icon-button':
+        return;
+
+      case 'icon':
+        return css`
+          color: ${theme.palette.label.alternative};
+          font-size: 24px;
+          overflow-y: clip;
+        `;
+
+      case 'avatar':
+        return css`
+          padding-right: 8px;
+          overflow-y: clip;
+        `;
+
+      case 'large-icon':
+        return css`
+          & > div {
+            flex-shrink: 0;
+            width: fit-content;
+            height: fit-content;
+            border-radius: 12px;
+            padding: 8px;
+            color: ${theme.palette.primary.normal};
+            background-color: ${theme.palette.fill.normal};
+            font-size: 32px;
+            overflow-y: clip;
+          }
+        `;
+
+      default:
+        return css`
+          overflow-y: clip;
+        `;
+    }
+  };
+
 export const listItemContentStyle =
-  ({ height, xl, lg, md, sm, xs }: ListItemContentProps) =>
+  ({ variant, height, xl, lg, md, sm, xs }: ListItemContentProps) =>
   (theme: Theme) => css`
     flex-shrink: 0;
     position: relative;
@@ -195,6 +237,7 @@ export const listItemContentStyle =
       z-index: 1;
     }
 
+    ${listItemContentVariantStyle({ variant })(theme)}
     ${listItemContentSizeStyle({ height })}
 
     ${createResponsiveStyle(
@@ -207,19 +250,3 @@ export const listItemContentStyle =
       `,
     )}
   `;
-
-export const listItemContentLargeIconBoxStyle = (theme: Theme) => css`
-  flex-shrink: 0;
-  width: fit-content;
-  height: fit-content;
-  border-radius: 12px;
-  padding: 8px;
-  color: ${theme.palette.primary.normal};
-  background-color: ${theme.palette.fill.normal};
-  font-size: 32px;
-`;
-
-export const listItemContentIconStyle = (theme: Theme) => css`
-  color: ${theme.palette.label.alternative};
-  font-size: 24px;
-`;

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -147,9 +147,9 @@ export const listCellDividerStyle = css`
 `;
 
 const listItemContentSizeStyle = ({
-  size,
-}: Pick<ListItemContentProps, 'size'>) => {
-  switch (size) {
+  height,
+}: Pick<ListItemContentProps, 'height'>) => {
+  switch (height) {
     case 'medium':
       return css`
         min-width: 40px;
@@ -181,7 +181,7 @@ const listItemContentSizeStyle = ({
 };
 
 export const listItemContentStyle =
-  ({ size, xl, lg, md, sm, xs }: ListItemContentProps) =>
+  ({ height, xl, lg, md, sm, xs }: ListItemContentProps) =>
   (theme: Theme) => css`
     flex-shrink: 0;
     position: relative;
@@ -190,14 +190,14 @@ export const listItemContentStyle =
       z-index: 1;
     }
 
-    ${listItemContentSizeStyle({ size })}
+    ${listItemContentSizeStyle({ height })}
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
       theme,
     )(
       (params) => css`
-        ${listItemContentSizeStyle({ size: params?.size })}
+        ${listItemContentSizeStyle({ height: params?.height })}
         ${params?.sx}
       `,
     )}

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -186,6 +186,10 @@ export const listItemContentStyle =
     flex-shrink: 0;
     position: relative;
 
+    &[data-role='list-item-right-content'] {
+      justify-content: flex-end;
+    }
+
     [wds-component='with-interaction'] {
       z-index: 1;
     }

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -61,6 +61,5 @@ export type ListCellProps = Merge<
 
 export type ListTextProps = {
   caption?: ReactNode;
-  bold?: boolean;
   color?: ThemeColorsToken;
 };

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -62,6 +62,7 @@ export type ListCellProps = Merge<
 export type ListTextProps = Merge<
   TypographyProps,
   {
-    caption?: ComponentProps<typeof Typography>;
+    caption?: ReactNode;
+    captionProps?: ComponentProps<typeof Typography>;
   }
 >;

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -47,6 +47,9 @@ export type ListCellDefaultProps = {
   divider?: boolean;
   disabled?: boolean;
   disableInteraction?: boolean;
+  /**
+   * fillWidth가 false일 때 인터랙션의 좌우 패딩을 지정할 수 있습니다.
+   */
   interactionPadding?: CSSProperties['paddingLeft'];
 };
 

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -1,9 +1,7 @@
-import type {
-  Merge,
-  ResponsiveProps,
-  ThemeColorsToken,
-} from '@wanteddev/wds-engine';
-import type { ReactNode } from 'react';
+import type Typography from '../typography';
+import type { TypographyProps } from '../typography/types';
+import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
+import type { ComponentProps, ReactNode } from 'react';
 import type { FlexBoxProps } from '../flex-box/types';
 
 export type ListProps = FlexBoxProps;
@@ -59,7 +57,10 @@ export type ListCellProps = Merge<
   ListItemProps
 >;
 
-export type ListTextProps = {
-  caption?: ReactNode;
-  color?: ThemeColorsToken;
-};
+export type ListTextProps = Merge<
+  TypographyProps,
+  {
+    ellipsis?: boolean;
+    caption?: ComponentProps<typeof Typography>;
+  }
+>;

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -11,6 +11,7 @@ export type ListItemDefaultProps = {
   rightContent?: ReactNode;
   active?: boolean;
   disabled?: boolean;
+  ellipsis?: boolean;
 };
 
 export type ListItemProps = Merge<ListItemDefaultProps, FlexBoxProps>;
@@ -60,7 +61,6 @@ export type ListCellProps = Merge<
 export type ListTextProps = Merge<
   TypographyProps,
   {
-    ellipsis?: boolean;
     caption?: ComponentProps<typeof Typography>;
   }
 >;

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -17,7 +17,7 @@ export type ListItemDefaultProps = {
 
 export type ListItemProps = Merge<ListItemDefaultProps, FlexBoxProps>;
 
-export type ListItemContentProps = {
+export type ListItemContentDefaultProps = {
   variant?:
     | 'icon'
     | 'radio'
@@ -30,9 +30,17 @@ export type ListItemContentProps = {
     | 'avatar'
     | 'large-icon'
     | 'custom';
+  size?: 'normal' | 'medium' | 'large';
   disabled?: boolean;
   chevron?: boolean;
 };
+export type ListItemContentResponsiveProps = ResponsiveProps<
+  Pick<ListItemContentDefaultProps, 'size'>
+>;
+export type ListItemContentProps = Merge<
+  ListItemContentDefaultProps,
+  ListItemContentResponsiveProps
+>;
 
 export type ListCellDefaultProps = {
   padding?: '12px' | '8px' | '16px' | '0px';

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -1,7 +1,7 @@
 import type Typography from '../typography';
 import type { TypographyProps } from '../typography/types';
 import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
-import type { ComponentProps, ReactNode } from 'react';
+import type { CSSProperties, ComponentProps, ReactNode } from 'react';
 import type { FlexBoxProps } from '../flex-box/types';
 
 export type ListProps = FlexBoxProps;
@@ -47,10 +47,11 @@ export type ListCellDefaultProps = {
   divider?: boolean;
   disabled?: boolean;
   disableInteraction?: boolean;
+  interactionPadding?: CSSProperties['paddingLeft'];
 };
 
 export type ListCellResponsiveProps = ResponsiveProps<
-  Pick<ListCellDefaultProps, 'padding' | 'fillWidth'>
+  Pick<ListCellDefaultProps, 'padding' | 'fillWidth' | 'interactionPadding'>
 >;
 
 export type ListCellProps = Merge<

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -30,12 +30,12 @@ export type ListItemContentDefaultProps = {
     | 'avatar'
     | 'large-icon'
     | 'custom';
-  size?: 'normal' | 'medium' | 'large';
+  height?: 'normal' | 'medium' | 'large';
   disabled?: boolean;
   chevron?: boolean;
 };
 export type ListItemContentResponsiveProps = ResponsiveProps<
-  Pick<ListItemContentDefaultProps, 'size'>
+  Pick<ListItemContentDefaultProps, 'height'>
 >;
 export type ListItemContentProps = Merge<
   ListItemContentDefaultProps,

--- a/packages/wds/src/components/menu/contexts.ts
+++ b/packages/wds/src/components/menu/contexts.ts
@@ -15,7 +15,7 @@ export const [MenuProvider, useMenuContext] =
   createContext<MenuContextType>(MENU_NAME);
 
 type MenuItemContextType = {
-  bold?: boolean;
+  active?: boolean;
 };
 
 export const [MenuItemProvider, useMenuItemContext] =

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -267,7 +267,9 @@ const MenuItem = forwardRef(
     };
 
     return (
-      <MenuItemProvider bold={variant === 'normal' ? normalActive : undefined}>
+      <MenuItemProvider
+        active={variant === 'normal' ? normalActive : undefined}
+      >
         <RovingFocusGroupItem
           asChild
           focusable={!disabled}


### PR DESCRIPTION
## 작업 내용

- ListCell
  - `ellipsis`, interactionPadding prop 추가
  - ellipsis={true}일 경우, alignItems="center"로 조정
- ListItem: disabled 스타일 변경
  - 하위 컴포넌트에 disabled 스타일을 주는 것이 아니라, 디자인처럼 ListItem에 `opacity.43`으로 처리
- ListItemContent: `height` prop 추가
- ListText
  - bold prop 제거 --> ListItem이 active={true}일 때, 내부에서 weight="medium" 처리
  - title, catpion이 typography props를 받도록 커스텀 범위 확장
- 그 외 스타일 보정, list docs 수정

@Sh031224 

## 참고
- https://wantedlab.atlassian.net/browse/PI-69833
- https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0%3A-Components?node-id=4013-9145&t=HiUYhYUXclDr3N6G-4