### PR TITLE
docs: compact-tooltip 문서 내 잘못된 tooltip 링크 수정

### DIFF
--- a/docs/src/docs/components/compact-tooltip.mdx
+++ b/docs/src/docs/components/compact-tooltip.mdx
@@ -34,7 +34,7 @@ export default Demo;`}
 
 ### CompactTooltip
 
-`defaultValue` 는 [tooltip](/wds/components/tooltip) 과 동일합니다.
+`defaultValue` 는 [tooltip](/wds/docs/components/tooltip) 과 동일합니다.
 
 <PropsTable component="CompactTooltip" />
 


### PR DESCRIPTION
- https://wanteddev.github.io/wds/docs/components/compact-tooltip 문서 내 `Tooltip` 컴포넌트로 이동하기 위한 링크 잘못된 URL 수정