### PR TITLE
chore(ci): figma sync workflow > iOS 파일 경로 수정

### DIFF
--- a/.github/workflows/figma-icon-sync.yml
+++ b/.github/workflows/figma-icon-sync.yml
@@ -517,7 +517,7 @@ jobs:
                   const swiftFileContent = `//\n//  Icon.swift\n//  Montage\n//\n//  Created by Eunyeong Kim on 2021/04/20.\n//\nimport Foundation\n\n/// Montage 번들 내에 포함된 아이콘들의 이름들입니다.\npublic enum Icon: String, CaseIterable {\n    ${shouldShowFoundations.sort().map((iconAsset) => `case ${iconAsset.replace('.imageset', '')}`).join('\n    ')}\n\n    public var name: String { rawValue }\n}\n`;
 
                   fs.writeFileSync(
-                    './Sources/Montage/Foundation/Icon.swift',
+                    './Sources/Montage/1 Theme/Icon.swift',
                     swiftFileContent,
                   );
                   break;


### PR DESCRIPTION
iOS Icon.swift 파일 경로가 변경되어 PR 드립니다.

혹시 깃헙액션이 wds 레포에 의존하지 않고 독립적으로 돌아가게 할 수 있을까요?