### PR TITLE
feat(wds): card sub caption 대응 및 미세 간격 조정

### DIFF
--- a/docs/src/docs/components/card.mdx
+++ b/docs/src/docs/components/card.mdx
@@ -396,8 +396,9 @@ const Demo = () => {
               <CardContentItemSkeleton />
             </CardContentItem>
             <CardTitleSkeleton />
-            <CardCaptionSkeleton type="extra"/>
             <CardCaptionSkeleton />
+            <CardCaptionSkeleton type="sub"/>
+            <CardCaptionSkeleton type="extra"/>
             <CardContentItem position="bottom">
               <CardContentItemSkeleton />
             </CardContentItem>
@@ -413,8 +414,9 @@ const Demo = () => {
               <CardContentItemSkeleton />
             </CardContentItem>
             <CardTitleSkeleton />
-            <CardCaptionSkeleton type="extra"/>
             <CardCaptionSkeleton />
+            <CardCaptionSkeleton type="sub"/>
+            <CardCaptionSkeleton type="extra"/>
             <CardContentItem position="bottom">
               <CardContentItemSkeleton />
             </CardContentItem>

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 import {
   Box,
   type DefaultComponentProps,
@@ -70,7 +70,6 @@ const Card = forwardRef(
       <FlexBox
         ref={ref}
         flexDirection="column"
-        gap="10px"
         {...props}
         sx={[cardStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
       />
@@ -197,7 +196,7 @@ const CardContentItem = forwardRef(
   (
     {
       sx,
-      position,
+      position = 'top',
       variant,
       ...props
     }: DefaultComponentProps<CardContentItemProps, 'div'>,
@@ -283,7 +282,6 @@ const CardSkeleton = forwardRef(
       <FlexBox
         ref={ref}
         flexDirection="column"
-        gap="10px"
         {...props}
         sx={[cardSkeletonStyle({ platform, width, xs, sm, md, lg, xl }), sx]}
       />
@@ -362,12 +360,27 @@ const CardCaptionSkeleton = forwardRef(
   (
     {
       type = 'normal',
-      width = type === 'normal' ? '25%' : '50%',
+      width: originWidth,
       height = '18px',
       ...props
     }: DefaultComponentProps<CardCaptionSkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
+    const width = useMemo(() => {
+      if (originWidth !== undefined) {
+        return originWidth;
+      }
+
+      switch (type) {
+        case 'normal':
+          return '75%';
+        case 'sub':
+          return '50%';
+        case 'extra':
+          return '25%';
+      }
+    }, [type, originWidth]);
+
     return (
       <Skeleton
         ref={ref}

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -19,6 +19,11 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
   switch (platform) {
     case 'desktop':
       return css`
+        gap: 8px;
+        --wds-card-content-item-top-position-margin-top: 2px;
+        --wds-card-content-item-top-position-margin-bottom: 4px;
+
+        --wds-card-content-item-bottom-position-margin-top: 8px;
         // thumbnail
         [wds-component='thumbnail'],
         [wds-component='thumbnail-skeleton'] {
@@ -54,6 +59,12 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
 
     case 'mobile':
       return css`
+        gap: 6px;
+
+        --wds-card-content-item-top-position-margin-top: 2px;
+        --wds-card-content-item-top-position-margin-bottom: 4px;
+
+        --wds-card-content-item-bottom-position-margin-top: 6px;
         // thumbnail
         [wds-component='thumbnail'],
         [wds-component='thumbnail-skeleton'] {
@@ -237,14 +248,6 @@ export const cardContentStyle = css`
   [wds-component='card-title-skeleton'] {
     margin-bottom: 2px;
   }
-
-  --wds-card-content-item-margin-top: 6px;
-  --wds-card-content-item-margin-bottom: 6px;
-
-  [wds-component='card-title'] + [wds-component='card-content-item'],
-  [wds-component='card-title-skeleton'] + [wds-component='card-content-item'] {
-    --wds-card-content-item-margin-top: 4px;
-  }
 `;
 
 export const cardContentItemStyle = ({
@@ -257,11 +260,14 @@ export const cardContentItemStyle = ({
     switch (position) {
       case 'top':
         return css`
-          margin-bottom: var(--wds-card-content-item-margin-bottom);
+          margin-top: var(--wds-card-content-item-top-position-margin-top);
+          margin-bottom: var(
+            --wds-card-content-item-top-position-margin-bottom
+          );
         `;
       case 'bottom':
         return css`
-          margin-top: var(--wds-card-content-item-margin-top);
+          margin-top: var(--wds-card-content-item-bottom-position-margin-top);
         `;
     }
   })()};
@@ -273,6 +279,12 @@ const cardSkeletonPlatformStyle = ({
   switch (platform) {
     case 'desktop':
       return css`
+        gap: 8px;
+        --wds-card-content-item-top-position-margin-top: 4px;
+        --wds-card-content-item-top-position-margin-bottom: 4px;
+
+        --wds-card-content-item-bottom-position-margin-top: 8px;
+
         // thumbnail
         [wds-component='thumbnail'],
         [wds-component='thumbnail-skeleton'] {
@@ -292,6 +304,12 @@ const cardSkeletonPlatformStyle = ({
 
     case 'mobile':
       return css`
+        gap: 6px;
+        --wds-card-content-item-top-position-margin-top: 2px;
+        --wds-card-content-item-top-position-margin-bottom: 4px;
+
+        --wds-card-content-item-bottom-position-margin-top: 6px;
+
         // thumbnail
         [wds-component='thumbnail'],
         [wds-component='thumbnail-skeleton'] {

--- a/packages/wds/src/components/card/types.ts
+++ b/packages/wds/src/components/card/types.ts
@@ -50,7 +50,7 @@ export type CardContentItemProps = Merge<
 >;
 
 type CardCaptionSkeletonDefaultProps = {
-  type?: 'normal' | 'extra';
+  type?: 'normal' | 'extra' | 'sub';
   children?: ReactNode;
 };
 export type CardCaptionSkeletonProps = Merge<


### PR DESCRIPTION
카드에 Sub Caption이 추가되었는데, 스타일은 동일하여 `CardCaption` 으로 사용합니다.

`CardCaptionSkeleton` 에는 type='sub'가 추가됩니다.

그리고 TopContent, BottomContent의 간격이 platform별로 변경되어

`--wds-card-content-item-top-position-margin-top`, `--wds-card-content-item-top-position-margin-bottom` `--wds-card-content-item-bottom-position-margin-top`

css 변수를 사용하였습니다


![image](https://github.com/user-attachments/assets/96ed1bf6-d6db-4600-8144-10d1e79f86c6)
