### PR TITLE
fix(wds): toast가 touch device에서 닫히지 않고 남아있는 현상

### DIFF
--- a/packages/wds/src/components/region-status/style.ts
+++ b/packages/wds/src/components/region-status/style.ts
@@ -60,20 +60,22 @@ export const bottomRegionStatusStyle =
 
     ${isMountAnimationDone &&
     css`
-      &:hover {
-        animation-play-state: paused;
-      }
+      @media (pointer: fine) {
+        &:hover {
+          animation-play-state: paused;
+        }
 
-      &:where(:focus-within) {
-        animation-play-state: paused;
-      }
+        &:where(:focus-within) {
+          animation-play-state: paused;
+        }
 
-      &:where(:focus) {
-        animation-play-state: paused;
-      }
+        &:where(:focus) {
+          animation-play-state: paused;
+        }
 
-      &:where(:hover) {
-        animation-play-state: paused;
+        &:where(:hover) {
+          animation-play-state: paused;
+        }
       }
     `}
   `;


### PR DESCRIPTION
#222 


![image](https://github.com/user-attachments/assets/e2404f55-f15d-4cb1-84f3-e972b16261b7)


원래 hover시 토스트, 스낵바의 닫힘 애니메이션을 멈추었는데 미디어 쿼리를 통해 정확한 pointer 기기를 통해서 동작할 때만 멈추도록 수정했습니다.