### PR TITLE
feat(wds): autocomplete 첫 포커스 비활성화 옵션 추가

### DIFF
--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -440,59 +440,60 @@ const AutocompleteInput = forwardRef<HTMLElement, SlotProps>(
 
 AutocompleteInput.displayName = AUTOCOMPLETE_TRIGGER_NAME;
 
-const AutocompleteList = forwardRef<HTMLDivElement, AutocompleteListProps>(
-  ({ children, ...props }, ref) => {
-    const {
-      input,
-      open,
-      contentId,
-      asSelect,
-      value,
-      width,
-      onSelectedOptionChange,
-    } = useAutocompleteContext(AUTOCOMPLETE_LIST_NAME);
-    const getItems = useCollection(AUTOCOMPLETE_SCOPE);
+const AutocompleteList = forwardRef<
+  HTMLDivElement,
+  DefaultComponentProps<AutocompleteListProps, 'div'>
+>(({ children, disableTrappedContent = false, ...props }, ref) => {
+  const {
+    input,
+    open,
+    contentId,
+    asSelect,
+    value,
+    width,
+    onSelectedOptionChange,
+  } = useAutocompleteContext(AUTOCOMPLETE_LIST_NAME);
+  const getItems = useCollection(AUTOCOMPLETE_SCOPE);
 
-    useLayoutEffect(() => {
-      if (!open || !asSelect) return;
+  useLayoutEffect(() => {
+    if (!open || !asSelect || disableTrappedContent) return;
 
-      requestAnimationFrame(() => {
-        const items = getItems();
+    requestAnimationFrame(() => {
+      const items = getItems();
 
-        const option = items.find((v) => v.value === value);
+      const option = items.find((v) => v.value === value);
 
-        focusSelectedOption(option, items);
-        onSelectedOptionChange(option ?? null);
-      });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [open]);
+      focusSelectedOption(option, items);
+      onSelectedOptionChange(option ?? null);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, disableTrappedContent]);
 
-    return open && !input?.readOnly && !input?.disabled ? (
-      <PopperContent
-        role="presentation"
-        ref={ref}
-        offset={8}
-        {...props}
-        sx={[{ width }, autocompleteListStyle, props.sx]}
+  return open && !input?.readOnly && !input?.disabled ? (
+    <PopperContent
+      role="presentation"
+      ref={ref}
+      offset={8}
+      {...props}
+      sx={[{ width }, autocompleteListStyle, props.sx]}
+    >
+      <ScrollArea
+        scrollbars="vertical"
+        size="small"
+        viewportProps={{ sx: autocompleteScrollAreaStyle }}
       >
-        <ScrollArea
-          scrollbars="vertical"
-          size="small"
-          viewportProps={{ sx: autocompleteScrollAreaStyle }}
+        <List
+          role="listbox"
+          id={contentId}
+          gap="4px"
+          onMouseDown={(e) => e.preventDefault()}
         >
-          <List
-            role="listbox"
-            id={contentId}
-            gap="4px"
-            onMouseDown={(e) => e.preventDefault()}
-          >
-            {children}
-          </List>
-        </ScrollArea>
-      </PopperContent>
-    ) : null;
-  },
-);
+          {children}
+        </List>
+      </ScrollArea>
+    </PopperContent>
+  ) : null;
+});
 
 AutocompleteList.displayName = AUTOCOMPLETE_LIST_NAME;
 

--- a/packages/wds/src/components/autocomplete/types.ts
+++ b/packages/wds/src/components/autocomplete/types.ts
@@ -1,12 +1,7 @@
+import type { PopperContentProps } from '../popper/types';
 import type { ListCellProps } from '../list/types';
 import type { Merge } from '@wanteddev/wds-engine';
-import type { PopperContent } from '../popper';
-import type {
-  ComponentPropsWithoutRef,
-  PropsWithChildren,
-  ReactNode,
-  RefObject,
-} from 'react';
+import type { PropsWithChildren, ReactNode, RefObject } from 'react';
 
 export type AutocompleteProps = {
   value?: string;
@@ -28,8 +23,14 @@ export type AutocompleteProps = {
 
 export type AutocompleteTriggerProps = PropsWithChildren;
 
-export type AutocompleteListProps = ComponentPropsWithoutRef<
-  typeof PopperContent
+export type AutocompleteListProps = Merge<
+  {
+    /**
+     * asSelect=`true` 일 때 첫 포커스를 지정하지 않습니다.
+     */
+    disableTrappedContent?: boolean;
+  },
+  PopperContentProps
 >;
 
 export type AutocompleteOptionProps = Merge<


### PR DESCRIPTION
이력서 작업 중 대응이 필요해서 `disableTrappedContent=true` 일 때 첫 포커스 관련 동작을 하지 않습니다.