### PR TITLE
feat(wds): card 컴포넌트 간격 조정

### DIFF
--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -27,6 +27,7 @@ import {
 } from './constants';
 import {
   cardContentItemStyle,
+  cardContentStyle,
   cardSkeletonStyle,
   cardStyle,
   cardThumbnailContentTextStyle,
@@ -68,7 +69,7 @@ const Card = forwardRef(
       <FlexBox
         ref={ref}
         flexDirection="column"
-        gap="12px"
+        gap="10px"
         {...props}
         sx={[cardStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
       />
@@ -162,9 +163,9 @@ const CardContent = forwardRef(
         ref={ref}
         flexDirection="column"
         flex="1"
-        gap="4px"
+        gap="2px"
         {...props}
-        sx={[{ overflow: 'hidden' }, sx]}
+        sx={[cardContentStyle, sx]}
       />
     );
   },
@@ -262,7 +263,7 @@ const CardSkeleton = forwardRef(
       <FlexBox
         ref={ref}
         flexDirection="column"
-        gap="12px"
+        gap="10px"
         {...props}
         sx={[cardSkeletonStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
       />

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -60,7 +60,7 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
           padding: 10px;
         }
         [data-role='card-thumbnail-content-text'] {
-          ${typographyStyle('caption1', 'bold')}
+          ${typographyStyle('caption2', 'bold')}
         }
         [data-role='card-thumbnail-content-toggle-icon'] {
           > button {
@@ -71,7 +71,7 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
         }
         // content
         [wds-component='card-content'] {
-          padding: 0;
+          padding: 0 2px;
         }
         // text
         [wds-component='card-title'] {
@@ -242,7 +242,7 @@ const cardSkeletonPlatformStyle = ({
         }
         // content
         [wds-component='card-content'] {
-          padding: 0;
+          padding: 0 2px;
         }
         // skeleton
         [wds-component='card-title-skeleton'] {

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -172,6 +172,23 @@ export const cardThumbnailContentToggleIconStyle = (theme: Theme) => css`
   }
 `;
 
+export const cardContentStyle = css`
+  overflow: hidden;
+
+  [wds-component='card-title'],
+  [wds-component='card-title-skeleton'] {
+    margin-bottom: 2px;
+  }
+
+  --wds-card-content-item-margin-top: 6px;
+  --wds-card-content-item-margin-bottom: 6px;
+
+  [wds-component='card-title'] + [wds-component='card-content-item'],
+  [wds-component='card-title-skeleton'] + [wds-component='card-content-item'] {
+    --wds-card-content-item-margin-top: 4px;
+  }
+`;
+
 export const cardContentItemStyle = ({
   variant,
   position,
@@ -182,11 +199,11 @@ export const cardContentItemStyle = ({
     switch (position) {
       case 'top':
         return css`
-          margin-bottom: 4px;
+          margin-bottom: var(--wds-card-content-item-margin-bottom);
         `;
       case 'bottom':
         return css`
-          margin-top: 4px;
+          margin-top: var(--wds-card-content-item-margin-top);
         `;
     }
   })()};


### PR DESCRIPTION

<img width="463" alt="스크린샷 2025-04-25 오후 9 31 57" src="https://github.com/user-attachments/assets/84688b18-38c0-4da6-aa15-ef7d0037864d" />

## 작업 내용

- card 컴포넌트 요소 내 간격 조정
  - `gap: 4px` --> `gap: 2px`로 변경 후, 특정 요소만 margin 조정
  -  gap으로 간격 조정을 다르게 하려면 한번 더 래핑해야 하는데, 사용이 불편할 거 같아 요소간 margin을 변경했습니다.

## 참고

- https://wantedlab.atlassian.net/browse/PI-75162
- https://www.figma.com/design/MK6KmtXBxX7ZkoQXfD9MFH/%EA%B0%9C%EC%84%A0--Components?node-id=5654-4974&t=D1bjxY0gbRTmjuZo-0