### PR TITLE
fix(wds): action area 간격이 디자인과 맞지 않음

### DIFF
--- a/packages/wds/src/components/action-area/index.tsx
+++ b/packages/wds/src/components/action-area/index.tsx
@@ -95,14 +95,18 @@ const ActionArea = forwardRef<
               >
                 {compactContent}
               </FlexBox>
-              <FlexBox flexShrink={0} gap="8px" data-role="action-area-wrapper">
+              <FlexBox
+                flexShrink={0}
+                gap="12px"
+                data-role="action-area-wrapper"
+              >
                 {children}
               </FlexBox>
             </FlexBox>
           ) : (
             <FlexBox
               flexDirection={priority === 'strong' ? 'column' : 'row'}
-              gap="8px"
+              gap={priority === 'strong' ? '8px' : '12px'}
               data-role="action-area-wrapper"
               alignSelf={priority === 'compact' ? 'flex-end' : 'initial'}
             >


### PR DESCRIPTION
`priority='compact'`, `priority='neutral'` 일 때 간격이 맞지 않아 조정하였습니다