### PR TITLE
fix(wds): icon button backgroud, normal의 경우 medium, small 을 지원하지 않도록 변경

### DIFF
--- a/packages/wds/src/components/icon-button/style.ts
+++ b/packages/wds/src/components/icon-button/style.ts
@@ -5,15 +5,16 @@ import { addOpacity, createResponsiveStyle } from '../../utils';
 import type { IconButtonProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';
 
-const getDefaultSize = (
-  variant: IconButtonProps['variant'],
-): IconButtonProps['size'] => {
+const getIconButtonSize = ({
+  variant,
+  size,
+}: Pick<IconButtonProps, 'variant' | 'size'>): IconButtonProps['size'] => {
   switch (variant) {
     case 'outlined':
     case 'solid':
-      return 'medium';
+      return size ?? 'medium';
     default:
-      return 24;
+      return typeof size === 'number' ? size : 24;
   }
 };
 
@@ -32,10 +33,7 @@ export const iconButtonStyle =
       cursor: not-allowed;
     }
 
-    ${iconButtonSizeStyle(
-      props.size || getDefaultSize(props.variant),
-      props.variant,
-    )}
+    ${iconButtonSizeStyle({ size: props.size, variant: props.variant })}
     ${iconButtonColorStyle(props, theme)}
 
   ${createResponsiveStyle(
@@ -43,16 +41,18 @@ export const iconButtonStyle =
       theme,
     )(
       (params = {}) => css`
-        ${iconButtonSizeStyle(params.size, props.variant)}
+        ${iconButtonSizeStyle({ size: params.size, variant: props.variant })}
         ${params.sx}
       `,
     )}
   `;
 
 const iconButtonSizeStyle = (
-  size: IconButtonProps['size'],
-  variant: IconButtonProps['variant'],
+  params: Pick<IconButtonProps, 'size' | 'variant'>,
 ) => {
+  const size = getIconButtonSize(params);
+  const { variant } = params;
+
   if (typeof size === 'number') {
     return css`
       width: ${size}px;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fa689a68-2657-464d-b9bb-85f50f4c42b3)
![image](https://github.com/user-attachments/assets/ed997532-8aef-423d-ba19-36d0f1304b8a)

normal, background 아이콘 버튼의 경우 interaction영역이 별도로 잡히기 때문에
정의된 medium (40px), small (32px) 로 사용시 과도하게 커보여 number로 직접 사용하는 경우에만 사이즈를 변경할 수 있습니다.

![image](https://github.com/user-attachments/assets/2e129ab8-d586-4176-a54f-9afc4c4fe16a)

기존 사용하는 쪽에서 과도한 크기의 아이콘 버튼을 사용하는 케이스가 없으므로 사이드이펙트는 없을 것으로 예상합니다.