### PR TITLE
fix(wds): touch device에서 modal과 함께 autocomplete를 사용할 경우 클릭 이벤트가 올바르지 않음

### DIFF
--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -168,8 +168,8 @@ const AutocompleteRoot = forwardRef<
       ref={ref}
       {...props}
       sx={[{ width: 'fit-content' }, props.sx]}
-      onPointerDown={composeEventHandlers(
-        props.onPointerDown,
+      onClick={composeEventHandlers(
+        props.onClick,
         useCallback(
           (event: MouseEvent) => {
             if (!event.currentTarget.contains(event.target as HTMLElement)) {
@@ -407,7 +407,7 @@ const AutocompleteInput = forwardRef<HTMLElement, SlotProps>(
               }
             });
           })}
-          onPointerDown={composeEventHandlers(props.onPointerDown, () => {
+          onClick={composeEventHandlers(props.onClick, () => {
             if (value === '' || (!open && !input?.disabled)) {
               onOpenChange(!open);
             }
@@ -510,6 +510,7 @@ const AutocompleteOption = forwardRef<
     value: contextValue,
     onInputValueChange,
     asSelect,
+    selectedOption,
     onSelectedOptionChange,
     onSearch,
     onOpenChange,
@@ -533,7 +534,7 @@ const AutocompleteOption = forwardRef<
         role="option"
         {...props}
         sx={[autocompleteOptionStyle, props.sx]}
-        onMouseEnter={composeEventHandlers(props.onMouseEnter, (e) => {
+        onTouchStart={composeEventHandlers(props.onTouchStart, (e) => {
           if (disabled) return;
 
           const items = getItems();
@@ -546,6 +547,22 @@ const AutocompleteOption = forwardRef<
           );
           setAttributeSelection(ref.current, items, true);
         })}
+        onMouseMove={composeEventHandlers(props.onMouseEnter, (e) => {
+          if (disabled) return;
+
+          const items = getItems();
+
+          const target = items.find(
+            (v) =>
+              v.ref.current ===
+              (e.currentTarget as unknown as HTMLButtonElement),
+          );
+
+          if (target?.ref !== selectedOption?.ref) {
+            onSelectedOptionChange(target ?? null);
+            setAttributeSelection(ref.current, items, true);
+          }
+        })}
         rightContent={
           active ? (
             <ListCellContent variant="icon">
@@ -553,7 +570,7 @@ const AutocompleteOption = forwardRef<
             </ListCellContent>
           ) : null
         }
-        onMouseDown={composeEventHandlers(props.onMouseDown, (e) => {
+        onClick={composeEventHandlers(props.onClick, (e) => {
           if (disabled) return e.preventDefault();
 
           onInputValueChange(value);
@@ -565,7 +582,6 @@ const AutocompleteOption = forwardRef<
             input?.focus();
           });
         })}
-        onClick={composeEventHandlers(props.onClick, (e) => e.preventDefault())}
       >
         {children}
       </ListCell>

--- a/packages/wds/src/components/search-input/index.tsx
+++ b/packages/wds/src/components/search-input/index.tsx
@@ -57,28 +57,6 @@ const SearchInput = forwardRef<
           }),
           sx,
         ]}
-        onPointerDown={(event) => {
-          const target = event.target as HTMLElement;
-          if (target.closest('input, button, a')) return;
-
-          const input = inputRef.current;
-          if (!input || target.tagName === 'INPUT') return;
-
-          requestAnimationFrame(() => {
-            input.dispatchEvent(
-              new PointerEvent('pointerdown', {
-                bubbles: false,
-              }),
-            );
-
-            props.onPointerDown?.({
-              ...event,
-              currentTarget: input as EventTarget & HTMLInputElement,
-              bubbles: false,
-            });
-            input.focus();
-          });
-        }}
         onClick={(event) => {
           const target = event.target as HTMLElement;
           if (target.closest('input, button, a')) return;
@@ -91,6 +69,7 @@ const SearchInput = forwardRef<
           if (!input || target.tagName === 'INPUT') return;
 
           requestAnimationFrame(() => {
+            input.focus();
             input.click();
           });
         }}

--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -169,29 +169,6 @@ const TextArea = forwardRef<
             ...style,
           }}
           gap="12px"
-          onPointerDown={(event) => {
-            const target = event.target as HTMLElement;
-            if (target.closest('input, textarea, button, a')) return;
-
-            const textArea = textAreaRef.current;
-            if (!textArea || target.tagName === 'TEXTAREA') return;
-
-            requestAnimationFrame(() => {
-              textArea.dispatchEvent(
-                new PointerEvent('pointerdown', {
-                  bubbles: false,
-                }),
-              );
-
-              props.onPointerDown?.({
-                ...event,
-                currentTarget: textArea as EventTarget & HTMLTextAreaElement,
-                bubbles: false,
-              });
-
-              textArea.focus();
-            });
-          }}
           onClick={(event) => {
             const target = event.target as HTMLElement;
             if (target.closest('input, textarea, button, a')) return;
@@ -204,6 +181,7 @@ const TextArea = forwardRef<
             if (!textArea || target.tagName === 'TEXTAREA') return;
 
             requestAnimationFrame(() => {
+              textArea.focus();
               textArea.click();
             });
           }}

--- a/packages/wds/src/components/text-input/index.tsx
+++ b/packages/wds/src/components/text-input/index.tsx
@@ -87,28 +87,6 @@ const TextInput = forwardRef<
           }),
           sx,
         ]}
-        onPointerDown={(event) => {
-          const target = event.target as HTMLElement;
-          if (target.closest('input, button, a')) return;
-
-          const input = inputRef.current;
-          if (!input || target.tagName === 'INPUT') return;
-
-          requestAnimationFrame(() => {
-            input.dispatchEvent(
-              new PointerEvent('pointerdown', {
-                bubbles: false,
-              }),
-            );
-
-            props.onPointerDown?.({
-              ...event,
-              currentTarget: input as EventTarget & HTMLInputElement,
-              bubbles: false,
-            });
-            input.focus();
-          });
-        }}
         onClick={(event) => {
           const target = event.target as HTMLElement;
           if (target.closest('input, button, a')) return;
@@ -121,6 +99,7 @@ const TextInput = forwardRef<
           if (!input || target.tagName === 'INPUT') return;
 
           requestAnimationFrame(() => {
+            input.focus();
             input.click();
           });
         }}


### PR DESCRIPTION
@1000peach 하이파이브 신청하기 모달 (모바일 환경) 에서 영상처럼 이상하게 동작하는 케이스가 있었습니다.

https://github.com/user-attachments/assets/60cc8eef-215a-410c-8f03-7ed81aef38dd

기본적으로 pointerdown -> pointerup -> onclick 순서로 이벤트가 실행되는데

Autocomplete의 onPointerDown 으로 AutocompleteList open -> 키보드 올라옴 -> pointerup -> 다른 곳 click 됨 -> 바로 포커스 해제

이런 현상이 있어서 pointerdown 이벤트들을 onclick으로 동작하도록 수정했습니다
