### PR TITLE
fix(wds-codemod): JSXExpressionContainer -> Literal 구조로 되어있는 코드 마이그레이션 대응

### DIFF
--- a/packages/wds-codemod/src/helpers/index.ts
+++ b/packages/wds-codemod/src/helpers/index.ts
@@ -161,6 +161,14 @@ export const deepConvertPropertyValue = (
 
   if (
     property.type === 'JSXExpressionContainer' &&
+    (property.expression.type === 'Literal' ||
+      property.expression.type === 'StringLiteral')
+  ) {
+    return deepConvertPropertyValue(property.expression, name, convert);
+  }
+
+  if (
+    property.type === 'JSXExpressionContainer' &&
     property.expression.type === 'LogicalExpression'
   ) {
     if (

--- a/packages/wds-codemod/src/transforms/filled-variant-to-solid.ts
+++ b/packages/wds-codemod/src/transforms/filled-variant-to-solid.ts
@@ -32,38 +32,46 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
           (v) => v.type === 'JSXAttribute' && v.name.name === 'variant',
         ) as JSXAttribute | undefined;
 
-        if (
-          Boolean(variant) &&
-          variant!.value?.type === 'JSXExpressionContainer' &&
-          variant!.value.expression.type === 'ConditionalExpression'
-        ) {
-          if (
-            (variant!.value.expression.consequent.type === 'Literal' ||
-              variant!.value.expression.consequent.type === 'StringLiteral') &&
-            variant!.value.expression.consequent.value === 'filled'
-          ) {
-            hasChanges = true;
-            variant!.value.expression.consequent.value = 'solid';
-          }
+        if (!variant) {
+          return;
+        }
 
-          if (
-            (variant!.value.expression.alternate.type === 'Literal' ||
-              variant!.value.expression.alternate.type === 'StringLiteral') &&
-            variant!.value.expression.alternate.value === 'filled'
+        if (variant.value?.type === 'JSXExpressionContainer') {
+          if (variant.value.expression.type === 'ConditionalExpression') {
+            if (
+              (variant.value.expression.consequent.type === 'Literal' ||
+                variant.value.expression.consequent.type === 'StringLiteral') &&
+              variant.value.expression.consequent.value === 'filled'
+            ) {
+              hasChanges = true;
+              variant.value.expression.consequent.value = 'solid';
+            }
+
+            if (
+              (variant.value.expression.alternate.type === 'Literal' ||
+                variant.value.expression.alternate.type === 'StringLiteral') &&
+              variant.value.expression.alternate.value === 'filled'
+            ) {
+              hasChanges = true;
+              variant.value.expression.alternate.value = 'solid';
+            }
+          } else if (
+            (variant.value.expression.type === 'Literal' ||
+              variant.value.expression.type === 'StringLiteral') &&
+            variant.value.expression.value === 'filled'
           ) {
             hasChanges = true;
-            variant!.value.expression.alternate.value = 'solid';
+            variant.value.expression.value = 'solid';
           }
         }
 
         if (
-          Boolean(variant) &&
-          (variant!.value?.type === 'Literal' ||
-            variant!.value?.type === 'StringLiteral') &&
-          variant!.value.value === 'filled'
+          (variant.value?.type === 'Literal' ||
+            variant.value?.type === 'StringLiteral') &&
+          variant.value.value === 'filled'
         ) {
           hasChanges = true;
-          variant!.value.value = 'solid';
+          variant.value.value = 'solid';
         }
       });
   }
@@ -85,38 +93,46 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
           (v) => v.type === 'JSXAttribute' && v.name.name === 'variant',
         ) as JSXAttribute | undefined;
 
-        if (
-          Boolean(variant) &&
-          variant!.value?.type === 'JSXExpressionContainer' &&
-          variant!.value.expression.type === 'ConditionalExpression'
-        ) {
-          if (
-            (variant!.value.expression.consequent.type === 'Literal' ||
-              variant!.value.expression.consequent.type === 'StringLiteral') &&
-            variant!.value.expression.consequent.value === 'filled'
-          ) {
-            hasChanges = true;
-            variant!.value.expression.consequent.value = 'solid';
-          }
+        if (!variant) {
+          return;
+        }
 
-          if (
-            (variant!.value.expression.alternate.type === 'Literal' ||
-              variant!.value.expression.alternate.type === 'StringLiteral') &&
-            variant!.value.expression.alternate.value === 'filled'
+        if (variant.value?.type === 'JSXExpressionContainer') {
+          if (variant.value.expression.type === 'ConditionalExpression') {
+            if (
+              (variant.value.expression.consequent.type === 'Literal' ||
+                variant.value.expression.consequent.type === 'StringLiteral') &&
+              variant.value.expression.consequent.value === 'filled'
+            ) {
+              hasChanges = true;
+              variant.value.expression.consequent.value = 'solid';
+            }
+
+            if (
+              (variant.value.expression.alternate.type === 'Literal' ||
+                variant.value.expression.alternate.type === 'StringLiteral') &&
+              variant.value.expression.alternate.value === 'filled'
+            ) {
+              hasChanges = true;
+              variant.value.expression.alternate.value = 'solid';
+            }
+          } else if (
+            (variant.value.expression.type === 'Literal' ||
+              variant.value.expression.type === 'StringLiteral') &&
+            variant.value.expression.value === 'filled'
           ) {
             hasChanges = true;
-            variant!.value.expression.alternate.value = 'solid';
+            variant.value.expression.value = 'solid';
           }
         }
 
         if (
-          Boolean(variant) &&
-          (variant!.value?.type === 'Literal' ||
-            variant!.value?.type === 'StringLiteral') &&
-          variant!.value.value === 'filled'
+          (variant.value?.type === 'Literal' ||
+            variant.value?.type === 'StringLiteral') &&
+          variant.value.value === 'filled'
         ) {
           hasChanges = true;
-          variant!.value.value = 'solid';
+          variant.value.value = 'solid';
         }
       });
   }
@@ -138,38 +154,46 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
           (v) => v.type === 'JSXAttribute' && v.name.name === 'variant',
         ) as JSXAttribute | undefined;
 
-        if (
-          Boolean(variant) &&
-          variant!.value?.type === 'JSXExpressionContainer' &&
-          variant!.value.expression.type === 'ConditionalExpression'
-        ) {
-          if (
-            (variant!.value.expression.consequent.type === 'Literal' ||
-              variant!.value.expression.consequent.type === 'StringLiteral') &&
-            variant!.value.expression.consequent.value === 'filled'
-          ) {
-            hasChanges = true;
-            variant!.value.expression.consequent.value = 'solid';
-          }
+        if (!variant) {
+          return;
+        }
 
-          if (
-            (variant!.value.expression.alternate.type === 'Literal' ||
-              variant!.value.expression.alternate.type === 'StringLiteral') &&
-            variant!.value.expression.alternate.value === 'filled'
+        if (variant.value?.type === 'JSXExpressionContainer') {
+          if (variant.value.expression.type === 'ConditionalExpression') {
+            if (
+              (variant.value.expression.consequent.type === 'Literal' ||
+                variant.value.expression.consequent.type === 'StringLiteral') &&
+              variant.value.expression.consequent.value === 'filled'
+            ) {
+              hasChanges = true;
+              variant.value.expression.consequent.value = 'solid';
+            }
+
+            if (
+              (variant.value.expression.alternate.type === 'Literal' ||
+                variant.value.expression.alternate.type === 'StringLiteral') &&
+              variant.value.expression.alternate.value === 'filled'
+            ) {
+              hasChanges = true;
+              variant.value.expression.alternate.value = 'solid';
+            }
+          } else if (
+            (variant.value.expression.type === 'Literal' ||
+              variant.value.expression.type === 'StringLiteral') &&
+            variant.value.expression.value === 'filled'
           ) {
             hasChanges = true;
-            variant!.value.expression.alternate.value = 'solid';
+            variant.value.expression.value = 'solid';
           }
         }
 
         if (
-          Boolean(variant) &&
-          (variant!.value?.type === 'Literal' ||
-            variant!.value?.type === 'StringLiteral') &&
-          variant!.value.value === 'filled'
+          (variant.value?.type === 'Literal' ||
+            variant.value?.type === 'StringLiteral') &&
+          variant.value.value === 'filled'
         ) {
           hasChanges = true;
-          variant!.value.value = 'solid';
+          variant.value.value = 'solid';
         }
       });
   }

--- a/packages/wds-codemod/src/transforms/palette-to-atomic-semantic.ts
+++ b/packages/wds-codemod/src/transforms/palette-to-atomic-semantic.ts
@@ -58,7 +58,12 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
 
   root
     .find(j.MemberExpression, {
-      object: { object: { name: 'theme' }, property: { name: 'palette' } },
+      object: {
+        object: {
+          name: (name: string) => name === 'theme' || name === 'wdsTheme',
+        },
+        property: { name: 'palette' },
+      },
     })
     .forEach((palette) => {
       const parent = palette.parent as ASTPath<MemberExpression> | undefined;
@@ -71,6 +76,11 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
         palette.value.object.property.type === 'Identifier' &&
         palette.value.object.property.name === 'palette'
       ) {
+        const originalName =
+          palette.value.object.object.type === 'Identifier'
+            ? palette.value.object.object.name
+            : 'theme';
+
         if (atomicKey.includes(parent.value.object.property.name)) {
           palette.value.object.property.name = 'atomic';
           hasChanges = true;
@@ -79,7 +89,7 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
           if (parent.value.object.property.name === 'accent') {
             palette.value.object = j.memberExpression(
               j.memberExpression(
-                j.identifier('theme'),
+                j.identifier(originalName),
                 j.identifier('semantic'),
               ),
               j.identifier('accent'),
@@ -94,7 +104,12 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
 
   root
     .find(j.MemberExpression, {
-      object: { object: { name: 'theme' }, property: { name: 'platform' } },
+      object: {
+        object: {
+          name: (name: string) => name === 'theme' || name === 'wdsTheme',
+        },
+        property: { name: 'platform' },
+      },
     })
     .forEach((palette) => {
       const parent = palette.parent as ASTPath<MemberExpression> | undefined;


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/096b563e-215b-4927-bab4-f532ec86ef3c)

JSXExpressionContainer ( attr={} 처럼 중괄호 형태 ) 내부에 바로 Literal이 오는 케이스를 대응합니다.

`attr={'string'}`

추가로 theme 색상 마이그레이션 중 wdsTheme로 네이밍을 사용하는 케이스도 추가 대응합니다.