### PR TITLE
feat(wds): progress tracker 디자인 및 구조 변경 대응

### DIFF
--- a/docs/src/docs/components/progress-tracker.mdx
+++ b/docs/src/docs/components/progress-tracker.mdx
@@ -38,6 +38,9 @@ export default Demo;`}
 
 <PropsTable component="ProgressTrackerItem" />
 
+### ProgressTrackerLabelContent
+
+<PropsTable component="ProgressTrackerLabelContent" />
 
 ## Direction
 
@@ -61,14 +64,12 @@ export default Demo;`}
 
 `label`, `completedLabel` prop을 통해 라벨을 주입할 수 있습니다.
 
-Horizontal에서 label은 영역을 차지하지 않기 때문에 간격 보정이 필요할 수 있습니다.
-
 
 <Demo code={`import { Box, ProgressTracker, ProgressTrackerItem, css } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
-    <ProgressTracker value="1" sx={{ paddingBottom: 40 }}>
+    <ProgressTracker value="1">
       <ProgressTrackerItem label="단계" completedLabel="완료" value="0" />
       <ProgressTrackerItem label="단계" completedLabel="완료" value="1" />
       <ProgressTrackerItem label="단계" completedLabel="완료" value="2" />
@@ -81,8 +82,7 @@ export default Demo;`}
 
 ### Vertical
 
-`direction=vertical` 로 사용하는 경우 꼭 children을 포함하여 주세요.<br />
-Grid ui가 올바르지 않게 동작할 수 있습니다.
+`direction=vertical` 로 사용하는 경우 꼭 children을 포함하여 렌더링 할 수 있습니다.
 
 <Demo code={`import { Box, ProgressTracker, ProgressTrackerItem, css } from '@wanteddev/wds';
 
@@ -118,7 +118,7 @@ const Item = () => {
 export default Demo;`}
 />
 
-`label`, `completedLabel` prop을 통해 라벨을 주입할 수 있습니다.
+또한 `label`, `completedLabel` prop을 통해 라벨을 주입할 수 있습니다.
 
 <Demo code={`import { Box, ProgressTracker, ProgressTrackerItem, css } from '@wanteddev/wds';
 
@@ -132,6 +132,82 @@ const Demo = () => {
         <Item />
       </ProgressTrackerItem>
       <ProgressTrackerItem label="단계" completedLabel="완료" value="2">
+        <Item />
+      </ProgressTrackerItem>
+    </ProgressTracker>
+  );
+}
+
+const Item = () => {
+  return (
+    <Box
+      sx={theme => css\`
+        width: 100%;
+        height: 64px;
+        background: \${theme.palette.accent.violet};
+        opacity: 0.08;
+      \`}
+    />
+  )
+}
+
+export default Demo;`}
+/>
+
+`direction='vertical'` 인 경우에만 `labelContent`를 사용할 수 있습니다.
+
+<Demo code={`import { Box, ProgressTracker, ProgressTrackerItem, ProgressTrackerLabelContent, ContentBadge, css } from '@wanteddev/wds';
+
+const Demo = () => {
+  return (
+    <ProgressTracker direction="vertical" value="1">
+      <ProgressTrackerItem
+        label="단계"
+        completedLabel="완료"
+        value="0"
+        labelContent={(
+          <ProgressTrackerLabelContent variant="caption">
+            캡션
+          </ProgressTrackerLabelContent>
+        )}
+      >
+        <Item />
+      </ProgressTrackerItem>
+      <ProgressTrackerItem
+        label="단계"
+        completedLabel="완료"
+        value="1"
+        labelContent={(
+          <ProgressTrackerLabelContent variant="badge">
+            <ContentBadge
+              color="neutral"
+              size="normal"
+              variant="filled"
+            >
+              텍스트
+            </ContentBadge>
+            <ContentBadge
+              color="neutral"
+              size="normal"
+              variant="filled"
+              >
+              텍스트
+            </ContentBadge>
+          </ProgressTrackerLabelContent>
+        )}
+      >
+        <Item />
+      </ProgressTrackerItem>
+      <ProgressTrackerItem
+        label="단계"
+        completedLabel="완료"
+        value="2"
+        labelContent={(
+          <ProgressTrackerLabelContent variant="custom">
+            커스텀
+          </ProgressTrackerLabelContent>
+        )}
+      >
         <Item />
       </ProgressTrackerItem>
     </ProgressTracker>

--- a/packages/wds/src/components/progress-tracker/index.tsx
+++ b/packages/wds/src/components/progress-tracker/index.tsx
@@ -13,6 +13,8 @@ import {
   progressTrackerItemContentStyle,
   progressTrackerItemDividerStyle,
   progressTrackerItemHorizontalStyle,
+  progressTrackerItemHorizontalWrapperStyle,
+  progressTrackerItemVerticalLabelWrapperStyle,
   progressTrackerItemVerticalStyle,
   progressTrackerWrapperStyle,
 } from './style';
@@ -20,7 +22,11 @@ import { PROGRESS_TRACKER_ITEM_NAME, PROGRESS_TRACKER_NAME } from './constants';
 import { ProgressTrackerProvider, useProgressTrackerContext } from './contexts';
 
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
-import type { ProgressTrackerItemProps, ProgressTrackerProps } from './types';
+import type {
+  ProgressTrackerItemProps,
+  ProgressTrackerLabelContentProps,
+  ProgressTrackerProps,
+} from './types';
 
 const ProgressTracker = forwardRef<
   HTMLOListElement,
@@ -104,7 +110,7 @@ ProgressTrackerItem.isProgressTrackerItem = true;
 const ProgressTrackerItemVertical = forwardRef<
   HTMLLIElement,
   DefaultComponentProps<ProgressTrackerItemProps, 'li'>
->(({ value, label, completedLabel, children, ...props }, ref) => {
+>(({ value, label, completedLabel, children, labelContent, ...props }, ref) => {
   const {
     value: contextValue,
     getStepIndex,
@@ -123,78 +129,98 @@ const ProgressTrackerItemVertical = forwardRef<
   const number = (index === -1 ? 0 : index) + 1;
 
   return (
-    <>
+    <FlexBox
+      as="li"
+      ref={ref}
+      wds-component="progress-tracker-item"
+      aria-current={isActive ? 'step' : undefined}
+      aria-label={`Step ${index}`}
+      gap="20px"
+      data-completed={isCompleted}
+      data-active={isActive}
+      {...props}
+      sx={[progressTrackerItemVerticalStyle, props.sx]}
+    >
       <FlexBox
-        as="li"
-        ref={ref}
-        wds-component="progress-tracker-item"
-        aria-current={isActive ? 'step' : undefined}
-        aria-label={`Step ${index}`}
-        gap="20px"
-        data-completed={isCompleted}
-        data-active={isActive}
-        {...props}
-        sx={[progressTrackerItemVerticalStyle, props.sx]}
+        data-role="progress-tracker-item-step-wrapper"
+        flex="1"
+        gap="8px"
       >
-        <FlexBox data-role="progress-tracker-item-wrapper" gap="8px">
+        <FlexBox
+          data-role="progress-tracker-item-icon-wrapper"
+          flexDirection="column"
+          alignItems="center"
+        >
           <FlexBox
-            data-role="progress-tracker-item-icon-wrapper"
-            flexDirection="column"
+            data-role="progress-tracker-item-stepper"
+            sx={progressCircleStyle(isActive, isCompleted)}
             alignItems="center"
+            justifyContent="center"
           >
-            <FlexBox
-              data-role="progress-tracker-item-stepper"
-              sx={progressCircleStyle(isActive, isCompleted)}
-              alignItems="center"
-              justifyContent="center"
-            >
-              {isCompleted ? (
-                <IconCheckThick />
-              ) : (
-                <Typography
-                  variant="caption1"
-                  weight="bold"
-                  align="center"
-                  data-role="progress-tracker-item-step"
-                >
-                  {number}
-                </Typography>
-              )}
-            </FlexBox>
-
-            {!isLast && (
-              <Box
-                data-role="progress-tracker-item-divider"
-                sx={progressTrackerItemDividerStyle(isCompleted, 'vertical')}
-              />
+            {isCompleted ? (
+              <IconCheckThick />
+            ) : (
+              <Typography
+                variant="caption1"
+                weight="bold"
+                align="center"
+                data-role="progress-tracker-item-step"
+              >
+                {number}
+              </Typography>
             )}
           </FlexBox>
 
-          <ProgressTrackerItemLabel
-            isCompleted={isCompleted}
-            isActive={isActive}
-            label={label}
-            completedLabel={completedLabel}
-          />
+          {!isLast && (
+            <Box
+              data-role="progress-tracker-item-divider"
+              sx={progressTrackerItemDividerStyle(isCompleted, 'vertical')}
+            />
+          )}
+        </FlexBox>
+
+        <FlexBox flexDirection="column" flex="1">
+          {(Boolean(label) ||
+            Boolean(completedLabel) ||
+            Boolean(labelContent)) && (
+            <FlexBox
+              data-role="progress-tracker-item-label-wrapper"
+              sx={progressTrackerItemVerticalLabelWrapperStyle}
+            >
+              <ProgressTrackerItemLabel
+                isCompleted={isCompleted}
+                isActive={isActive}
+                label={label}
+                completedLabel={completedLabel}
+              />
+
+              <FlexBox
+                data-role="progress-tracker-item-label-content-wrapper"
+                flex="1"
+              >
+                {labelContent}
+              </FlexBox>
+            </FlexBox>
+          )}
+
+          {Boolean(children) ? (
+            <FlexBox
+              data-role="progress-tracker-item-content"
+              sx={progressTrackerItemContentStyle}
+            >
+              {children}
+            </FlexBox>
+          ) : (
+            <FlexBox
+              data-role="progress-tracker-item-content"
+              sx={{ width: 0, height: 0 }}
+            >
+              {children}
+            </FlexBox>
+          )}
         </FlexBox>
       </FlexBox>
-
-      {Boolean(children) ? (
-        <FlexBox
-          data-role="progress-tracker-item-content"
-          sx={progressTrackerItemContentStyle}
-        >
-          {children}
-        </FlexBox>
-      ) : (
-        <FlexBox
-          data-role="progress-tracker-item-content"
-          sx={{ width: 0, height: 0 }}
-        >
-          {children}
-        </FlexBox>
-      )}
-    </>
+    </FlexBox>
   );
 });
 
@@ -206,6 +232,7 @@ const ProgressTrackerItemHorizontal = forwardRef<
     value: contextValue,
     getStepIndex,
     getActiveStepIndex,
+    getTotalLength,
   } = useProgressTrackerContext(PROGRESS_TRACKER_ITEM_NAME);
 
   const isActive = contextValue === value;
@@ -215,61 +242,79 @@ const ProgressTrackerItemHorizontal = forwardRef<
   const isCompleted = activeIndex > index;
 
   const isFirst = index === 0;
+  const isLast = index === getTotalLength() - 1;
 
   const number = (index === -1 ? 0 : index) + 1;
 
   return (
-    <>
-      {!isFirst && (
+    <FlexBox
+      as="li"
+      ref={ref}
+      wds-component="progress-tracker-item"
+      aria-current={isActive ? 'step' : undefined}
+      aria-label={`Step ${index}`}
+      flexDirection="column"
+      alignItems="center"
+      gap="8px"
+      data-completed={isCompleted}
+      data-active={isActive}
+      {...props}
+      sx={[progressTrackerItemHorizontalStyle, props.sx]}
+    >
+      <FlexBox
+        data-role="progress-tracker-item-wrapper"
+        flexDirection="row"
+        alignItems="center"
+        sx={progressTrackerItemHorizontalWrapperStyle}
+      >
         <Box
           data-role="progress-tracker-item-divider"
-          sx={progressTrackerItemDividerStyle(
-            isActive || isCompleted,
-            'horizontal',
-          )}
+          sx={[
+            progressTrackerItemDividerStyle(
+              isActive || isCompleted,
+              'horizontal',
+            ),
+            isFirst && { backgroundColor: 'transparent' },
+          ]}
         />
-      )}
 
-      <FlexBox
-        as="li"
-        ref={ref}
-        wds-component="progress-tracker-item"
-        aria-current={isActive ? 'step' : undefined}
-        aria-label={`Step ${index}`}
-        flexDirection="column"
-        alignItems="center"
-        data-completed={isCompleted}
-        data-active={isActive}
-        {...props}
-        sx={[progressTrackerItemHorizontalStyle, props.sx]}
-      >
-        <FlexBox
-          sx={progressCircleStyle(isActive, isCompleted)}
-          alignItems="center"
-          justifyContent="center"
-        >
-          {isCompleted ? (
-            <IconCheckThick />
-          ) : (
-            <Typography
-              variant="caption1"
-              weight="bold"
-              align="center"
-              data-role="progress-tracker-item-step"
-            >
-              {number}
-            </Typography>
-          )}
-
-          <ProgressTrackerItemLabel
-            isCompleted={isCompleted}
-            isActive={isActive}
-            label={label}
-            completedLabel={completedLabel}
-          />
+        <FlexBox flexDirection="column" alignItems="center">
+          <FlexBox
+            sx={progressCircleStyle(isActive, isCompleted)}
+            alignItems="center"
+            justifyContent="center"
+          >
+            {isCompleted ? (
+              <IconCheckThick />
+            ) : (
+              <Typography
+                variant="caption1"
+                weight="bold"
+                align="center"
+                data-role="progress-tracker-item-step"
+              >
+                {number}
+              </Typography>
+            )}
+          </FlexBox>
         </FlexBox>
+
+        <Box
+          data-role="progress-tracker-item-divider"
+          sx={[
+            progressTrackerItemDividerStyle(isCompleted, 'horizontal'),
+            isLast && { backgroundColor: 'transparent' },
+          ]}
+        />
       </FlexBox>
-    </>
+
+      <ProgressTrackerItemLabel
+        isCompleted={isCompleted}
+        isActive={isActive}
+        label={label}
+        completedLabel={completedLabel}
+      />
+    </FlexBox>
   );
 });
 
@@ -285,11 +330,12 @@ const ProgressTrackerItemLabel = ({
   if (isCompleted) {
     return Boolean(completedLabel) ? (
       <Typography
-        sx={{ padding: '1px 0px', height: 'fit-content', width: 'max-content' }}
+        sx={{ padding: '1px 0px', height: 'fit-content' }}
         data-role="progress-tracker-item-label"
         color={isActive ? 'palette.label.normal' : 'palette.label.alternative'}
         variant="label2"
         weight="bold"
+        align="center"
       >
         {completedLabel}
       </Typography>
@@ -298,15 +344,68 @@ const ProgressTrackerItemLabel = ({
 
   return Boolean(label) ? (
     <Typography
-      sx={{ padding: '1px 0px', height: 'fit-content', width: 'max-content' }}
+      sx={{ padding: '1px 0px', height: 'fit-content' }}
       data-role="progress-tracker-item-label"
       color={isActive ? 'palette.label.normal' : 'palette.label.alternative'}
       variant="label2"
       weight="bold"
+      align="center"
     >
       {label}
     </Typography>
   ) : null;
 };
 
-export { ProgressTracker, ProgressTrackerItem };
+const ProgressTrackerLabelContent = forwardRef<
+  HTMLDivElement,
+  DefaultComponentProps<ProgressTrackerLabelContentProps, 'div'>
+>(({ variant = 'custom', ...props }, ref) => {
+  switch (variant) {
+    case 'badge':
+      return (
+        <FlexBox
+          wds-component="progress-tracker-label-content"
+          ref={ref}
+          alignItems="center"
+          gap="4px"
+          {...props}
+          sx={[{ height: 20 }, props.sx]}
+        />
+      );
+    case 'caption':
+      return (
+        <FlexBox
+          wds-component="progress-tracker-label-content"
+          ref={ref}
+          alignItems="center"
+          justifyContent="flex-end"
+          gap="4px"
+          flex="1"
+          {...props}
+          sx={[{ padding: '2px 0px', height: 20 }, props.sx]}
+        >
+          <Typography
+            variant="caption1"
+            weight="regular"
+            color="palette.label.alternative"
+          >
+            {props.children}
+          </Typography>
+        </FlexBox>
+      );
+    case 'custom':
+      return (
+        <FlexBox
+          wds-component="progress-tracker-label-content"
+          ref={ref}
+          flex="1"
+          {...props}
+          sx={[{ height: 20 }, props.sx]}
+        />
+      );
+  }
+});
+
+ProgressTrackerLabelContent.displayName = 'ProgressTrackerLabelContent';
+
+export { ProgressTracker, ProgressTrackerItem, ProgressTrackerLabelContent };

--- a/packages/wds/src/components/progress-tracker/style.ts
+++ b/packages/wds/src/components/progress-tracker/style.ts
@@ -17,30 +17,35 @@ export const progressTrackerWrapperStyle = ({
 
   ${direction === 'horizontal'
     ? css`
-        align-items: center;
         flex-direction: row;
       `
     : css`
-        display: grid;
-        grid-template-columns: max-content 1fr;
-        grid-template-rows: 1fr;
-        column-gap: 20px;
+        flex-direction: column;
       `}
 `;
 
 export const progressTrackerItemVerticalStyle = css`
   position: relative;
+
+  [data-role='progress-tracker-item-label'] {
+    display: block;
+    text-align: left;
+    margin-right: 6px;
+  }
+`;
+
+export const progressTrackerItemVerticalLabelWrapperStyle = css`
+  margin-bottom: 12px;
+  height: 20px;
 `;
 
 export const progressTrackerItemHorizontalStyle = css`
-  position: relative;
+  flex: 1 0 0;
+`;
 
-  [data-role='progress-tracker-item-label'] {
-    position: absolute;
-    left: 50%;
-    top: calc(100% + 8px);
-    transform: translateX(-50%);
-  }
+export const progressTrackerItemHorizontalWrapperStyle = css`
+  width: 100%;
+  position: relative;
 `;
 
 export const progressTrackerItemDividerStyle =

--- a/packages/wds/src/components/progress-tracker/types.ts
+++ b/packages/wds/src/components/progress-tracker/types.ts
@@ -13,4 +13,12 @@ export type ProgressTrackerItemProps = {
   label?: ReactNode;
   completedLabel?: ReactNode;
   children?: ReactNode;
+  /**
+   * direction='vertical' only
+   */
+  labelContent?: ReactNode;
+};
+
+export type ProgressTrackerLabelContentProps = {
+  variant?: 'badge' | 'caption' | 'custom';
 };


### PR DESCRIPTION

horizonal 에서 label 영역을 absolute에서 영역을 차지하도록 변경됩니다.

![image](https://github.com/user-attachments/assets/4ac531b6-bdcb-467f-8263-58f997519c19)

vertical 에서 label, 콘텐츠 영역 레이아웃이 row에서 column 형태로 변경됩니다.
![image](https://github.com/user-attachments/assets/fc314653-64c9-4e13-a070-4d868f7369e8)

vertical 에서 labelContent로 label에 대한 콘텐츠를 추가할 수 있습니다.
![image](https://github.com/user-attachments/assets/f67ee7d7-d488-4842-83b2-c22527db4a55)
