### PR TITLE
fix(wds): skeleton align 버그 수정

### DIFF
--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -103,7 +103,7 @@ const skeletonSizeStyle = ({
 const skeletonVariantStyle = (
   {
     variant,
-    align,
+    align: alignProp,
     color: colorProp,
     radius = 'initial',
   }: Pick<SkeletonProps, 'variant' | 'radius' | 'align' | 'color'>,
@@ -117,7 +117,11 @@ const skeletonVariantStyle = (
         display: inline-flex;
         padding: 2px 0px;
         border-radius: 3px;
-        text-align: ${align};
+        justify-content: ${{
+          left: 'flex-start',
+          center: 'center',
+          right: 'flex-end',
+        }[alignProp ?? 'left']};
 
         & > span {
           display: inline-block;


### PR DESCRIPTION
## 작업 내용

- Skeleton: CardSkeleton 작업의 사이드이펙트로 Skeleton의 align 커스텀이 반영되지 않는 버그를 수정했습니다.