### PR TITLE
feat(wds): button loading 상태일 때 일부 이벤트 동작을 막도록 설정

### DIFF
--- a/docs/src/docs/components/button.mdx
+++ b/docs/src/docs/components/button.mdx
@@ -101,8 +101,13 @@ export default Demo;`}
 
 ## Loading
 
-`loading` 옵션을 통해 로딩 상태를 트리거 할 수 있습니다.
-onClick 이벤트를 막지 않으므로 onClick 이벤트를 막기 위해서 별도 처리가 필요합니다.
+- `loading` 옵션을 통해 로딩 상태를 트리거 할 수 있습니다.
+- 로딩 상태일 때 아래 이벤트 실행을 막습니다.
+  - onClick
+  - onMouseDown
+  - onPointerDown
+  - onKeyDown `(e.key === 'Enter' || e.key === ' ')`
+- 이벤트 실행을 막지 않으려면 `disableLoadingPreventEvents` 옵션을 통해 실행할 수 있습니다.
 
 <Demo code={`import { Button, FlexBox } from '@wanteddev/wds';
 import { useState, useEffect } from 'react';

--- a/docs/src/docs/components/text-button.mdx
+++ b/docs/src/docs/components/text-button.mdx
@@ -47,8 +47,13 @@ export default Demo;`}
 
 ## Loading
 
-`loading` 옵션을 통해 로딩 상태를 트리거 할 수 있습니다.
-onClick 이벤트를 막지 않으므로 onClick 이벤트를 막기 위해서 별도 처리가 필요합니다.
+- `loading` 옵션을 통해 로딩 상태를 트리거 할 수 있습니다.
+- 로딩 상태일 때 아래 이벤트 실행을 막습니다.
+  - onClick
+  - onMouseDown
+  - onPointerDown
+  - onKeyDown `(e.key === 'Enter' || e.key === ' ')`
+- 이벤트 실행을 막지 않으려면 `disableLoadingPreventEvents` 옵션을 통해 실행할 수 있습니다.
 
 <Demo code={`import { TextButton, FlexBox } from '@wanteddev/wds';
 import { useState, useEffect } from 'react';

--- a/packages/wds/src/components/action-area/types.ts
+++ b/packages/wds/src/components/action-area/types.ts
@@ -46,4 +46,8 @@ export type ActionButtonProps = {
    */
   buttonColor?: ButtonProps['color'];
   loading?: ButtonProps['loading'];
+  /**
+   * loading=true 일 때 event 막는 동작을 비활성화합니다.
+   */
+  disableLoadingPreventEvents?: boolean;
 };

--- a/packages/wds/src/components/button/index.tsx
+++ b/packages/wds/src/components/button/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { forwardRef, useId } from 'react';
 import { Box } from '@wanteddev/wds-engine';
+import { composeEventHandlers } from '@radix-ui/primitive';
 
 import WithInteraction from '../with-interaction';
 import Loading from '../loading';
@@ -12,7 +13,7 @@ import type {
   PolymorphicProps,
   ThemeColorsToken,
 } from '@wanteddev/wds-engine';
-import type { ElementType, ForwardedRef } from 'react';
+import type { ElementType, ForwardedRef, SyntheticEvent } from 'react';
 import type { ButtonProps } from './types';
 
 const Button = forwardRef(
@@ -29,6 +30,7 @@ const Button = forwardRef(
       leftContent,
       rightContent,
       size = 'medium',
+      disableLoadingPreventEvents,
       children,
       xs,
       sm,
@@ -57,6 +59,13 @@ const Button = forwardRef(
       }
     };
 
+    const handlePreventEventsLoading = (e: SyntheticEvent) => {
+      if (loading && !disableLoadingPreventEvents) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
     return (
       <WithInteraction
         color={interactionColor}
@@ -71,6 +80,23 @@ const Button = forwardRef(
           aria-disabled={disabled}
           type="button"
           {...props}
+          onClick={composeEventHandlers(
+            handlePreventEventsLoading,
+            props.onClick,
+          )}
+          onMouseDown={composeEventHandlers(
+            handlePreventEventsLoading,
+            props.onMouseDown,
+          )}
+          onPointerDown={composeEventHandlers(
+            handlePreventEventsLoading,
+            props.onPointerDown,
+          )}
+          onKeyDown={composeEventHandlers((e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              handlePreventEventsLoading(e);
+            }
+          }, props.onKeyDown)}
           sx={[
             buttonStyle({
               variant,

--- a/packages/wds/src/components/button/types.ts
+++ b/packages/wds/src/components/button/types.ts
@@ -17,6 +17,10 @@ export type ButtonDefaultProps = {
   iconOnly?: boolean;
   children?: ReactNode;
   loading?: boolean;
+  /**
+   * loading=true 일 때 event 막는 동작을 비활성화합니다.
+   */
+  disableLoadingPreventEvents?: boolean;
 };
 
 export type ButtonResponsiveProps = ResponsiveProps<

--- a/packages/wds/src/components/text-button/index.tsx
+++ b/packages/wds/src/components/text-button/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { forwardRef, useId, useMemo } from 'react';
 import { Box } from '@wanteddev/wds-engine';
+import { composeEventHandlers } from '@radix-ui/primitive';
 
 import WithInteraction from '../with-interaction';
 import Loading from '../loading';
@@ -13,7 +14,7 @@ import type {
   PolymorphicProps,
   ThemeColorsToken,
 } from '@wanteddev/wds-engine';
-import type { ElementType, ForwardedRef } from 'react';
+import type { ElementType, ForwardedRef, SyntheticEvent } from 'react';
 import type { TextButtonProps } from './types';
 
 const TextButton = forwardRef(
@@ -28,6 +29,7 @@ const TextButton = forwardRef(
       size = 'medium',
       children,
       loading = false,
+      disableLoadingPreventEvents,
       xs,
       sm,
       md,
@@ -47,6 +49,13 @@ const TextButton = forwardRef(
       return context?.[variant];
     }, [context, variant]);
 
+    const handlePreventEventsLoading = (e: SyntheticEvent) => {
+      if (loading && !disableLoadingPreventEvents) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
     return (
       <WithInteraction
         color={interactionColor}
@@ -64,6 +73,23 @@ const TextButton = forwardRef(
           disabled={disabled}
           aria-disabled={disabled}
           {...props}
+          onClick={composeEventHandlers(
+            handlePreventEventsLoading,
+            props.onClick,
+          )}
+          onMouseDown={composeEventHandlers(
+            handlePreventEventsLoading,
+            props.onMouseDown,
+          )}
+          onPointerDown={composeEventHandlers(
+            handlePreventEventsLoading,
+            props.onPointerDown,
+          )}
+          onKeyDown={composeEventHandlers((e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              handlePreventEventsLoading(e);
+            }
+          }, props.onKeyDown)}
           sx={[
             textButtonStyle({
               color,

--- a/packages/wds/src/components/text-button/types.ts
+++ b/packages/wds/src/components/text-button/types.ts
@@ -12,6 +12,10 @@ export type TextButtonDefaultProps = {
   rightContent?: ReactNode;
   children?: ReactNode;
   loading?: boolean;
+  /**
+   * loading=true 일 때 event 막는 동작을 비활성화합니다.
+   */
+  disableLoadingPreventEvents?: boolean;
 };
 
 export type TextButtonResponsiveProps = ResponsiveProps<

--- a/packages/wds/src/components/text-field/types.ts
+++ b/packages/wds/src/components/text-field/types.ts
@@ -43,6 +43,10 @@ export type TextFieldContentProps = PropsWithChildren<{
 export type TextFieldButtonProps = {
   variant?: 'normal' | 'assistive';
   loading?: boolean;
+  /**
+   * loading=true 일 때 event 막는 동작을 비활성화합니다.
+   */
+  disableLoadingPreventEvents?: boolean;
   disabled?: boolean;
   leftContent?: ReactNode;
   rightContent?: ReactNode;


### PR DESCRIPTION
ios, android와 동작을 맞추었습니다.
인터렉션 UI는 그대로 표시되어야 하기 때문에 pointer-events: none 을 사용할 수 없고, 키보드로 포커스를 할 수 있어야 하기 때문에 disabled를 사용할 수 없어 수동으로 이벤트를 막습니다.

`disableLoadingPreventEvents` 옵션을 통해 loading 상태에서도 정상적으로 이벤트 실행이 되게 구성할 수 있습니다.