### PR TITLE
fix(wds): tab list item 내부에 resize observer 추가

### DIFF
--- a/packages/wds/src/components/tab/contexts.ts
+++ b/packages/wds/src/components/tab/contexts.ts
@@ -1,6 +1,6 @@
 import { createContext } from '@radix-ui/react-context';
 
-import { TAB_NAME } from './constants';
+import { TAB_LIST_NAME, TAB_NAME } from './constants';
 
 import type { Dispatch, SetStateAction } from 'react';
 
@@ -18,3 +18,10 @@ export type TabContextType = {
 
 export const [TabProvider, useTabContext] =
   createContext<TabContextType>(TAB_NAME);
+
+export type TabListContextType = {
+  handleResize: () => void;
+};
+
+export const [TabListProvider, useTabListContext] =
+  createContext<TabListContextType>(TAB_LIST_NAME);

--- a/packages/wds/src/components/tab/index.tsx
+++ b/packages/wds/src/components/tab/index.tsx
@@ -28,7 +28,12 @@ import {
   tabListItemStyle,
   tabListStyle,
 } from './style';
-import { TabProvider, useTabContext } from './contexts';
+import {
+  TabListProvider,
+  TabProvider,
+  useTabContext,
+  useTabListContext,
+} from './contexts';
 import {
   TAB_LIST_ITEM_NAME,
   TAB_LIST_NAME,
@@ -247,8 +252,9 @@ const TabList = forwardRef<
                 ref={motionDividerRef}
                 sx={motionDividerStyle}
               />
-
-              {children}
+              <TabListProvider handleResize={handleResize}>
+                {children}
+              </TabListProvider>
             </FlexBox>
           </ScrollArea>
 
@@ -285,12 +291,20 @@ const TabListItem = forwardRef<any, TabListItemProps>(
     const composedRefs = useComposedRefs(ref, forwardedRef);
 
     const context = useTabContext(TAB_LIST_ITEM_NAME);
+    const { handleResize } = useTabListContext(TAB_LIST_ITEM_NAME);
     const isDisabled = disabled;
 
-    const isActive = context.value === value;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const isActive = context.value?.toString() === value?.toString();
+
     const isArrowKeyPressedRef = useRef(false);
 
-    const controls = context.panels.find((v) => v === value);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const controls = context.panels.find(
+      (v) => v.toString() === value.toString(),
+    );
+
+    useResizeObserver(ref.current as HTMLElement, handleResize);
 
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
@@ -414,7 +428,8 @@ const TabPanel = forwardRef<
   const [firstRendered, setFirstRendered] = useState(false);
 
   const deferredValue = useDeferredValue(value);
-  const isActive = value === context.value;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const isActive = context.value?.toString() === value?.toString();
 
   useEffect(() => {
     if (!firstRendered && isActive) {

--- a/packages/wds/src/components/tab/index.tsx
+++ b/packages/wds/src/components/tab/index.tsx
@@ -299,9 +299,9 @@ const TabListItem = forwardRef<any, TabListItemProps>(
 
     const isArrowKeyPressedRef = useRef(false);
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const controls = context.panels.find(
-      (v) => v.toString() === value.toString(),
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      (v) => v?.toString() === value?.toString(),
     );
 
     useResizeObserver(ref.current as HTMLElement, handleResize);


### PR DESCRIPTION
탭 내부 콘텐츠의 너비가 변경되었을 때도 대응하기 위해 resize observer를 추가합니다.