### PR TITLE
feat(wds): tooltip group 컴포넌트 추가

### DIFF
--- a/docs/src/docs/components/compact-tooltip.mdx
+++ b/docs/src/docs/components/compact-tooltip.mdx
@@ -32,6 +32,10 @@ export default Demo;`}
 
 ## Props
 
+### TooltipGroup
+
+<PropsTable component="TooltipGroup" />
+
 ### CompactTooltip
 
 `defaultValue` 는 [tooltip](/wds/docs/components/tooltip) 과 동일합니다.
@@ -85,6 +89,55 @@ const Demo = () => {
     </CompactTooltip>
   )
 }
+
+export default Demo;`}
+/>
+
+### TooltipGroup
+
+TooltipGroup을 사용하면 여러 개의 Tooltip을 그룹으로 묶어 자연스럽게 전환할 수 있습니다.
+
+<Demo code={`import { FlexBox, TooltipGroup, CompactTooltip, CompactTooltipTrigger, CompactTooltipContent, IconButton } from '@wanteddev/wds';
+import { IconCopy, IconTrash, IconRefresh } from '@wanteddev/wds-icon';
+
+const Demo = () => {
+  return (
+    <FlexBox gap="10px">
+      <TooltipGroup>
+        <CompactTooltip>
+          <CompactTooltipTrigger>
+            <IconButton>
+              <IconCopy />
+            </IconButton>
+          </CompactTooltipTrigger>
+          <CompactTooltipContent shortcut="⌘C">
+            복사
+          </CompactTooltipContent>
+        </CompactTooltip>
+        <CompactTooltip>
+          <CompactTooltipTrigger>
+            <IconButton>
+              <IconTrash />
+            </IconButton>
+          </CompactTooltipTrigger>
+          <CompactTooltipContent shortcut="⌘⌫">
+            삭제
+          </CompactTooltipContent>
+        </CompactTooltip>
+        <CompactTooltip>
+          <CompactTooltipTrigger>
+            <IconButton>
+              <IconRefresh />
+            </IconButton>
+          </CompactTooltipTrigger>
+          <CompactTooltipContent shortcut="⌘R">
+            새로고침
+          </CompactTooltipContent>
+        </CompactTooltip>
+      </TooltipGroup>
+    </FlexBox>
+  );
+};
 
 export default Demo;`}
 />

--- a/docs/src/docs/components/tooltip.mdx
+++ b/docs/src/docs/components/tooltip.mdx
@@ -32,6 +32,10 @@ export default Demo;`}
 
 ## Props
 
+### TooltipGroup
+
+<PropsTable component="TooltipGroup" />
+
 ### Tooltip
 
 <PropsTable component="Tooltip" />
@@ -46,6 +50,55 @@ export default Demo;`}
 
 
 ## Examples
+
+### TooltipGroup
+
+TooltipGroup을 사용하면 여러 개의 Tooltip을 그룹으로 묶어 자연스럽게 전환할 수 있습니다.
+
+<Demo code={`import { FlexBox, TooltipGroup, Tooltip, TooltipTrigger, TooltipContent, IconButton } from '@wanteddev/wds';
+import { IconCopy, IconTrash, IconRefresh } from '@wanteddev/wds-icon';
+
+const Demo = () => {
+  return (
+    <FlexBox gap="10px">
+      <TooltipGroup>
+        <Tooltip>
+          <TooltipTrigger>
+            <IconButton>
+              <IconCopy />
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent>
+            복사
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <IconButton>
+              <IconTrash />
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent>
+            삭제
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <IconButton>
+              <IconRefresh />
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent>
+            새로고침
+          </TooltipContent>
+        </Tooltip>
+      </TooltipGroup>
+    </FlexBox>
+  );
+};
+
+export default Demo;`}
+/>
 
 ### Action
 

--- a/docs/src/features/mdx/components/demo/editor/index.tsx
+++ b/docs/src/features/mdx/components/demo/editor/index.tsx
@@ -17,6 +17,7 @@ import tsx from 'refractor/lang/tsx';
 import CodeEditor from 'react-simple-code-editor';
 import { useEffect, useRef } from 'react';
 import { Typography } from '@wanteddev/wds';
+import { TooltipGroup } from '@wanteddev/wds';
 
 import { codeBlockStyle } from '../../code-block/style';
 
@@ -97,32 +98,34 @@ const Editor = ({
           {collapsed ? 'Expand code' : 'Collapse code'}
         </ChipAction>
 
-        <CompactTooltip>
-          <CompactTooltipTrigger>
-            <IconButton size={18} onClick={handleCopy}>
-              <IconCopy />
-            </IconButton>
-          </CompactTooltipTrigger>
-          <CompactTooltipContent shortcut="⌘C">Copy</CompactTooltipContent>
-        </CompactTooltip>
+        <TooltipGroup>
+          <CompactTooltip>
+            <CompactTooltipTrigger>
+              <IconButton size={18} onClick={handleCopy}>
+                <IconCopy />
+              </IconButton>
+            </CompactTooltipTrigger>
+            <CompactTooltipContent shortcut="⌘C">Copy</CompactTooltipContent>
+          </CompactTooltip>
 
-        <CompactTooltip>
-          <CompactTooltipTrigger>
-            <IconButton size={18} onClick={reset}>
-              <IconRefresh />
-            </IconButton>
-          </CompactTooltipTrigger>
-          <CompactTooltipContent shortcut="⌘R">Reset</CompactTooltipContent>
-        </CompactTooltip>
+          <CompactTooltip>
+            <CompactTooltipTrigger>
+              <IconButton size={18} onClick={reset}>
+                <IconRefresh />
+              </IconButton>
+            </CompactTooltipTrigger>
+            <CompactTooltipContent shortcut="⌘R">Reset</CompactTooltipContent>
+          </CompactTooltip>
 
-        <CompactTooltip>
-          <CompactTooltipTrigger>
-            <IconButton size={18} onClick={() => setHatched((prev) => !prev)}>
-              <IconImage />
-            </IconButton>
-          </CompactTooltipTrigger>
-          <CompactTooltipContent>Change Background</CompactTooltipContent>
-        </CompactTooltip>
+          <CompactTooltip>
+            <CompactTooltipTrigger>
+              <IconButton size={18} onClick={() => setHatched((prev) => !prev)}>
+                <IconImage />
+              </IconButton>
+            </CompactTooltipTrigger>
+            <CompactTooltipContent>Change Background</CompactTooltipContent>
+          </CompactTooltip>
+        </TooltipGroup>
       </FlexBox>
       {children}
       <Typography

--- a/packages/wds/src/components/tooltip/constants.ts
+++ b/packages/wds/src/components/tooltip/constants.ts
@@ -1,3 +1,4 @@
+export const TOOLTIP_GROUP_NAME = 'TooltipGroup';
 export const TOOLTIP_NAME = 'Tooltip';
 export const TOOLTIP_TRIGGER_NAME = 'TooltipTrigger';
 export const TOOLTIP_CONTENT_NAME = 'TooltipContent';

--- a/packages/wds/src/components/tooltip/contexts.ts
+++ b/packages/wds/src/components/tooltip/contexts.ts
@@ -1,6 +1,8 @@
 import { createContext } from '@radix-ui/react-context';
 
-import { TOOLTIP_NAME } from './constants';
+import createLooseContext from '../../hooks/use-loose-context';
+
+import { TOOLTIP_GROUP_NAME, TOOLTIP_NAME } from './constants';
 
 import type { PointerDownOutsideEvent } from '../dismissable-layer/types';
 import type {
@@ -26,3 +28,12 @@ type TooltipContextValue = {
 
 export const [TooltipProvider, useTooltipContext] =
   createContext<TooltipContextValue>(TOOLTIP_NAME);
+
+type TooltipGroupContextValue = {
+  onOpen: () => void;
+  onClose: () => void;
+  isOpenWithoutDelayRef: RefObject<boolean>;
+};
+
+export const [TooltipGroupProvider, useTooltipGroupContext] =
+  createLooseContext<TooltipGroupContextValue>(TOOLTIP_GROUP_NAME);

--- a/packages/wds/src/components/tooltip/hooks.ts
+++ b/packages/wds/src/components/tooltip/hooks.ts
@@ -1,6 +1,8 @@
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { useTooltipGroupContext } from './contexts';
+
 import type { PointerDownOutsideEvent } from '../dismissable-layer/types';
 import type { FocusEventHandler, MouseEvent, MouseEventHandler } from 'react';
 import type { TooltipProps } from './types';
@@ -16,6 +18,7 @@ export const useTooltip = ({
   disableOpenOnFocus,
 }: TooltipProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const groupContext = useTooltipGroupContext();
 
   const openTimerRef = useRef(0);
   const closeTimerRef = useRef(0);
@@ -23,7 +26,14 @@ export const useTooltip = ({
   const [open = false, setOpen] = useControllableState({
     prop: originOpen,
     defaultProp: defaultOpen,
-    onChange: onOpenChange,
+    onChange: (value) => {
+      if (value) {
+        groupContext?.onOpen();
+      } else {
+        groupContext?.onClose();
+      }
+      onOpenChange?.(value);
+    },
   });
 
   // setTimeout 에서 최신 state를 가지기 위해 ref로도 저장해야함.
@@ -75,9 +85,13 @@ export const useTooltip = ({
         return;
       }
 
-      handleOpen();
+      if (groupContext?.isOpenWithoutDelayRef.current) {
+        handleOpen(0);
+      } else {
+        handleOpen();
+      }
     },
-    [handleOpen],
+    [handleOpen, groupContext],
   );
 
   const handleMouseLeave: MouseEventHandler<any> = useCallback(
@@ -86,9 +100,13 @@ export const useTooltip = ({
         return;
       }
 
-      handleClose();
+      if (groupContext?.isOpenWithoutDelayRef.current) {
+        handleClose(0);
+      } else {
+        handleClose();
+      }
     },
-    [handleClose],
+    [handleClose, groupContext],
   );
 
   const handleFocus: FocusEventHandler<any> = useCallback(() => {

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -1,4 +1,11 @@
-import { Fragment, forwardRef, useId } from 'react';
+import {
+  Fragment,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+} from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
@@ -15,9 +22,14 @@ import IconButton from '../icon-button';
 import useTransitionStatus from '../../hooks/use-transition-status';
 import ComponentOrFragment from '../component-or-fragment';
 
-import { TooltipProvider, useTooltipContext } from './contexts';
+import {
+  TooltipGroupProvider,
+  TooltipProvider,
+  useTooltipContext,
+} from './contexts';
 import {
   TOOLTIP_CONTENT_NAME,
+  TOOLTIP_GROUP_NAME,
   TOOLTIP_NAME,
   TOOLTIP_TRIGGER_NAME,
 } from './constants';
@@ -27,6 +39,39 @@ import { useTooltip } from './hooks';
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { TooltipContentProps, TooltipProps } from './types';
 import type { CSSProperties, PropsWithChildren } from 'react';
+
+const TooltipGroup = ({
+  children,
+  skipDelayDuration = 300,
+}: PropsWithChildren<{ skipDelayDuration?: number }>) => {
+  const isOpenWithoutDelayRef = useRef(false);
+  const skipDelayTimerRef = useRef(0);
+
+  useEffect(() => {
+    const skipDelayTimer = skipDelayTimerRef.current;
+    return () => window.clearTimeout(skipDelayTimer);
+  }, []);
+
+  return (
+    <TooltipGroupProvider
+      onOpen={useCallback(() => {
+        window.clearTimeout(skipDelayTimerRef.current);
+        isOpenWithoutDelayRef.current = true;
+      }, [])}
+      onClose={useCallback(() => {
+        window.clearTimeout(skipDelayTimerRef.current);
+        skipDelayTimerRef.current = window.setTimeout(() => {
+          isOpenWithoutDelayRef.current = false;
+        }, skipDelayDuration);
+      }, [skipDelayDuration])}
+      isOpenWithoutDelayRef={isOpenWithoutDelayRef}
+    >
+      {children}
+    </TooltipGroupProvider>
+  );
+};
+
+TooltipGroup.displayName = TOOLTIP_GROUP_NAME;
 
 const Tooltip = ({
   mode = 'hover',
@@ -250,4 +295,4 @@ const TooltipContent = forwardRef<
 
 TooltipTrigger.displayName = TOOLTIP_TRIGGER_NAME;
 
-export { Tooltip, TooltipTrigger, TooltipContent };
+export { TooltipGroup, Tooltip, TooltipTrigger, TooltipContent };

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -37,13 +37,17 @@ import { tooltipContentStyle, tooltipWrapperStyle } from './style';
 import { useTooltip } from './hooks';
 
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
-import type { TooltipContentProps, TooltipProps } from './types';
-import type { CSSProperties, PropsWithChildren } from 'react';
+import type {
+  TooltipContentProps,
+  TooltipGroupProps,
+  TooltipProps,
+} from './types';
+import type { CSSProperties } from 'react';
 
 const TooltipGroup = ({
   children,
   skipDelayDuration = 300,
-}: PropsWithChildren<{ skipDelayDuration?: number }>) => {
+}: TooltipGroupProps) => {
   const isOpenWithoutDelayRef = useRef(false);
   const skipDelayTimerRef = useRef(0);
 
@@ -83,7 +87,7 @@ const Tooltip = ({
   leaveDelay = 300,
   disableCloseOnPointDown = false,
   disableOpenOnFocus = false,
-}: PropsWithChildren<TooltipProps>) => {
+}: TooltipProps) => {
   const containerId = useId();
   const {
     containerRef,

--- a/packages/wds/src/components/tooltip/types.ts
+++ b/packages/wds/src/components/tooltip/types.ts
@@ -1,5 +1,9 @@
-import type { ReactNode } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 import type { PopperContentProps } from '../popper/types';
+
+export type TooltipGroupProps = PropsWithChildren<{
+  skipDelayDuration?: number;
+}>;
 
 export type TooltipProps = {
   mode?: 'hover' | 'always';


### PR DESCRIPTION
툴팁을 여러개 붙여서 사용하는 경우 AS-IS 영상처럼 뚝뚝끊겨서 연속된 동작으로 나타납니다.

## AS-IS

https://github.com/user-attachments/assets/e9bb6ba2-4105-4f49-a712-4bdb5c8c110d

TooltipGroup이라는 컴포넌트를 만들어서 skipDelayDuration prop (기본값 300) ms 시간 내에 바로 open을 한다면 
`enterDelay`, `leaveDelay` 를 무시하고 바로 열리도록 추가해보았습니다.

## TO-BE

https://github.com/user-attachments/assets/24b3f052-0a45-41e6-b06c-6dedb65d5f31

