### PR TITLE
fix(wds): accordion 내부 인터랙션 잘림 수정, 가이드 보완

### DIFF
--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -44,6 +44,7 @@ export default Demo;`}
     <AccordionDescription>
       내용
     </AccordionDescription>
+    <AccordionContent />
   </AccordionDetails>
 </Accordion>
 ```
@@ -73,6 +74,12 @@ export default Demo;`}
 `Typography`와 동일한 props를 사용해요.
 
 <PropsTable component="AccordionDescription" />
+
+### AccordionContent
+
+`Box`와 동일한 props를 사용해요.
+
+<PropsTable component="AccordionContent" />
 
 ## Examples
 
@@ -288,11 +295,88 @@ const Demo = () => {
 export default Demo;`}
 />
 
-### Content
+### Nested Accordion  
 
-추가 콘텐츠를 넣을 수 있어요.
+- Accordion을 중첩해서 사용할 수 있어요.
+- 하위 Accordion은 `disableInteraction`과 함께 사용하면 자연스러운 동작으로 열고 닫을 수 있어요.
 
-<Demo code={`import { Accordion, AccordionSummary, AccordionDetails, AccordionDescription, ListCellContent } from '@wanteddev/wds';
+<Demo code={`import { Accordion, AccordionSummary, AccordionDetails, AccordionDescription } from '@wanteddev/wds';
+
+const Demo = () => {
+  return (
+    <div>
+      <Accordion>
+        <AccordionSummary>
+          제목
+        </AccordionSummary>
+        <AccordionDetails>
+          <Accordion divider={false}>
+            <AccordionSummary padding="12px" disableInteraction>
+              하위 메뉴
+            </AccordionSummary>
+            <AccordionDetails>
+              <AccordionDescription>
+                제목에 대한 상세 내용을 입력해주세요.<br />
+                긴 컨텐츠라면 접은 상태를 기본 값으로 사용하세요.
+              </AccordionDescription>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion divider={false}>
+            <AccordionSummary padding="12px" disableInteraction>
+              하위 메뉴
+            </AccordionSummary>
+            <AccordionDetails>
+              <AccordionDescription>
+                제목에 대한 상세 내용을 입력해주세요.<br />
+                긴 컨텐츠라면 접은 상태를 기본 값으로 사용하세요.
+              </AccordionDescription>
+            </AccordionDetails>
+          </Accordion>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion>
+        <AccordionSummary>
+          제목
+        </AccordionSummary>
+        <AccordionDetails>
+          <Accordion divider={false}>
+            <AccordionSummary padding="12px" disableInteraction>
+              하위 메뉴
+            </AccordionSummary>
+            <AccordionDetails>
+              <AccordionDescription>
+                제목에 대한 상세 내용을 입력해주세요.<br />
+                긴 컨텐츠라면 접은 상태를 기본 값으로 사용하세요.
+              </AccordionDescription>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion divider={false}>
+            <AccordionSummary padding="12px" disableInteraction>
+              하위 메뉴
+            </AccordionSummary>
+            <AccordionDetails>
+              <AccordionDescription>
+                제목에 대한 상세 내용을 입력해주세요.<br />
+                긴 컨텐츠라면 접은 상태를 기본 값으로 사용하세요.
+              </AccordionDescription>
+            </AccordionDetails>
+          </Accordion>
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  )
+}
+
+export default Demo;`}
+/>
+
+### AccordionContent
+
+콘텐츠를 추가할 수 있어요.
+
+<Demo code={`import { Accordion, AccordionSummary, AccordionDetails, AccordionDescription, AccordionContent, TextButton } from '@wanteddev/wds';
+import { IconExternalLink } from '@wanteddev/wds-icon';
 
 const Demo = () => {
   return (
@@ -305,7 +389,15 @@ const Demo = () => {
           제목에 대한 상세 내용을 입력해주세요.<br />
           긴 컨텐츠라면 접은 상태를 기본 값으로 사용하세요.
         </AccordionDescription>
-       추가 콘텐츠 입니다.
+        <AccordionContent>
+          <TextButton
+            size="small"
+            variant="assistive"
+            rightContent={<IconExternalLink />}
+          >
+            자세히 알아보기
+          </TextButton>
+        </AccordionContent>
       </AccordionDetails>
     </Accordion>
   )

--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -6,7 +6,8 @@ description: Accordion Component
 # Accordion
 
 - 내용을 최소화하거나 펼칠 때 사용합니다.
-- AccordionSummary의 rightContent를 교체할 때는 `AccordionSummaryContent`로 감싸서 사용합니다.
+- AccordionSummary의 rightContent를 교체할 때는 `AccordionSummaryContent`로 감싸주세요.
+- AccordionDetails의 내부 간격을 조정할 때는 `--wds-accordion-details-padding-left`, `--wds-accordion-details-padding-right`, `--wds-accordion-details-gap`을 사용해주세요.
 
 ## 활용
 
@@ -76,8 +77,6 @@ export default Demo;`}
 <PropsTable component="AccordionDescription" />
 
 ### AccordionContent
-
-`Box`와 동일한 props를 사용해요.
 
 <PropsTable component="AccordionContent" />
 
@@ -301,15 +300,20 @@ export default Demo;`}
 - 하위 Accordion은 `disableInteraction`과 함께 사용하면 자연스러운 동작으로 열고 닫을 수 있어요.
 
 <Demo code={`import { Accordion, AccordionSummary, AccordionDetails, AccordionDescription } from '@wanteddev/wds';
+import type { CSSProperties } from 'react';
 
 const Demo = () => {
   return (
     <div>
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary fillWidth>
           제목
         </AccordionSummary>
-        <AccordionDetails>
+        <AccordionDetails
+          style={
+            { '--wds-accordion-details-padding-left': '32px' } as CSSProperties
+          }
+        >
           <Accordion divider={false}>
             <AccordionSummary padding="12px" disableInteraction>
               하위 메뉴
@@ -336,10 +340,14 @@ const Demo = () => {
       </Accordion>
 
       <Accordion>
-        <AccordionSummary>
+        <AccordionSummary fillWidth>
           제목
         </AccordionSummary>
-        <AccordionDetails>
+        <AccordionDetails
+          style={
+            { '--wds-accordion-details-padding-left': '32px' } as CSSProperties
+          }
+        >
           <Accordion divider={false}>
             <AccordionSummary padding="12px" disableInteraction>
               하위 메뉴

--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -7,7 +7,6 @@ description: Accordion Component
 
 - 내용을 최소화하거나 펼칠 때 사용합니다.
 - AccordionSummary의 rightContent를 교체할 때는 `AccordionSummaryContent`로 감싸주세요.
-- AccordionDetails의 내부 간격을 조정할 때는 `--wds-accordion-details-padding-left`, `--wds-accordion-details-padding-right`, `--wds-accordion-details-gap`을 사용해주세요.
 
 ## 활용
 
@@ -309,12 +308,8 @@ const Demo = () => {
         <AccordionSummary fillWidth>
           제목
         </AccordionSummary>
-        <AccordionDetails
-          style={
-            { '--wds-accordion-details-padding-left': '32px' } as CSSProperties
-          }
-        >
-          <Accordion divider={false}>
+        <AccordionDetails sx={{ gap: '4px' }}>
+          <Accordion divider={false} sx={{ paddingLeft: '12px' }}>
             <AccordionSummary padding="12px" disableInteraction>
               하위 메뉴
             </AccordionSummary>
@@ -325,7 +320,7 @@ const Demo = () => {
               </AccordionDescription>
             </AccordionDetails>
           </Accordion>
-          <Accordion divider={false}>
+          <Accordion divider={false} sx={{ paddingLeft: '12px' }}>
             <AccordionSummary padding="12px" disableInteraction>
               하위 메뉴
             </AccordionSummary>
@@ -343,12 +338,8 @@ const Demo = () => {
         <AccordionSummary fillWidth>
           제목
         </AccordionSummary>
-        <AccordionDetails
-          style={
-            { '--wds-accordion-details-padding-left': '32px' } as CSSProperties
-          }
-        >
-          <Accordion divider={false}>
+        <AccordionDetails sx={{ gap: '4px'}}>
+          <Accordion divider={false} sx={{ paddingLeft: '12px' }}>
             <AccordionSummary padding="12px" disableInteraction>
               하위 메뉴
             </AccordionSummary>
@@ -359,7 +350,7 @@ const Demo = () => {
               </AccordionDescription>
             </AccordionDetails>
           </Accordion>
-          <Accordion divider={false}>
+          <Accordion divider={false} sx={{ paddingLeft: '12px' }}>
             <AccordionSummary padding="12px" disableInteraction>
               하위 메뉴
             </AccordionSummary>

--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -304,7 +304,7 @@ import type { CSSProperties } from 'react';
 const Demo = () => {
   return (
     <div>
-      <Accordion>
+      <Accordion defaultExpanded>
         <AccordionSummary fillWidth>
           제목
         </AccordionSummary>

--- a/packages/wds/src/components/accordion/constants.ts
+++ b/packages/wds/src/components/accordion/constants.ts
@@ -3,3 +3,4 @@ export const ACCORDION_SUMMARY_NAME = 'AccordionSummary';
 export const ACCORDION_DETAILS_NAME = 'AccordionDetails';
 export const ACCORDION_DESCRIPTION_NAME = 'AccordionDescription';
 export const ACCORDION_SUMMARY_CONTENT_NAME = 'AccordionSummaryContent';
+export const ACCORDION_CONTENT_NAME = 'AccordionContent';

--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -36,7 +36,11 @@ import type {
 } from 'react';
 import type { ListCellProps } from '../list/types';
 import type { TypographyProps } from '../typography/types';
-import type { AccordionProps, AccordionSummaryContentProps } from './types';
+import type {
+  AccordionDetailsProps,
+  AccordionProps,
+  AccordionSummaryContentProps,
+} from './types';
 import type {
   DefaultComponentProps,
   PolymorphicComponent,
@@ -187,7 +191,7 @@ AccordionSummaryContent.displayName = ACCORDION_SUMMARY_CONTENT_NAME;
 
 const AccordionDetails = forwardRef<
   HTMLDivElement,
-  DefaultComponentProps<TypographyProps, 'div'>
+  DefaultComponentProps<AccordionDetailsProps, 'div'>
 >(({ sx, children, ...props }, forwardedRef) => {
   const { expanded, detailsId, summaryId } = useAccordionContext(
     ACCORDION_DETAILS_NAME,

--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -1,14 +1,15 @@
 import { Box } from '@wanteddev/wds-engine';
-import { forwardRef, useEffect, useId, useRef } from 'react';
+import { forwardRef, useEffect, useId, useRef, useState } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { IconChevronDown } from '@wanteddev/wds-icon';
 import { composeEventHandlers } from '@radix-ui/primitive';
 
 import { ListCell, ListCellContent } from '../list';
 import Typography from '../typography';
-import { Divider, FlexBox, useComposedRefs } from '../..';
+import { Divider, FlexBox, useComposedRefs, useSize } from '../..';
 
 import {
+  ACCORDION_CONTENT_NAME,
   ACCORDION_DESCRIPTION_NAME,
   ACCORDION_DETAILS_NAME,
   ACCORDION_NAME,
@@ -17,18 +18,30 @@ import {
 } from './constants';
 import { AccordionProvider, useAccordionContext } from './contexts';
 import {
+  accordionContentStyle,
   accordionDetailsStyle,
   accordionDetailsWrapperStyle,
   accordionDividerStyle,
   accordionStyle,
   accordionSummaryContentStyle,
+  accordionSummaryStyle,
   accordionSummaryTextStyle,
 } from './style';
 
+import type {
+  ComponentPropsWithoutRef,
+  ElementType,
+  ForwardedRef,
+  PropsWithChildren,
+} from 'react';
 import type { ListCellProps } from '../list/types';
 import type { TypographyProps } from '../typography/types';
 import type { AccordionProps, AccordionSummaryContentProps } from './types';
-import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+import type {
+  DefaultComponentProps,
+  PolymorphicComponent,
+  PolymorphicProps,
+} from '@wanteddev/wds-engine';
 
 const Accordion = forwardRef<
   HTMLDivElement,
@@ -83,56 +96,72 @@ Accordion.displayName = ACCORDION_NAME;
 const AccordionSummary = forwardRef<
   HTMLDivElement,
   DefaultComponentProps<ListCellProps, 'div'>
->(({ disabled, children, rightContent, textProps, ...props }, ref) => {
-  const {
-    expanded,
-    disabled: accordionDisabled,
-    onExpandedChange,
-    detailsId,
-    summaryId,
-  } = useAccordionContext(ACCORDION_SUMMARY_NAME);
+>(
+  (
+    {
+      disabled: givenDisabled,
+      children,
+      rightContent,
+      textProps,
+      sx,
+      ...props
+    },
+    ref,
+  ) => {
+    const {
+      expanded,
+      disabled: accordionDisabled,
+      onExpandedChange,
+      detailsId,
+      summaryId,
+    } = useAccordionContext(ACCORDION_SUMMARY_NAME);
 
-  return (
-    <ListCell
-      ref={ref}
-      wds-component="accordion-summary"
-      as="div"
-      padding="16px"
-      disabled={accordionDisabled || disabled}
-      disableInteraction={accordionDisabled || disabled}
-      aria-expanded={expanded}
-      aria-controls={detailsId}
-      id={summaryId}
-      rightContent={
-        rightContent ?? (
-          <AccordionSummaryContent
-            variant="icon"
-            data-role="accordion-summary-expand-icon"
-          >
-            <IconChevronDown
-              sx={(theme) => ({
-                color: theme.palette.label.normal,
-              })}
-            />
-          </AccordionSummaryContent>
-        )
-      }
-      textProps={{
-        variant: 'body2_normal',
-        weight: 'bold',
-        ...textProps,
-        sx: [accordionSummaryTextStyle, textProps?.sx],
-      }}
-      {...props}
-      onClick={composeEventHandlers(props.onClick, (e) => {
-        onExpandedChange(!expanded);
-        e.preventDefault();
-      })}
-    >
-      {children}
-    </ListCell>
-  );
-});
+    const disabled = givenDisabled || accordionDisabled;
+
+    return (
+      <ListCell
+        ref={ref}
+        wds-component="accordion-summary"
+        as="div"
+        role="button"
+        padding="16px"
+        disabled={disabled}
+        disableInteraction={disabled}
+        aria-expanded={expanded}
+        aria-controls={detailsId}
+        id={summaryId}
+        rightContent={
+          rightContent ?? (
+            <AccordionSummaryContent
+              variant="icon"
+              data-role="accordion-summary-expand-icon"
+            >
+              <IconChevronDown
+                sx={(theme) => ({
+                  color: theme.palette.label.normal,
+                })}
+              />
+            </AccordionSummaryContent>
+          )
+        }
+        textProps={{
+          variant: 'body2_normal',
+          weight: 'bold',
+          ...textProps,
+          sx: [accordionSummaryTextStyle, textProps?.sx],
+        }}
+        {...props}
+        sx={[accordionSummaryStyle({ disabled }), sx]}
+        onClick={composeEventHandlers(props.onClick, (e) => {
+          onExpandedChange(!expanded);
+          e.preventDefault();
+        })}
+      >
+        {children}
+      </ListCell>
+    );
+  },
+);
 
 AccordionSummary.displayName = ACCORDION_SUMMARY_NAME;
 
@@ -165,8 +194,10 @@ const AccordionDetails = forwardRef<
   );
 
   const ref = useRef<HTMLDivElement>(null);
-
   const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  const [wrapperNode, setWrapperNode] = useState<HTMLDivElement | null>(null);
+  const { height = 0 } = useSize(wrapperNode) ?? {};
 
   useEffect(() => {
     if (ref.current) {
@@ -201,6 +232,38 @@ const AccordionDetails = forwardRef<
     }
   }, [expanded]);
 
+  useEffect(() => {
+    if (!ref.current || !wrapperNode) return;
+
+    const element = ref.current;
+
+    if (expanded) {
+      element.style.overflow = 'hidden';
+      element.style.height = `${height}px`;
+    } else {
+      element.style.height = `${height}px`;
+      element.style.overflow = 'hidden';
+
+      requestAnimationFrame(() => {
+        element.style.height = '0px';
+      });
+    }
+
+    const handleTransitionEnd = () => {
+      if (expanded) {
+        element.style.height = 'auto';
+        element.style.overflow = 'visible';
+      }
+    };
+
+    element.addEventListener('transitionend', handleTransitionEnd);
+
+    return () => {
+      element.removeEventListener('transitionend', handleTransitionEnd);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded]);
+
   return (
     <Box
       ref={composedRefs}
@@ -209,16 +272,15 @@ const AccordionDetails = forwardRef<
       aria-hidden={!expanded}
       id={detailsId}
       {...props}
-      sx={[accordionDetailsStyle({ expanded }), sx]}
+      sx={[accordionDetailsStyle, sx]}
     >
-      <div>
-        <FlexBox
-          data-role="accordion-details-wrapper"
-          sx={accordionDetailsWrapperStyle}
-        >
-          {children}
-        </FlexBox>
-      </div>
+      <FlexBox
+        ref={setWrapperNode}
+        data-role="accordion-details-wrapper"
+        sx={accordionDetailsWrapperStyle}
+      >
+        {children}
+      </FlexBox>
     </Box>
   );
 });
@@ -243,10 +305,29 @@ const AccordionDescription = forwardRef<
 
 AccordionDescription.displayName = ACCORDION_DESCRIPTION_NAME;
 
+const AccordionContent = forwardRef(
+  <E extends ElementType = 'div'>(
+    { sx, ...props }: PolymorphicProps<PropsWithChildren, E>,
+    ref: ForwardedRef<E>,
+  ) => {
+    return (
+      <Box
+        wds-component="accordion-content"
+        ref={ref}
+        {...props}
+        sx={[accordionContentStyle, sx]}
+      />
+    );
+  },
+) as PolymorphicComponent<ComponentPropsWithoutRef<typeof Box>, 'div'>;
+
+AccordionContent.displayName = ACCORDION_CONTENT_NAME;
+
 export {
   Accordion,
   AccordionSummary,
   AccordionSummaryContent,
   AccordionDetails,
   AccordionDescription,
+  AccordionContent,
 };

--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -261,12 +261,13 @@ const AccordionDetails = forwardRef<
     };
 
     element.addEventListener('transitionend', handleTransitionEnd);
-
     return () => {
       element.removeEventListener('transitionend', handleTransitionEnd);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expanded]);
+
+  const initialExpandedRef = useRef(expanded);
 
   return (
     <Box
@@ -276,7 +277,9 @@ const AccordionDetails = forwardRef<
       aria-hidden={!expanded}
       id={detailsId}
       {...props}
-      sx={accordionDetailsStyle}
+      sx={accordionDetailsStyle({
+        initialExpanded: initialExpandedRef.current,
+      })}
     >
       <FlexBox
         ref={setWrapperNode}

--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -276,12 +276,12 @@ const AccordionDetails = forwardRef<
       aria-hidden={!expanded}
       id={detailsId}
       {...props}
-      sx={[accordionDetailsStyle, sx]}
+      sx={accordionDetailsStyle}
     >
       <FlexBox
         ref={setWrapperNode}
         data-role="accordion-details-wrapper"
-        sx={accordionDetailsWrapperStyle}
+        sx={[accordionDetailsWrapperStyle, sx]}
       >
         {children}
       </FlexBox>

--- a/packages/wds/src/components/accordion/style.ts
+++ b/packages/wds/src/components/accordion/style.ts
@@ -64,18 +64,10 @@ export const accordionDetailsStyle = css`
 
 export const accordionDetailsWrapperStyle = css`
   flex-direction: column;
-  gap: var(--wds-accordion-details-gap, 0px);
-
   padding-top: calc(16px - var(--wds-list-cell-padding, 16px));
   padding-bottom: var(--wds-list-cell-padding, 16px);
-  padding-left: var(
-    --wds-accordion-details-padding-left,
-    calc(var(--wds-list-cell-fill-width-padding, 0px))
-  );
-  padding-right: var(
-    --wds-accordion-details-padding-right,
-    calc(var(--wds-list-cell-fill-width-padding, 0px))
-  );
+  padding-left: calc(var(--wds-list-cell-fill-width-padding, 0px));
+  padding-right: calc(var(--wds-list-cell-fill-width-padding, 0px));
 `;
 
 export const accordionDividerStyle = ({

--- a/packages/wds/src/components/accordion/style.ts
+++ b/packages/wds/src/components/accordion/style.ts
@@ -64,10 +64,18 @@ export const accordionDetailsStyle = css`
 
 export const accordionDetailsWrapperStyle = css`
   flex-direction: column;
+  gap: var(--wds-accordion-details-gap, 0px);
+
   padding-top: calc(16px - var(--wds-list-cell-padding, 16px));
   padding-bottom: var(--wds-list-cell-padding, 16px);
-  padding-left: var(--wds-list-cell-fill-width-padding, 0px);
-  padding-right: var(--wds-list-cell-fill-width-padding, 0px);
+  padding-left: var(
+    --wds-accordion-details-padding-left,
+    calc(var(--wds-list-cell-fill-width-padding, 0px))
+  );
+  padding-right: var(
+    --wds-accordion-details-padding-right,
+    calc(var(--wds-list-cell-fill-width-padding, 0px))
+  );
 `;
 
 export const accordionDividerStyle = ({

--- a/packages/wds/src/components/accordion/style.ts
+++ b/packages/wds/src/components/accordion/style.ts
@@ -6,6 +6,17 @@ export const accordionStyle = ({ disabled }: { disabled: boolean }) => css`
   }
 `;
 
+export const accordionSummaryStyle = ({
+  disabled,
+}: {
+  disabled: boolean;
+}) => css`
+  ${!disabled &&
+  css`
+    cursor: pointer;
+  `}
+`;
+
 export const accordionSummaryTextStyle = css`
   min-height: 24px;
   justify-content: center;
@@ -42,29 +53,17 @@ export const accordionSummaryContentStyle = ({
   }
 `;
 
-export const accordionDetailsStyle = ({
-  expanded,
-}: {
-  expanded: boolean;
-}) => css`
-  display: grid;
-  grid-template-rows: 0fr;
-  will-change: grid-template-rows;
-  transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-
-  ${expanded &&
-  css`
-    grid-template-rows: 1fr;
-  `}
-
-  > div {
-    overflow: hidden;
-  }
+export const accordionDetailsStyle = css`
+  overflow: hidden;
+  height: 0px;
+  will-change: height, overflow;
+  transition:
+    height 0.3s cubic-bezier(0.25, 0.1, 0.25, 1),
+    overflow;
 `;
 
 export const accordionDetailsWrapperStyle = css`
   flex-direction: column;
-  gap: var(--wds-list-cell-padding, 16px);
   padding-top: calc(16px - var(--wds-list-cell-padding, 16px));
   padding-bottom: var(--wds-list-cell-padding, 16px);
   padding-left: var(--wds-list-cell-fill-width-padding, 0px);
@@ -88,4 +87,8 @@ export const accordionDividerStyle = ({
       opacity: 0;
     }
   `}
+`;
+
+export const accordionContentStyle = css`
+  margin-top: var(--wds-list-cell-padding, 16px);
 `;

--- a/packages/wds/src/components/accordion/style.ts
+++ b/packages/wds/src/components/accordion/style.ts
@@ -53,13 +53,25 @@ export const accordionSummaryContentStyle = ({
   }
 `;
 
-export const accordionDetailsStyle = css`
-  overflow: hidden;
-  height: 0px;
+export const accordionDetailsStyle = ({
+  initialExpanded,
+}: {
+  initialExpanded: boolean;
+}) => css`
   will-change: height, overflow;
   transition:
     height 0.3s cubic-bezier(0.25, 0.1, 0.25, 1),
     overflow;
+
+  ${initialExpanded
+    ? css`
+        height: auto;
+        overflow: visible;
+      `
+    : css`
+        overflow: hidden;
+        height: 0px;
+      `}
 `;
 
 export const accordionDetailsWrapperStyle = css`

--- a/packages/wds/src/components/accordion/types.ts
+++ b/packages/wds/src/components/accordion/types.ts
@@ -18,3 +18,5 @@ export type AccordionSummaryContentProps = Merge<
   },
   ListCellContentProps
 >;
+
+export type AccordionDetailsProps = {};


### PR DESCRIPTION
## 작업 내용

https://github.com/user-attachments/assets/d8dc6236-8f60-448f-9a48-bab08f51cf25

![스크린샷 2025-02-05 오전 11 13 52](https://github.com/user-attachments/assets/81678b4f-3eb4-4218-9ef8-02100ddce56b)





- `AccordionDetails`: 애니메이션 변경(grid rows 조정 --> height 조정): 내부 인터랙션 요소 잘림 방지
- `AccordionContent` 추가: 커스텀 콘텐츠 추가할 경우 간격 보정을 위한 `Box` 컴포넌트
- docs 보완: 중첩 아코디언, 추가 콘텐츠
  - 중첩 아코디언 가이드: 하위 아코디언에 disabledInteraction 가이드 추가
 
closes #232 