### PR TITLE
feat(wds): toast, snackbar에 semantic duration 추가

### DIFF
--- a/docs/src/docs/hooks/use-snackbar.mdx
+++ b/docs/src/docs/hooks/use-snackbar.mdx
@@ -43,7 +43,7 @@ export default Demo;`}
 ## Props
 
 <PropsTable component="useSnackbar" fallback={[
-{ name: 'duration', types: 'number | undefined', defaultValue: 5000 },
+{ name: 'duration', types: 'number | "short" | "long" | undefined', defaultValue: 'short' },
 { name: 'variant', types: '\"normal\" | undefined', defaultValue: 'normal' },
 { name: 'title', types: 'ReactNode' },
 { name: 'description', types: 'ReactNode' },

--- a/docs/src/docs/hooks/use-toast.mdx
+++ b/docs/src/docs/hooks/use-toast.mdx
@@ -40,7 +40,7 @@ export default Demo;`}
 <PropsTable component="useToast" fallback={[
 { name: 'id', types: 'string', required: false },
 { name: 'content', types: 'ReactNode', required: true },
-{ name: 'duration', types: 'number | undefined', defaultValue: 3000 },
+{ name: 'duration', types: 'number | "short" | "long" | undefined', defaultValue: 'short' },
 { name: 'icon', types: 'ReactNode', required: false },
 { name: 'variant', types: '\"normal\" | \"positive\" | \"cautionary\" | \"negative\" | undefined', defaultValue: 'normal' },
 { name: 'onAnimationEnd', types: '(type: \"hide\" | \"show\") => void' }

--- a/packages/wds/src/components/region-status/index.tsx
+++ b/packages/wds/src/components/region-status/index.tsx
@@ -47,7 +47,7 @@ const RegionStatus = () => {
 
 const Toast = ({
   id,
-  duration = 3000,
+  duration,
   variant = 'normal',
   icon,
   content,
@@ -105,7 +105,7 @@ const Toast = ({
 
 const Snackbar = ({
   id,
-  duration = 5000,
+  duration,
   title,
   description,
   extraContent,

--- a/packages/wds/src/hooks/use-snackbar.ts
+++ b/packages/wds/src/hooks/use-snackbar.ts
@@ -1,16 +1,40 @@
 import { useRegionStore } from '../stores/region-store';
 
-import type { RegionSnackbarItem } from '../stores/region-store';
+import type {
+  RegionSnackbarItem,
+  UseRegionStoreAddDuration,
+  WithUseRegionStoreAddDuration,
+} from '../stores/region-store';
 
 const useSnackbar = () => {
   const storeAdd = useRegionStore((state) => state.add);
 
-  const add = (item: Omit<RegionSnackbarItem, 'type'>) =>
+  const add = (
+    item: WithUseRegionStoreAddDuration<
+      Omit<RegionSnackbarItem, 'type' | 'duration'>
+    >,
+  ) => {
+    const getDuration = (duration?: UseRegionStoreAddDuration): number => {
+      if (typeof duration === 'number') {
+        return duration;
+      }
+
+      switch (duration) {
+        case 'short':
+          return 4000;
+        case 'long':
+          return 16000;
+        default:
+          return getDuration('short');
+      }
+    };
+
     storeAdd({
       type: 'snackbar',
       ...item,
-      duration: item.duration ?? 5000,
+      duration: getDuration(item.duration),
     });
+  };
 
   return add;
 };

--- a/packages/wds/src/hooks/use-toast.ts
+++ b/packages/wds/src/hooks/use-toast.ts
@@ -1,16 +1,40 @@
 import { useRegionStore } from '../stores/region-store';
 
-import type { RegionToastItem } from '../stores/region-store';
+import type {
+  RegionToastItem,
+  UseRegionStoreAddDuration,
+  WithUseRegionStoreAddDuration,
+} from '../stores/region-store';
 
 const useToast = () => {
   const storeAdd = useRegionStore((state) => state.add);
 
-  const add = (item: Omit<RegionToastItem, 'type'>) =>
+  const add = (
+    item: WithUseRegionStoreAddDuration<
+      Omit<RegionToastItem, 'type' | 'duration'>
+    >,
+  ) => {
+    const getDuration = (duration?: UseRegionStoreAddDuration): number => {
+      if (typeof duration === 'number') {
+        return duration;
+      }
+
+      switch (duration) {
+        case 'short':
+          return 3000;
+        case 'long':
+          return 5000;
+        default:
+          return getDuration('short');
+      }
+    };
+
     storeAdd({
       type: 'toast',
       ...item,
-      duration: item.duration ?? 3000,
+      duration: getDuration(item.duration),
     });
+  };
 
   return add;
 };

--- a/packages/wds/src/stores/region-store.ts
+++ b/packages/wds/src/stores/region-store.ts
@@ -31,6 +31,15 @@ export type RegionSnackbarItem = {
   onAnimationEnd?: (type: 'hide' | 'show') => void;
 };
 
+export type UseRegionStoreAddDuration = number | 'short' | 'long';
+
+export type WithUseRegionStoreAddDuration<T extends object> = Merge<
+  {
+    duration?: UseRegionStoreAddDuration;
+  },
+  T
+>;
+
 export type RegionItem = RegionToastItem | RegionSnackbarItem;
 
 export type WithRegionSystem<T extends object> = Merge<


### PR DESCRIPTION
toast, snackbar의 duration에 `short`, `long` 을 지원합니다.