### PR TITLE
docs: not-found 페이지 작성

### DIFF
--- a/docs/src/app/docs/[...slug]/page.tsx
+++ b/docs/src/app/docs/[...slug]/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation';
+
 import { getAllFrontmatter, getSourceBySlug } from '@/lib/mdx';
 import { generatePropTypes } from '@/lib/props';
 
@@ -12,6 +14,9 @@ type Props = {
 const parseSlug = (params: Props['params']) =>
   Array.isArray(params.slug) ? params.slug : [params.slug];
 
+const isFileNotFoundError = (error: unknown) =>
+  error instanceof Error && 'code' in error && error.code === 'ENOENT';
+
 export const generateStaticParams = async () => {
   const frontmatter = await getAllFrontmatter('/');
 
@@ -21,12 +26,20 @@ export const generateStaticParams = async () => {
 export const generateMetadata = async ({
   params,
 }: Props): Promise<Metadata> => {
-  const { frontmatter } = await getSourceBySlug('/', parseSlug(params));
+  try {
+    const { frontmatter } = await getSourceBySlug('/', parseSlug(params));
 
-  return {
-    title: frontmatter.title + ' - WDS',
-    description: frontmatter.description,
-  };
+    return {
+      title: frontmatter.title + ' - WDS',
+      description: frontmatter.description,
+    };
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      notFound();
+    }
+
+    throw error;
+  }
 };
 
 export const dynamic = 'force-static';

--- a/docs/src/app/full-page-layout.client.tsx
+++ b/docs/src/app/full-page-layout.client.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { FlexBox } from '@wanteddev/wds';
+
+import type { PropsWithChildren } from 'react';
+
+const ClientFullPageLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <FlexBox
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      gap="8px"
+      sx={{ width: '100%', height: 'calc(100dvh - var(--header-height))' }}
+      sm={{
+        sx: { padding: '0px 0px 20px 20px', width: 'calc(100% - 250px)' },
+      }}
+      md={{
+        sx: {
+          padding: '0px 20px 20px 20px',
+          width: 'calc(100% - 250px - 150px)',
+        },
+      }}
+    >
+      {children}
+    </FlexBox>
+  );
+};
+
+export default ClientFullPageLayout;

--- a/docs/src/app/not-found.tsx
+++ b/docs/src/app/not-found.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import {
+  EmptyState,
+  EmptyStateButton,
+  EmptyStateContent,
+  EmptyStateImage,
+  EmptyStateText,
+  ImageLoader,
+} from '@wanteddev/wds';
+import Link from 'next/link';
+
+import ClientFullPageLayout from './full-page-layout.client';
+
+const NotFoundPage = () => {
+  return (
+    <ClientFullPageLayout>
+      <EmptyState platform="mobile" sm={{ platform: 'desktop' }}>
+        <EmptyStateImage>
+          <ImageLoader
+            src="https://static.wanted.co.kr/images/ghost.png"
+            width={200}
+            quality={100}
+            alt="ghost"
+          />
+        </EmptyStateImage>
+        <EmptyStateContent>
+          <EmptyStateText
+            heading="페이지를 찾을 수 없어요."
+            description={
+              <>
+                잘못된 경로로 접근했거나 페이지가 삭제되었어요.
+                <br />
+                다시 시도해 주세요.
+              </>
+            }
+          />
+          <EmptyStateButton as={Link} href="/docs/overview/getting-started">
+            문서 확인하기
+          </EmptyStateButton>
+        </EmptyStateContent>
+      </EmptyState>
+    </ClientFullPageLayout>
+  );
+};
+
+export default NotFoundPage;

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@wanteddev/wds';
+import { EmptyState, EmptyStateButton } from '@wanteddev/wds';
 import Link from 'next/link';
 
 import ClientFullPageLayout from './full-page-layout.client';
@@ -8,14 +8,11 @@ import ClientFullPageLayout from './full-page-layout.client';
 const RootPage = () => {
   return (
     <ClientFullPageLayout>
-      <Button
-        variant="solid"
-        size="medium"
-        as={Link}
-        href="/docs/overview/getting-started"
-      >
-        문서 확인하기
-      </Button>
+      <EmptyState platform="mobile" sm={{ platform: 'desktop' }}>
+        <EmptyStateButton as={Link} href="/docs/overview/getting-started">
+          문서 확인하기
+        </EmptyStateButton>
+      </EmptyState>
     </ClientFullPageLayout>
   );
 };

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,36 +1,22 @@
 'use client';
 
-import { Button, FlexBox } from '@wanteddev/wds';
-import { useRouter } from 'next/navigation';
+import { Button } from '@wanteddev/wds';
+import Link from 'next/link';
+
+import ClientFullPageLayout from './full-page-layout.client';
 
 const RootPage = () => {
-  const router = useRouter();
-
   return (
-    <FlexBox
-      flexDirection="column"
-      alignItems="center"
-      justifyContent="center"
-      gap="8px"
-      sx={{ width: '100%', height: 'calc(100dvh - var(--header-height))' }}
-      sm={{
-        sx: { padding: '0px 0px 20px 20px', width: 'calc(100% - 250px)' },
-      }}
-      md={{
-        sx: {
-          padding: '0px 20px 20px 20px',
-          width: 'calc(100% - 250px - 150px)',
-        },
-      }}
-    >
+    <ClientFullPageLayout>
       <Button
         variant="solid"
         size="medium"
-        onClick={() => router.push('/docs/overview/getting-started')}
+        as={Link}
+        href="/docs/overview/getting-started"
       >
         문서 확인하기
       </Button>
-    </FlexBox>
+    </ClientFullPageLayout>
   );
 };
 

--- a/packages/wds/src/components/empty-state/style.ts
+++ b/packages/wds/src/components/empty-state/style.ts
@@ -124,6 +124,10 @@ export const emptyStateStyle =
       max-width: 100%;
       max-height: 100%;
 
+      img {
+        max-width: 100%;
+      }
+
       svg {
         width: 100%;
         height: 100%;


### PR DESCRIPTION

![스크린샷 2024-12-10 오후 2 37 49](https://github.com/user-attachments/assets/d5f8679c-ab6c-46da-9028-9daeac0040a6)
![스크린샷 2024-12-10 오후 2 38 40](https://github.com/user-attachments/assets/817ffe6a-ec11-4261-a3d9-1d7bfb28d913)

## 작업 내용

- 커스텀 not-found 페이지 작성
  - `EmptyState` 컴포넌트 활용
  - `ClientFullPageLayout` 추가: root 페이지, 에러 페이지 같이 가운데 요소만 있는 레이아웃을 분리했습니다. 
- 기타
  - EmptyState: img max-width 조정