### PR TITLE
feat(wds): select radio 에서 클릭시 콘텐츠 닫히게 작업 필요

### DIFF
--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -74,7 +74,7 @@ const Select = forwardRef<
       render,
       placeholder,
       leadingContent,
-      enableMenuActionArea,
+      enableMenuActionArea = false,
       menuValue: menuValueProp,
       onMenuValueChange,
       xs,
@@ -345,7 +345,7 @@ const Option = memo(
           as={as || 'li'}
           {...props}
           onClick={composeEventHandlers(props.onClick, () => {
-            if (variant !== 'radio' && !enableMenuActionArea) {
+            if (enableMenuActionArea === false) {
               onOpenChange?.(false);
             }
           })}

--- a/packages/wds/src/components/select/types.ts
+++ b/packages/wds/src/components/select/types.ts
@@ -21,6 +21,9 @@ export type SelectDefaultProps = {
   defaultOpen?: boolean;
   onOpenChange?: (state: boolean) => void;
 
+  /**
+   * @description Menu Action Area를 사용하는 경우 활성화 하여 메뉴 아이템을 클릭할 때 오픈 상태를 유지합니다.
+   */
   enableMenuActionArea?: boolean;
   menuValue?: string;
   onMenuValueChange?: (value: string) => void;


### PR DESCRIPTION
@1000peach #82 에서 작업할 때 radio일때는 enableMenuActionArea이 false여도 SelectContent를 닫지 않게 설계되었었는데요,

Radio일때는 바로 닫히지 않는지 문의가 들어와서 생각해보니 Radio, Normal 과는 상관없이 enableMenuActionArea 값만 따라가면 될 것 같아서 작업해보았어요! 의견 부탁드려요!