### PR TITLE
feat(wds): chip action, filter, badge 이전 버전 호환성 지원

### DIFF
--- a/packages/wds/src/components/chip-action/style.ts
+++ b/packages/wds/src/components/chip-action/style.ts
@@ -113,6 +113,7 @@ const actionVariantStyle = (
 ) => {
   switch (variant) {
     case 'solid':
+    case 'filled':
       return css`
         color: ${theme.palette.label.normal};
         background-color: ${theme.palette.fill.alternative};

--- a/packages/wds/src/components/chip-action/types.ts
+++ b/packages/wds/src/components/chip-action/types.ts
@@ -1,9 +1,14 @@
+/* FIXME 마이그레이션 시 filled 제거 필요 */
 import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
 import type { ReactNode } from 'react';
 
 export type ChipActionDefaultProps = {
   size?: 'xsmall' | 'small' | 'normal' | 'large';
-  variant?: 'solid' | 'outlined';
+  variant?:
+    | 'solid'
+    | 'outlined'
+    /** @deprecated */
+    | 'filled';
   active?: boolean;
   disabled?: boolean;
   disableInteraction?: boolean;

--- a/packages/wds/src/components/chip-filter/style.ts
+++ b/packages/wds/src/components/chip-filter/style.ts
@@ -140,6 +140,7 @@ const actionVariantStyle = (
 ) => {
   switch (variant) {
     case 'solid':
+    case 'filled':
       return css`
         color: ${theme.palette.label.normal};
         background-color: ${theme.palette.fill.alternative};

--- a/packages/wds/src/components/chip-filter/types.ts
+++ b/packages/wds/src/components/chip-filter/types.ts
@@ -1,11 +1,14 @@
+/* FIXME 마이그레이션 시 filled 제거 필요 */
 import type { ReactNode } from 'react';
 import type { Merge, ResponsiveProps } from '@wanteddev/wds-engine';
 
-export type ChipFilterVariant = 'solid' | 'outlined';
-
 export type ChipFilterDefaultProps = {
   size?: 'xsmall' | 'small' | 'normal' | 'large';
-  variant?: 'solid' | 'outlined';
+  variant?:
+    | 'solid'
+    | 'outlined'
+    /** @deprecated */
+    | 'filled';
   active?: boolean;
   expanded?: boolean;
   disabled?: boolean;

--- a/packages/wds/src/components/content-badge/style.ts
+++ b/packages/wds/src/components/content-badge/style.ts
@@ -71,6 +71,7 @@ const contentBadgeColorVariant = (
 
   switch (variant) {
     case 'solid':
+    case 'filled':
       return css`
         background-color: ${background};
         color: ${font};

--- a/packages/wds/src/components/content-badge/types.ts
+++ b/packages/wds/src/components/content-badge/types.ts
@@ -1,3 +1,4 @@
+/* FIXME 마이그레이션 시 filled 제거 필요 */
 import type {
   Merge,
   ResponsiveProps,
@@ -9,7 +10,11 @@ export type ContentBadgeDefaultProps = {
   leftContent?: ReactNode;
   rightContent?: ReactNode;
   size?: 'normal' | 'medium' | 'large';
-  variant?: 'solid' | 'outlined';
+  variant?:
+    | 'solid'
+    | 'outlined'
+    /** @deprecated */
+    | 'filled';
   color?: 'neutral' | 'accent';
   accentColor?: ThemeColorsToken;
   children?: ReactNode;


### PR DESCRIPTION
이번 버전은 minor가 아닌 patch 버전을 올리기 위해 이전 버전 호환성을 유지합니다.

3~4 월 사이에 아래 작업들을 함께 진행해서 한번에 마이그레이션 되면 좋을 것 같습니다.

- typography variant snake_case to kebab-case
- typography 에서 display 속성을 기본 inline 이 아닌 각 태그별 기본값으로 동작
- chip, filter, badge 이전버전 호환성 제거
- nested checkbox -> check mark
- 아이콘 circleClose 추가 및 기존 circleClose를 circleCloseFill로 변경
- 기타 디자인과 싱크 맞추어 용어 정리
  - size normal, medium 등

위 작업을 진행한 뒤 15개 프로젝트 일괄 마이그레이션
-> 이후 문서 재정비, 외부에 문서 공개

이렇게 진행하면 어떨까 싶습니다!