### PR TITLE
feat(wds): modal 높이가 작은 디바이스에서 사이즈 대응 및 기본 사이즈 변경

### DIFF
--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -162,7 +162,7 @@ const ModalContainer = forwardRef<
   (
     {
       variant = 'popup',
-      size = variant === 'popup' ? 'large' : 'medium',
+      size = 'medium',
       resize = 'hug',
       handle,
       xs,

--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -391,7 +391,7 @@ const modalContainerVariant = (
       return css`
         border-radius: var(--wds-modal-popup-border-radius, 12px);
         animation: none;
-        max-height: 760px;
+        max-height: min(760px, 100%);
         padding: initial;
         overflow: hidden;
         transition: none;

--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -284,7 +284,7 @@ const modalContainerSize = (
       `;
     case 'large':
       return css`
-        width: 400px;
+        width: 480px;
         min-width: 320px;
         max-width: 100%;
         height: initial;


### PR DESCRIPTION
[PI-75327](https://wantedlab.atlassian.net/browse/PI-75327)


AS-IS

높이가 760px + 40px 보다 작은 경우 깨지게 되어 있었습니다.

<img width="734" alt="image" src="https://github.com/user-attachments/assets/13c01d2b-1a6c-4f35-b5a0-15a12c1eee4a" />

TO-BE

기본적으로 최대 높이는 760px이지만 100% (100dvh - 40px) 보다 작은 경우에는 최대치로 보여집니다.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/4e91e0f7-729d-40f9-9cdc-8c8a7ec9a1c2" />




[PI-75327]: https://wantedlab.atlassian.net/browse/PI-75327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ