### PR TITLE
fix(wds): category 컴포넌트 잘못된 조건 수정

### DIFF
--- a/docs/src/docs/components/category.mdx
+++ b/docs/src/docs/components/category.mdx
@@ -330,7 +330,7 @@ const Demo = () => {
     <Category defaultValue="0">
       <CategoryList
         rightContent={(
-          <IconButton size={24}>
+          <IconButton size={22}>
             <IconBlank />
           </IconButton>
         )}>

--- a/docs/src/docs/components/tab.mdx
+++ b/docs/src/docs/components/tab.mdx
@@ -281,7 +281,7 @@ const Demo = () => {
     <Tab defaultValue="0">
       <TabList
         rightContent={(
-          <IconButton size={24}>
+          <IconButton size={22}>
             <IconBlank />
           </IconButton>
         )}>

--- a/packages/wds/src/components/category/style.ts
+++ b/packages/wds/src/components/category/style.ts
@@ -59,24 +59,24 @@ export const categoryListStyle =
           isScrollableLeft,
           isScrollableRight,
         })}
-        ${params?.horizontalPadding !== undefined ||
-        (params?.size !== undefined &&
-          css`
-            ${categorySizeStyle({
-              size: getPreviousValue(
-                { xs, sm, md, lg, xl },
-                'size',
-                params.size,
-                breakpoint!,
-              ),
-              verticalPadding: getPreviousValue(
-                { xs, sm, md, lg, xl },
-                'verticalPadding',
-                params.verticalPadding,
-                breakpoint!,
-              ),
-            })}
-          `)}
+        ${(params?.horizontalPadding !== undefined ||
+          params?.size !== undefined) &&
+        css`
+          ${categorySizeStyle({
+            size: getPreviousValue(
+              { xs, sm, md, lg, xl },
+              'size',
+              params.size,
+              breakpoint!,
+            ),
+            verticalPadding: getPreviousValue(
+              { xs, sm, md, lg, xl },
+              'verticalPadding',
+              params.verticalPadding,
+              breakpoint!,
+            ),
+          })}
+        `}
         ${params?.sx}
       `,
     )}


### PR DESCRIPTION
Category, Tab의 Icon Button 사이즈 변경건이 요청 들어왔는데 어차피 Slot 형태라
문서에서 가이드만 좀 수정해두었습니다.

https://wantedlab.atlassian.net/browse/PI-73126

코드 확인 중 responsive props에 괄호가 잘못 쳐져 있는 곳이 있어서 수정해주었습니다
