### PR TITLE
feat(wds): accordion left-content 대응

### DIFF
--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -158,7 +158,7 @@ export default Demo;`}
 
 ### LeftContent, RightContent
 
-- AccordionSummary에 LeftContent를 추가하거나, 기본 rightContent를 교체할 수 있어요.
+- leftContent를 추가하거나 기본 rightContent를 교체할 수 있어요.
 - rightContent가 a 태그이거나 클릭 이벤트가 있는 경우 `e.stopPropagation` 을 통해 아코디언이 열리고 닫히는 동작을 막을 수 있어요.
 
 <Demo code={`import { Accordion, AccordionSummary, AccordionDetails, AccordionDescription, AccordionSummaryContent, IconButton } from '@wanteddev/wds';

--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -6,7 +6,7 @@ description: Accordion Component
 # Accordion
 
 - 내용을 최소화하거나 펼칠 때 사용합니다.
-- AccordionSummary의 rightContent를 교체할 때는 `AccordionSummaryContent`로 감싸주세요.
+- AccordionSummary에 leftContent를 추가하거나 rightContent를 교체할 때는 `AccordionSummaryContent`로 감싸주세요.
 
 ## 활용
 
@@ -156,13 +156,13 @@ const Demo = () => {
 export default Demo;`}
 />
 
-### RightContent
+### LeftContent, RightContent
 
-- AccordionSummary의 기본 rightContent를 교체할 수 있어요.
+- AccordionSummary에 LeftContent를 추가하거나, 기본 rightContent를 교체할 수 있어요.
 - rightContent가 a 태그이거나 클릭 이벤트가 있는 경우 `e.stopPropagation` 을 통해 아코디언이 열리고 닫히는 동작을 막을 수 있어요.
 
 <Demo code={`import { Accordion, AccordionSummary, AccordionDetails, AccordionDescription, AccordionSummaryContent, IconButton } from '@wanteddev/wds';
-import { IconCircleCheckFill, IconChevronDown, IconArrowRight, IconCaretDown } from '@wanteddev/wds-icon';
+import { IconCircleCheckFill, IconChevronDown, IconArrowRight, IconCaretDown, IconPlus } from '@wanteddev/wds-icon';
 import { useState } from 'react';
 
 const Demo = () => {
@@ -173,6 +173,24 @@ const Demo = () => {
       <Accordion disabled>
         <AccordionSummary>
           Disabled, true
+        </AccordionSummary>
+        <AccordionDetails>
+          <AccordionDescription>
+            제목에 대한 상세 내용을 입력해주세요.<br />
+            긴 컨텐츠라면 접은 상태를 기본 값으로 사용하세요.
+          </AccordionDescription>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion>
+        <AccordionSummary
+          leftContent={
+            <AccordionSummaryContent variant="icon">
+              <IconPlus />
+            </AccordionSummaryContent>
+          }
+        >
+          LeftContent, Icon<br />
         </AccordionSummary>
         <AccordionDetails>
           <AccordionDescription>

--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -6,7 +6,7 @@ import { composeEventHandlers } from '@radix-ui/primitive';
 
 import { ListCell, ListCellContent } from '../list';
 import Typography from '../typography';
-import { Divider, FlexBox, useComposedRefs, useSize } from '../..';
+import { Divider, FlexBox, Slot, useComposedRefs, useSize } from '../..';
 
 import {
   ACCORDION_CONTENT_NAME,
@@ -105,6 +105,7 @@ const AccordionSummary = forwardRef<
     {
       disabled: givenDisabled,
       children,
+      leftContent,
       rightContent,
       textProps,
       sx,
@@ -134,8 +135,19 @@ const AccordionSummary = forwardRef<
         aria-expanded={expanded}
         aria-controls={detailsId}
         id={summaryId}
+        {...(Boolean(leftContent) && {
+          leftContent: (
+            <Slot data-role="accordion-summary-left-content">
+              {leftContent}
+            </Slot>
+          ),
+        })}
         rightContent={
-          rightContent ?? (
+          Boolean(rightContent) ? (
+            <Slot data-role="accordion-summary-right-content">
+              {rightContent}
+            </Slot>
+          ) : (
             <AccordionSummaryContent
               variant="icon"
               data-role="accordion-summary-expand-icon"
@@ -180,7 +192,10 @@ const AccordionSummaryContent = forwardRef<
       ref={ref}
       {...props}
       sx={[
-        accordionSummaryContentStyle({ expanded, disableExpandIconAnimation }),
+        accordionSummaryContentStyle({
+          expanded,
+          disableExpandIconAnimation,
+        }),
         sx,
       ]}
     />

--- a/packages/wds/src/components/accordion/style.ts
+++ b/packages/wds/src/components/accordion/style.ts
@@ -35,21 +35,24 @@ export const accordionSummaryContentStyle = ({
   height: 20px;
   z-index: 1;
 
-  ${!disableExpandIconAnimation &&
-  css`
-    will-change: transform;
-    transform: rotate(0deg);
-    transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
-
-    ${expanded &&
-    css`
-      transform: rotate(180deg);
-    `}
-  `}
-
   [wds-component='icon-button'] {
     width: 100%;
     height: 100%;
+  }
+
+  &[data-role='accordion-summary-expand-icon'],
+  &[data-role='accordion-summary-right-content'] {
+    ${!disableExpandIconAnimation &&
+    css`
+      will-change: transform;
+      transform: rotate(0deg);
+      transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+
+      ${expanded &&
+      css`
+        transform: rotate(180deg);
+      `}
+    `}
   }
 `;
 


### PR DESCRIPTION
<img width="893" alt="스크린샷 2025-02-12 오후 3 34 59" src="https://github.com/user-attachments/assets/604f163b-6152-4f67-a36c-a008cfa1febe" />

## 작업 내용

- leftContent 예시 추가
- leftContent는 회전 애니메이션 반영 안 되도록 분기처리



(+ align이 묘하게 틀어지는 거 같아서 채리님께 확인 한번 받고 스타일 추가로 수정할 수 있습니닷)