### PR TITLE
feat(wds): section header 디자인 업데이트

### DIFF
--- a/packages/wds/src/components/section-header/index.tsx
+++ b/packages/wds/src/components/section-header/index.tsx
@@ -47,7 +47,7 @@ const SectionHeader = forwardRef<
       <FlexBox
         ref={ref}
         {...props}
-        gap="16px"
+        gap="12px"
         sx={[
           sectionHeaderStyle({ size, platform, color, xs, sm, md, lg, xl }),
           props.sx,
@@ -55,11 +55,13 @@ const SectionHeader = forwardRef<
       >
         <FlexBox
           data-role="section-header-content"
-          gap="10px"
+          gap="12px"
           flex="1 0 0"
-          alignItems="center"
+          alignItems="flex-end"
         >
-          <Box as={headingTag}>{children}</Box>
+          <Box as={headingTag} data-role="section-header-content-heading">
+            {children}
+          </Box>
 
           {Boolean(leftContent) && (
             <FlexBox

--- a/packages/wds/src/components/section-header/style.ts
+++ b/packages/wds/src/components/section-header/style.ts
@@ -15,12 +15,7 @@ export const sectionHeaderStyle =
     width: 100%;
 
     [data-role='section-header-content'],
-    [data-role='section-header-content'] > h1,
-    [data-role='section-header-content'] > h2,
-    [data-role='section-header-content'] > h3,
-    [data-role='section-header-content'] > h4,
-    [data-role='section-header-content'] > h5,
-    [data-role='section-header-content'] > h6 {
+    [data-role='section-header-content-heading'] {
       font: inherit;
       color: inherit;
     }
@@ -29,7 +24,7 @@ export const sectionHeaderStyle =
       [wds-component='icon-button'][data-variant='normal'],
     [data-role='section-header-left-content']
       [wds-component='icon-button'][data-variant='normal'] {
-      color: ${theme.palette.label.alternative};
+      color: ${theme.palette.label.assistive};
     }
 
     ${sectionHeaderSizeStyle({ size, color, platform }, theme)}


### PR DESCRIPTION
## 내용

gap 16px -> 12px로 변경되었습니다.

![image](https://github.com/user-attachments/assets/0ed66ebe-1ad8-419c-bf53-c0ae9496d7b9)

좌측 콘텐츠의 align items가 center -> flex-end로 변경되었습니다.
![image](https://github.com/user-attachments/assets/82213d36-47c2-4944-b4a5-d587310ae17f)

icon button의 기본 색상이 변경되었습니다.
![image](https://github.com/user-attachments/assets/dbd9282f-fce5-44e6-8827-52e778d418ec)

leading, trailing 으로 네이밍 변경하는 건은 한번에 제가 작업해두겠습니다

## JIRA

https://wantedlab.atlassian.net/browse/PI-72591

