### PR TITLE
feat(wds): accordion expaned 상태에 따른 tab index 접근성 개선

### DIFF
--- a/packages/wds/src/components/accordion/contexts.ts
+++ b/packages/wds/src/components/accordion/contexts.ts
@@ -6,6 +6,8 @@ type AccordionContextType = {
   expanded: boolean;
   disabled: boolean;
   onExpandedChange: (expanded: boolean) => void;
+  summaryId: string;
+  detailsId: string;
 };
 
 export const [AccordionProvider, useAccordionContext] =

--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -1,12 +1,12 @@
 import { Box } from '@wanteddev/wds-engine';
-import { forwardRef } from 'react';
+import { forwardRef, useEffect, useId, useRef } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { IconChevronDown } from '@wanteddev/wds-icon';
 import { composeEventHandlers } from '@radix-ui/primitive';
 
 import { ListCell, ListCellContent } from '../list';
 import Typography from '../typography';
-import { Divider, FlexBox } from '../..';
+import { Divider, FlexBox, useComposedRefs } from '../..';
 
 import {
   ACCORDION_DESCRIPTION_NAME,
@@ -52,17 +52,18 @@ const Accordion = forwardRef<
       onChange,
     });
 
+    const summaryId = useId();
+    const detailsId = useId();
+
     return (
       <AccordionProvider
         expanded={expanded}
         disabled={disabled}
         onExpandedChange={setExpand}
+        summaryId={summaryId}
+        detailsId={detailsId}
       >
-        <Box
-          ref={ref}
-          aria-expanded={expanded}
-          sx={[accordionStyle({ disabled }), sx]}
-        >
+        <Box ref={ref} sx={[accordionStyle({ disabled }), sx]}>
           {children}
           {divider && (
             <Divider
@@ -87,6 +88,8 @@ const AccordionSummary = forwardRef<
     expanded,
     disabled: accordionDisabled,
     onExpandedChange,
+    detailsId,
+    summaryId,
   } = useAccordionContext(ACCORDION_SUMMARY_NAME);
 
   return (
@@ -97,6 +100,9 @@ const AccordionSummary = forwardRef<
       padding="16px"
       disabled={accordionDisabled || disabled}
       disableInteraction={accordionDisabled || disabled}
+      aria-expanded={expanded}
+      aria-controls={detailsId}
+      id={summaryId}
       rightContent={
         rightContent ?? (
           <AccordionSummaryContent
@@ -153,16 +159,57 @@ AccordionSummaryContent.displayName = ACCORDION_SUMMARY_CONTENT_NAME;
 const AccordionDetails = forwardRef<
   HTMLDivElement,
   DefaultComponentProps<TypographyProps, 'div'>
->(({ sx, children, ...props }, ref) => {
-  const { expanded } = useAccordionContext(ACCORDION_DETAILS_NAME);
+>(({ sx, children, ...props }, forwardedRef) => {
+  const { expanded, detailsId, summaryId } = useAccordionContext(
+    ACCORDION_DETAILS_NAME,
+  );
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  useEffect(() => {
+    if (ref.current) {
+      const elements = ref.current.querySelectorAll(
+        'a, button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), details, [tabindex]',
+      );
+
+      elements.forEach((elm) => {
+        const currentTabIndex = elm.getAttribute('tabindex');
+        const prevTabIndex = elm.getAttribute('data-prev-tabindex');
+
+        const details = elm.closest('[wds-component="accordion-details"]');
+
+        if (details !== ref.current) {
+          return;
+        }
+
+        if (expanded) {
+          if (prevTabIndex === 'unset') {
+            elm.removeAttribute('tabindex');
+          } else if (prevTabIndex !== null) {
+            elm.setAttribute('tabindex', prevTabIndex);
+          }
+          elm.removeAttribute('data-prev-tabindex');
+        } else {
+          if (prevTabIndex === null) {
+            elm.setAttribute('data-prev-tabindex', currentTabIndex || 'unset');
+          }
+          elm.setAttribute('tabindex', '-1');
+        }
+      });
+    }
+  }, [expanded]);
 
   return (
     <Box
-      ref={ref}
+      ref={composedRefs}
       wds-component="accordion-details"
+      aria-labelledby={summaryId}
+      aria-hidden={!expanded}
+      id={detailsId}
       {...props}
       sx={[accordionDetailsStyle({ expanded }), sx]}
-      aria-hidden={!expanded}
     >
       <div>
         <FlexBox


### PR DESCRIPTION
- 펼쳐지지 않았을 때 키보드로 AccordionDetails 내부 요소를 포커스 할 수 있어서 이 부분 개선했습니다.


@1000peach 추가적으로 accordion을 2중으로 겹쳐 사용할 때 cell의 interaction부분이 overflow: hidden; 때문에 짤리게 되는데..

1. 애니메이션 제거
2. 이중 accordion 사용하지 않도록 가이드

이 부분은 고민해보다가 형진님 오셨을 때 논의해보면 좋을 것 같아요.

![image](https://github.com/user-attachments/assets/a01cd186-13a7-47b2-bb4f-0d369dfd54e7)
