### PR TITLE
feat(wds): mix blend mode를 사용하는 부분 브라우저별 차이 최소화

### DIFF
--- a/packages/wds/src/components/icon-button/index.tsx
+++ b/packages/wds/src/components/icon-button/index.tsx
@@ -5,11 +5,7 @@ import { Box } from '@wanteddev/wds-engine';
 import WithInteraction from '../with-interaction';
 import PushBadge from '../push-badge';
 
-import {
-  backgroundBlendLayerStyle,
-  backgroundBlendStyle,
-  iconButtonStyle,
-} from './style';
+import { backgroundBlendStyle, iconButtonStyle } from './style';
 import { useIconButtonContext } from './contexts';
 
 import type {
@@ -124,20 +120,12 @@ const IconButton = forwardRef(
           ]}
         >
           {variant === 'background' && !alternative && (
-            <>
-              <Box
-                as="span"
-                role="presentation"
-                data-role="icon-button-background-blend"
-                sx={backgroundBlendStyle}
-              />
-              <Box
-                as="span"
-                role="presentation"
-                data-role="icon-button-background-blend-layer"
-                sx={backgroundBlendLayerStyle}
-              />
-            </>
+            <Box
+              as="span"
+              role="presentation"
+              data-role="icon-button-background-blend"
+              sx={backgroundBlendStyle}
+            />
           )}
           {children}
 

--- a/packages/wds/src/components/icon-button/style.ts
+++ b/packages/wds/src/components/icon-button/style.ts
@@ -182,7 +182,7 @@ const iconButtonColorStyle = (
           css`
             @supports (-webkit-backdrop-filter: none) {
               will-change: mix-blend-mode;
-              mix-blend-mode: difference;
+              mix-blend-mode: plus-darker;
             }
           `}
         }
@@ -195,6 +195,12 @@ const iconButtonColorStyle = (
         &::before {
           position: absolute;
           content: '';
+          width: calc(100% + 8px);
+          height: calc(100% + 8px);
+          top: -4px;
+          left: -4px;
+          border-radius: inherit;
+
           ${alternative
             ? css`
                 background-color: ${addOpacity(
@@ -203,13 +209,25 @@ const iconButtonColorStyle = (
                 )};
               `
             : css`
-                backdrop-filter: blur(32px);
+                background-color: ${addOpacity(
+                  theme.palette.static.white,
+                  theme.opacity[52],
+                )};
+                will-change: backdrop-filter;
+                backdrop-filter: blur(32px) saturate(150%) brightness(150%);
+
+                @supports (-webkit-backdrop-filter: none) {
+                  clip-path: inset(0 round 1000px);
+                  overflow: auto;
+                  border-radius: 0;
+                }
+
+                @supports (-moz-appearance: none) {
+                  clip-path: inset(0 round 1000px);
+                  overflow: auto;
+                  border-radius: 0;
+                }
               `}
-          width: calc(100% + 8px);
-          height: calc(100% + 8px);
-          top: -4px;
-          left: -4px;
-          border-radius: inherit;
         }
 
         &:focus-visible {
@@ -236,7 +254,6 @@ const iconButtonColorStyle = (
           &::before {
             background-color: ${theme.palette.fill.alternative};
             backdrop-filter: none;
-            mix-blend-mode: initial;
           }
 
           svg {
@@ -290,29 +307,14 @@ const iconButtonColorStyle = (
 export const backgroundBlendStyle = (theme: Theme) => css`
   position: absolute;
   content: '';
-  width: calc(100% + 8px);
-  height: calc(100% + 8px);
-  top: -4px;
-  left: -4px;
-  border-radius: inherit;
-  background-color: ${addOpacity(
-    theme.palette.static.white,
-    theme.opacity[35],
-  )};
-
-  @supports (-webkit-backdrop-filter: none) {
-    mix-blend-mode: plus-lighter;
-    will-change: mix-blend-mode;
-  }
-`;
-
-export const backgroundBlendLayerStyle = (theme: Theme) => css`
-  position: absolute;
-  content: '';
   background-color: ${addOpacity(theme.palette.static.black, theme.opacity[5])};
   width: calc(100% + 8px);
   height: calc(100% + 8px);
   top: -4px;
   left: -4px;
   border-radius: inherit;
+
+  @supports (-webkit-backdrop-filter: none) {
+    background-color: ${addOpacity(theme.palette.static.black, 0.14)};
+  }
 `;

--- a/packages/wds/src/components/pagination-counter/index.tsx
+++ b/packages/wds/src/components/pagination-counter/index.tsx
@@ -3,11 +3,7 @@ import { Box } from '@wanteddev/wds-engine';
 
 import FlexBox from '../flex-box';
 
-import {
-  backgroundBlendLayerStyle,
-  backgroundBlendStyle,
-  paginationCounterStyle,
-} from './style';
+import { backgroundBlendStyle, paginationCounterStyle } from './style';
 
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { PaginationCounterProps } from './types';
@@ -42,20 +38,12 @@ const PaginationCounter = forwardRef<
         ]}
       >
         {!alternative && (
-          <>
-            <Box
-              as="span"
-              role="presentation"
-              data-role="pagination-counter-background-blend"
-              sx={backgroundBlendStyle}
-            />
-            <Box
-              as="span"
-              role="presentation"
-              data-role="pagination-counter-background-blend-layer"
-              sx={backgroundBlendLayerStyle}
-            />
-          </>
+          <Box
+            as="span"
+            role="presentation"
+            data-role="pagination-counter-background-blend"
+            sx={backgroundBlendStyle}
+          />
         )}
 
         <span data-role="pagination-counter-text">{currentPage}</span>

--- a/packages/wds/src/components/pagination-counter/style.ts
+++ b/packages/wds/src/components/pagination-counter/style.ts
@@ -34,6 +34,7 @@ export const paginationCounterStyle =
     &::before {
       position: absolute;
       content: '';
+      border-radius: inherit;
       ${alternative
         ? css`
             background-color: ${addOpacity(
@@ -42,13 +43,23 @@ export const paginationCounterStyle =
             )};
           `
         : css`
-            backdrop-filter: blur(32px);
+            will-change: backdrop-filter;
+            backdrop-filter: blur(32px) saturate(150%) brightness(150%);
+            background-color: ${addOpacity(
+              theme.palette.static.white,
+              theme.opacity[35],
+            )};
+
+            @supports (-webkit-backdrop-filter: none) {
+              clip-path: inset(0 round 1000px);
+              overflow: auto;
+              border-radius: 0;
+            }
           `}
       width: 100%;
       height: 100%;
       top: 0px;
       left: 0px;
-      border-radius: inherit;
     }
 
     ${alternative
@@ -74,28 +85,10 @@ export const paginationCounterStyle =
               text-shadow: 0px 0px 6px
                 ${addOpacity(theme.palette.static.black, theme.opacity[8])};
             }
-
-            @supports (-webkit-backdrop-filter: none) {
-              color: ${addOpacity(
-                theme.palette.coolNeutral[70],
-                theme.opacity[74],
-              )};
-              will-change: mix-blend-mode;
-              mix-blend-mode: plus-lighter;
-            }
           }
 
           [data-role='pagination-counter-divider'] {
-            color: ${addOpacity(theme.palette.static.white, theme.opacity[28])};
-
-            @supports (-webkit-backdrop-filter: none) {
-              color: ${addOpacity(
-                theme.palette.coolNeutral[70],
-                theme.opacity[28],
-              )};
-              will-change: mix-blend-mode;
-              mix-blend-mode: plus-lighter;
-            }
+            color: ${addOpacity(theme.palette.static.white, theme.opacity[61])};
           }
         `}
 
@@ -146,29 +139,10 @@ const paginationCounterSizeStyle = ({
 export const backgroundBlendStyle = (theme: Theme) => css`
   position: absolute;
   content: '';
-  width: 100%;
-  height: 100%;
-  top: 0px;
-  left: 0px;
-  border-radius: inherit;
-  background-color: ${addOpacity(
-    theme.palette.static.white,
-    theme.opacity[35],
-  )};
-
-  @supports (-webkit-backdrop-filter: none) {
-    mix-blend-mode: plus-lighter;
-    will-change: mix-blend-mode;
-  }
-`;
-
-export const backgroundBlendLayerStyle = (theme: Theme) => css`
   background-color: ${addOpacity(
     theme.palette.static.black,
     theme.opacity[28],
   )};
-  position: absolute;
-  content: '';
   width: 100%;
   height: 100%;
   top: 0px;

--- a/packages/wds/src/components/top-navigation/style.ts
+++ b/packages/wds/src/components/top-navigation/style.ts
@@ -176,7 +176,7 @@ export const topNavigationButtonFloat = ({
     css`
       @supports (-webkit-backdrop-filter: none) {
         will-change: mix-blend-mode;
-        mix-blend-mode: difference;
+        mix-blend-mode: plus-darker;
       }
     `}
   }


### PR DESCRIPTION
https://wantedx.slack.com/archives/C04TTGN5F1C/p1737531113734099

## 배경

safari 에서만 mix-blend-mode를 이용하여 어떤 배경 이미지가 와도 완벽히 의도대로 보여졌는데
이번에 `backdrop-filter: blur(32px) saturate(150%) brightness(150%);` 를 통해 chrome에서도 의도한 바와 최대한 가깝게
보여지도록 형진님께서 보정해주셨습니다.

position: fixed 로 사용할 때 safari만 색상이 그대로이고, 다른 브라우저에서는 올바르게 적용되지 않아서 safari에서만 mix-blend-mode를 사용 했었습니다.


- IconButton variant="background" alternative={false}
- PaginationCounter alternative={false}
- TopNavigation variant="floating" > TopNavigationButton variant="text" background={true} alternative={false}
