### PR TITLE
fix(wds): date-calendar year range 비교 수정

### DIFF
--- a/docs/src/docs/components/date-picker.mdx
+++ b/docs/src/docs/components/date-picker.mdx
@@ -101,8 +101,8 @@ export default Demo;`}
 <Demo code={`import { DatePicker, FlexBox, FormErrorMessage, FormField, FormLabel, FormControl } from '@wanteddev/wds';
 import { Controller, useForm } from 'react-hook-form';
 
-const minDate = new Date('2000-01-01T00:00:00Z');
-const maxDate = new Date('2025-12-31T23:59:59Z');
+const minDate = new Date('2000-01-01');
+const maxDate = new Date('2025-12-31');
 
 const Demo = () => {
   const form = useForm({

--- a/packages/wds/src/components/date-calendar/index.tsx
+++ b/packages/wds/src/components/date-calendar/index.tsx
@@ -368,17 +368,16 @@ const YearCalendar = forwardRef<
   } = useDateCalendarContext('YearCalendar');
 
   const yearRange = useMemo(() => {
-    const startDate = dayjsTimezone(dayjs(min ?? ACCESSIBLE_MIN_DATE), timezone)
-      .set('month', 11)
-      .set('day', 31);
-    const endDate = dayjsTimezone(dayjs(max ?? ACCESSIBLE_MAX_DATE), timezone)
-      .set('month', 11)
-      .set('day', 31);
+    const startDate = dayjsTimezone(
+      dayjs(min ?? ACCESSIBLE_MIN_DATE),
+      timezone,
+    );
+    const endDate = dayjsTimezone(dayjs(max ?? ACCESSIBLE_MAX_DATE), timezone);
     const years: Array<number> = [];
 
     let current = startDate;
 
-    while (current.isBefore(endDate, 'year')) {
+    while (current.year() <= endDate.year()) {
       years.push(current.get('year'));
       current = current.add(1, 'year');
     }


### PR DESCRIPTION
## 작업 내용

- 이슈: min, max가 utc --> 로컬 시간대로 변환되면서 시간대에 따라 노출되는 max year이 달라짐
- 수정
  - min, max를 로컬 시간대로 설정하도록 가이드
  - yearRange에서 연도만 비교하도록 변경

코드 수정을 하지 않고 사용하는 측에서 대응할 수 있거나, 더 간단히 반영할 수 있는 방법이 있다면 공유 부탁드립니다.

## 참고
- https://wantedx.slack.com/archives/C06RQUTEURL/p1739518715180949