### PR TITLE
fix(wds): 툴팁 trigger mousedown으로 포커스 되지 않는 현상 수정

### DIFF
--- a/packages/wds/src/components/tooltip/hooks.ts
+++ b/packages/wds/src/components/tooltip/hooks.ts
@@ -23,6 +23,8 @@ export const useTooltip = ({
   const openTimerRef = useRef(0);
   const closeTimerRef = useRef(0);
 
+  const isMouseDownTriggered = useRef(false);
+
   const [open = false, setOpen] = useControllableState({
     prop: originOpen,
     defaultProp: defaultOpen,
@@ -111,10 +113,12 @@ export const useTooltip = ({
 
   const handleFocus: FocusEventHandler<any> = useCallback(() => {
     if (!disableOpenOnFocus && mode === 'hover') {
-      if (!latestOpen.current) {
+      if (!latestOpen.current && !isMouseDownTriggered.current) {
         handleOpen(0);
       }
     }
+
+    isMouseDownTriggered.current = false;
   }, [handleOpen, mode, disableOpenOnFocus]);
 
   const handleBlur: FocusEventHandler<any> = useCallback(() => {
@@ -127,17 +131,14 @@ export const useTooltip = ({
 
   const handleMouseDown: (
     event: PointerDownOutsideEvent | MouseEvent<any>,
-  ) => void = useCallback(
-    (e) => {
-      e.preventDefault();
-      if (mode === 'hover' && !disableCloseOnPointDown) {
-        setOpen(false);
-        window.clearTimeout(openTimerRef.current);
-        window.clearTimeout(closeTimerRef.current);
-      }
-    },
-    [mode, setOpen, disableCloseOnPointDown],
-  );
+  ) => void = useCallback(() => {
+    if (mode === 'hover' && !disableCloseOnPointDown) {
+      isMouseDownTriggered.current = true;
+      setOpen(false);
+      window.clearTimeout(openTimerRef.current);
+      window.clearTimeout(closeTimerRef.current);
+    }
+  }, [mode, setOpen, disableCloseOnPointDown]);
 
   const handleDismiss = useCallback(() => {
     if (latestOpen.current) {


### PR DESCRIPTION
## 배경

https://wantedx.slack.com/archives/C06RQUTEURL/p1746154005236629

MouseDown 이벤트에 preventDefault가 걸려있어 포커스 동작이 실행되지 않음.

## 해결 방법

handleFocus에서 다시 open 동작을 하기 때문에 포커스 동작이 실행되지 않게 하는건 의도된 동작이 맞습니다.
하지만 이벤트 자체를 막는 방법은 잘못된 방법 같아 Mousedown으로 포커스 되었을 때에는 handleFocus 함수가 실행되지 않도록 변경하였습니다.