### PR TITLE
feat(wds): control component WAI-ARIA 조정

### DIFF
--- a/packages/wds/src/components/checkbox/index.tsx
+++ b/packages/wds/src/components/checkbox/index.tsx
@@ -3,11 +3,10 @@ import { IconCheckThick, IconLineHorizontalThick } from '@wanteddev/wds-icon';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { useSize } from '@radix-ui/react-use-size';
-import { usePrevious } from '@radix-ui/react-use-previous';
 import { Box } from '@wanteddev/wds-engine';
 
 import WithInteraction from '../with-interaction';
+import { VirtualCheckboxInput } from '../virtual-input';
 
 import { checkboxStyle } from './style';
 
@@ -71,14 +70,11 @@ const Checkbox = forwardRef<
     return (
       <>
         {isFormControl && (
-          <BubbleInput
+          <VirtualCheckboxInput
             name={name}
             value={checked ? 'on' : 'off'}
-            type="checkbox"
             checked={checked}
             defaultChecked={defaultChecked}
-            sx={{ display: 'none', pointerEvents: 'none' }}
-            control={button}
             bubbles={!hasConsumerStoppedPropagationRef.current}
           />
         )}
@@ -146,62 +142,3 @@ const Checkbox = forwardRef<
 Checkbox.displayName = 'Checkbox';
 
 export default Checkbox;
-
-type BubbleInputProps = DefaultComponentProps<
-  {
-    checked: boolean;
-    control: HTMLElement | null;
-    bubbles: boolean;
-  },
-  'input'
->;
-
-const BubbleInput = ({
-  control,
-  checked,
-  bubbles = true,
-  ...inputProps
-}: BubbleInputProps) => {
-  const ref = useRef<HTMLInputElement>(null);
-  const prevChecked = usePrevious(checked);
-  const controlSize = useSize(control);
-
-  useEffect(() => {
-    const input = ref.current!;
-    const inputProto = window.HTMLInputElement.prototype;
-    const descriptor = Object.getOwnPropertyDescriptor(
-      inputProto,
-      'checked',
-    ) as PropertyDescriptor;
-    const setChecked = descriptor.set;
-
-    if (prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles });
-      setChecked.call(input, checked);
-      input.dispatchEvent(event);
-    }
-  }, [prevChecked, checked, bubbles]);
-
-  return (
-    <Box
-      as="input"
-      type="checkbox"
-      aria-hidden
-      defaultChecked={checked}
-      {...inputProps}
-      tabIndex={-1}
-      ref={ref}
-      sx={[
-        {
-          ...controlSize,
-          transform: 'translateX(-100%)',
-          position: 'absolute',
-          pointerEvents: 'none',
-          opacity: 0,
-          margin: 0,
-        },
-        inputProps.sx,
-      ]}
-    />
-  );
-};

--- a/packages/wds/src/components/chip-multi-select/index.tsx
+++ b/packages/wds/src/components/chip-multi-select/index.tsx
@@ -3,11 +3,10 @@ import { IconCheckThick } from '@wanteddev/wds-icon';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { useSize } from '@radix-ui/react-use-size';
-import { usePrevious } from '@radix-ui/react-use-previous';
 import { Box } from '@wanteddev/wds-engine';
 
 import WithInteraction from '../with-interaction';
+import { VirtualCheckboxInput } from '../virtual-input';
 
 import { multiSelectStyle } from './style';
 
@@ -71,14 +70,12 @@ const ChipMultiSelect = forwardRef<
     return (
       <>
         {isFormControl && (
-          <BubbleInput
+          <VirtualCheckboxInput
             name={name}
             value={checked ? 'on' : 'off'}
             type="checkbox"
             checked={checked}
             defaultChecked={defaultChecked}
-            sx={{ display: 'none', pointerEvents: 'none' }}
-            control={button}
             bubbles={!hasConsumerStoppedPropagationRef.current}
           />
         )}
@@ -137,62 +134,3 @@ const ChipMultiSelect = forwardRef<
 ChipMultiSelect.displayName = 'ChipMultiSelect';
 
 export default ChipMultiSelect;
-
-type BubbleInputProps = DefaultComponentProps<
-  {
-    checked: boolean;
-    control: HTMLElement | null;
-    bubbles: boolean;
-  },
-  'input'
->;
-
-const BubbleInput = ({
-  control,
-  checked,
-  bubbles = true,
-  ...inputProps
-}: BubbleInputProps) => {
-  const ref = useRef<HTMLInputElement>(null);
-  const prevChecked = usePrevious(checked);
-  const controlSize = useSize(control);
-
-  useEffect(() => {
-    const input = ref.current!;
-    const inputProto = window.HTMLInputElement.prototype;
-    const descriptor = Object.getOwnPropertyDescriptor(
-      inputProto,
-      'checked',
-    ) as PropertyDescriptor;
-    const setChecked = descriptor.set;
-
-    if (prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles });
-      setChecked.call(input, checked);
-      input.dispatchEvent(event);
-    }
-  }, [prevChecked, checked, bubbles]);
-
-  return (
-    <Box
-      as="input"
-      type="checkbox"
-      aria-hidden
-      defaultChecked={checked}
-      {...inputProps}
-      tabIndex={-1}
-      ref={ref}
-      sx={[
-        {
-          ...controlSize,
-          transform: 'translateX(-100%)',
-          position: 'absolute',
-          pointerEvents: 'none',
-          opacity: 0,
-          margin: 0,
-        },
-        inputProps.sx,
-      ]}
-    />
-  );
-};

--- a/packages/wds/src/components/radio-group/index.tsx
+++ b/packages/wds/src/components/radio-group/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
@@ -39,6 +39,20 @@ const RadioGroup = forwardRef<
     onChange: onValueChange,
   });
 
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const composedRefs = useComposedRefs<HTMLDivElement>(ref, setNode);
+
+  const initialValueStateRef = useRef(value);
+
+  useEffect(() => {
+    const form = node?.closest('form');
+    if (form) {
+      const reset = () => setValue(initialValueStateRef.current);
+      form.addEventListener('reset', reset);
+      return () => form.removeEventListener('reset', reset);
+    }
+  }, [node, setValue]);
+
   return (
     <RadioGroupProvider
       name={name}
@@ -60,7 +74,7 @@ const RadioGroup = forwardRef<
           data-disabled={disabled ? '' : undefined}
           dir={dir || 'ltr'}
           {...groupProps}
-          ref={ref}
+          ref={composedRefs}
         />
       </RovingFocusGroup.Root>
     </RadioGroupProvider>

--- a/packages/wds/src/components/radio/index.tsx
+++ b/packages/wds/src/components/radio/index.tsx
@@ -1,12 +1,11 @@
-import { forwardRef, useEffect, useRef, useState } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { useSize } from '@radix-ui/react-use-size';
-import { usePrevious } from '@radix-ui/react-use-previous';
 import { IconDot } from '@wanteddev/wds-icon';
 import { Box } from '@wanteddev/wds-engine';
 
 import WithInteraction from '../with-interaction';
+import { VirtualCheckboxInput } from '../virtual-input';
 
 import { radioStyle } from './style';
 
@@ -45,15 +44,10 @@ const Radio = forwardRef<
     return (
       <>
         {isFormControl && (
-          <BubbleInput
-            aria-hidden="true"
-            tabIndex={-1}
+          <VirtualCheckboxInput
             value={value}
-            type="radio"
             checked={checked}
-            defaultChecked={checked}
-            sx={{ display: 'none', pointerEvents: 'none' }}
-            control={button}
+            type="radio"
             bubbles={!hasConsumerStoppedPropagationRef.current}
             name={name}
             required={required}
@@ -116,61 +110,3 @@ const Radio = forwardRef<
 Radio.displayName = 'Radio';
 
 export default Radio;
-
-type BubbleInputProps = DefaultComponentProps<
-  {
-    checked: boolean;
-    control: HTMLElement | null;
-    bubbles: boolean;
-  },
-  'input'
->;
-
-const BubbleInput = ({
-  control,
-  checked,
-  bubbles = true,
-  ...inputProps
-}: BubbleInputProps) => {
-  const ref = useRef<HTMLInputElement>(null);
-  const prevChecked = usePrevious(checked);
-  const controlSize = useSize(control);
-
-  useEffect(() => {
-    const input = ref.current!;
-    const inputProto = window.HTMLInputElement.prototype;
-    const descriptor = Object.getOwnPropertyDescriptor(
-      inputProto,
-      'checked',
-    ) as PropertyDescriptor;
-    const setChecked = descriptor.set;
-    if (prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles });
-      setChecked.call(input, checked);
-      input.dispatchEvent(event);
-    }
-  }, [prevChecked, checked, bubbles]);
-
-  return (
-    <Box
-      as="input"
-      type="checkbox"
-      aria-hidden
-      defaultChecked={checked}
-      {...inputProps}
-      tabIndex={-1}
-      ref={ref}
-      sx={[
-        {
-          ...controlSize,
-          transform: 'translateX(-100%)',
-          position: 'absolute',
-          pointerEvents: 'none',
-          opacity: 0,
-          margin: 0,
-        },
-        inputProps.sx,
-      ]}
-    />
-  );
-};

--- a/packages/wds/src/components/segmented-control/contexts.ts
+++ b/packages/wds/src/components/segmented-control/contexts.ts
@@ -10,6 +10,7 @@ export type SegmentedControlContextType = {
   variant: Exclude<SegmentedControlProps['variant'], undefined>;
   size: Exclude<SegmentedControlProps['size'], undefined>;
   responsive?: Pick<SegmentedControlProps, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>;
+  name?: string;
 };
 
 export const [SegmentedControlProvider, useSegmentedControlContext] =

--- a/packages/wds/src/components/segmented-control/index.tsx
+++ b/packages/wds/src/components/segmented-control/index.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import * as RovingFocusGroup from '@radix-ui/react-roving-focus';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -9,6 +16,7 @@ import { usePrevious } from '@radix-ui/react-use-previous';
 import FlexBox from '../flex-box';
 import useResizeObserver from '../../hooks/use-resize-observer';
 import { calculateAnimationStyle } from '../../utils/animation';
+import { VirtualCheckboxInput } from '../virtual-input';
 
 import {
   motionThumbStyle,
@@ -51,6 +59,7 @@ const SegmentedControl = forwardRef<
       children,
       variant = 'solid',
       size = 'medium',
+      name,
       xs,
       sm,
       md,
@@ -120,12 +129,25 @@ const SegmentedControl = forwardRef<
 
     useResizeObserver(node, handleResize);
 
+    const initialValueStateRef = useRef(value);
+
+    useEffect(() => {
+      const form = node?.closest('form');
+
+      if (form) {
+        const reset = () => setValue(initialValueStateRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [node, setValue]);
+
     return (
       <SegmentedControlProvider
         value={value}
         onValueChange={setValue}
         variant={variant}
         size={size}
+        name={name}
         responsive={{
           xs,
           sm,
@@ -138,7 +160,7 @@ const SegmentedControl = forwardRef<
           <FlexBox
             ref={composedRefs}
             alignItems="stretch"
-            role="listbox"
+            role="radiogroup"
             {...props}
             wds-component="segmented-control"
             sx={[
@@ -176,14 +198,20 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
     }: PolymorphicProps<SegmentedControlItemProps, T>,
     forwardedRef: ForwardedRef<ElementRef<T>>,
   ) => {
-    const ref = useRef<ElementRef<T>>(null);
-    const composedRefs = useComposedRefs(ref, forwardedRef);
+    const id = useId();
 
-    const { size, variant, responsive, ...context } =
+    const [node, setNode] = useState<ElementRef<T> | null>(null);
+    const composedRefs = useComposedRefs(forwardedRef, setNode);
+
+    const { size, variant, responsive, name, ...context } =
       useSegmentedControlContext(SEGMENTED_CONTROL_ITEM_NAME);
 
     const active = context.value === value;
     const isArrowKeyPressedRef = useRef(false);
+
+    const isFormControl = node
+      ? Boolean((node as unknown as HTMLElement).closest('form'))
+      : true;
 
     useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
@@ -207,12 +235,14 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
           as={(as || 'label') as T}
           ref={composedRefs}
           flex="1 1 0"
-          data-value={value}
-          aria-disabled={disabled}
           alignItems="center"
           justifyContent="center"
           gap="4px"
-          role="option"
+          data-value={value}
+          role="radio"
+          aria-disabled={disabled}
+          aria-checked={active}
+          aria-labelledby={id}
           {...props}
           disabled={disabled}
           wds-component="segmented-control-item"
@@ -245,7 +275,17 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
             data-role="segmented-control-item-text"
             aria-selected={active}
             aria-disabled={disabled}
+            id={id}
           >
+            {isFormControl && (
+              <VirtualCheckboxInput
+                type="radio"
+                name={name}
+                value={value}
+                checked={active}
+                disabled={disabled}
+              />
+            )}
             {children}
           </span>
           {trailingContent}

--- a/packages/wds/src/components/segmented-control/types.ts
+++ b/packages/wds/src/components/segmented-control/types.ts
@@ -8,6 +8,7 @@ export type SegmentedControlDefaultProps = {
   variant?: 'solid' | 'outlined';
   size?: 'large' | 'medium' | 'small';
   children?: ReactNode;
+  name?: string;
 };
 
 type SegmentedControlResponsiveProps = ResponsiveProps<

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -16,7 +16,6 @@ import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useSize } from '@radix-ui/react-use-size';
-import { Box, type DefaultComponentProps } from '@wanteddev/wds-engine';
 
 import { Menu, MenuContent, MenuList, MenuTrigger } from '../menu';
 import FlexBox from '../flex-box';
@@ -26,14 +25,15 @@ import { SelectContent } from '../select';
 import { convertChildrenToData } from '../select/helpers';
 import {
   invalidIconWrapperStyle,
-  selectBubbleInputStyle,
   selectIconStyle,
   selectStyle,
 } from '../select/style';
 import useResizeObserver from '../../hooks/use-resize-observer';
+import { VirtualValueInput } from '../virtual-input';
 
 import { customSelectMultipleRenderWrapperStyle } from './style';
 
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { UIEventHandler } from 'react';
 import type { SelectMultipleProps } from './types';
 
@@ -78,7 +78,7 @@ const SelectMultiple = forwardRef<
     const [renderWrapperNode, setRenderWrapperNode] =
       useState<HTMLDivElement | null>(null);
 
-    const { width: contentWidth, height: contentHeight } = useSize(node) || {};
+    const { width: contentWidth } = useSize(node) || {};
 
     const [isScrollableLeft, setIsScrollableLeft] = useState(false);
     const [isScrollableRight, setIsScrollableRight] = useState(false);
@@ -188,23 +188,13 @@ const SelectMultiple = forwardRef<
     return (
       <>
         {isFormControl && (
-          <Box
-            as="input"
+          <VirtualValueInput
             name={props.name}
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             value={Array.isArray(value) ? value.join(',') : value ?? ''}
             aria-invalid={invalid}
             disabled={disabled}
             tabIndex={-1}
-            aria-hidden
-            readOnly
-            sx={[
-              {
-                width: contentWidth,
-                height: contentHeight,
-              },
-              selectBubbleInputStyle,
-            ]}
           />
         )}
 

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -13,12 +13,6 @@ import {
   IconCircleExclamationFill,
 } from '@wanteddev/wds-icon';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import {
-  Box,
-  type DefaultComponentProps,
-  type PolymorphicComponent,
-  type PolymorphicProps,
-} from '@wanteddev/wds-engine';
 import { useSize } from '@radix-ui/react-use-size';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
@@ -36,13 +30,9 @@ import { TextFieldContent } from '../text-field';
 import FlexBox from '../flex-box';
 import Typography from '../typography';
 import { invalidIconWrapperStyle } from '../text-field/style';
+import { VirtualValueInput } from '../virtual-input';
 
-import {
-  selectBubbleInputStyle,
-  selectIconStyle,
-  selectStyle,
-  selectTextStyle,
-} from './style';
+import { selectIconStyle, selectStyle, selectTextStyle } from './style';
 import { convertChildrenToData } from './helpers';
 import {
   OPTION_GROUP_NAME,
@@ -52,6 +42,11 @@ import {
 } from './constants';
 import { SelectProvider, useSelectContext } from './context';
 
+import type {
+  DefaultComponentProps,
+  PolymorphicComponent,
+  PolymorphicProps,
+} from '@wanteddev/wds-engine';
 import type { ForwardedRef } from 'react';
 import type { OptionGroupProps, OptionProps, SelectProps } from './types';
 
@@ -90,7 +85,7 @@ const Select = forwardRef<
   ) => {
     const [node, setNode] = useState<HTMLDivElement | null>(null);
 
-    const { width: contentWidth, height: contentHeight } = useSize(node) || {};
+    const { width: contentWidth } = useSize(node) || {};
 
     const composedRefs = useComposedRefs<HTMLDivElement>(forwardedRef, setNode);
 
@@ -154,22 +149,12 @@ const Select = forwardRef<
         enableMenuActionArea={enableMenuActionArea}
       >
         {isFormControl && (
-          <Box
-            as="input"
+          <VirtualValueInput
             name={props.name}
             value={value}
             aria-invalid={invalid}
             disabled={disabled}
             tabIndex={-1}
-            readOnly
-            aria-hidden
-            sx={[
-              {
-                width: contentWidth,
-                height: contentHeight,
-              },
-              selectBubbleInputStyle,
-            ]}
           />
         )}
         <Menu

--- a/packages/wds/src/components/select/style.ts
+++ b/packages/wds/src/components/select/style.ts
@@ -184,12 +184,3 @@ export const selectTextStyle = css`
   ${ellipsisTypographyStyle(1)}
   user-select: none;
 `;
-
-export const selectBubbleInputStyle = css`
-  display: none;
-  pointer-events: none;
-  position: absolute;
-  opacity: 0;
-  margin: 0;
-  transform: translateX(-100%);
-`;

--- a/packages/wds/src/components/slider/index.tsx
+++ b/packages/wds/src/components/slider/index.tsx
@@ -1,10 +1,18 @@
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Box, type DefaultComponentProps } from '@wanteddev/wds-engine';
 import { composeEventHandlers } from '@radix-ui/primitive';
 
 import FlexBox from '../flex-box';
 import Typography from '../typography';
+import { VirtualValueInput } from '../virtual-input';
 
 import {
   clamp,
@@ -60,10 +68,11 @@ const Slider = forwardRef<
     },
     forwardedRef,
   ) => {
+    const labelId = useId();
     const thumbRefs = useRef<Set<HTMLSpanElement>>(new Set());
     const currentFocusedIndex = useRef(0);
     const rect = useRef<DOMRect | undefined>(undefined);
-    const ref = useRef<HTMLSpanElement | null>(null);
+    const [node, setNode] = useState<HTMLSpanElement | null>(null);
 
     const [values = [], setValues] = useControllableState({
       prop: value,
@@ -131,16 +140,27 @@ const Slider = forwardRef<
     );
 
     const getValueFromPointer = (pointerPosition: number) => {
-      if (!ref.current) {
+      if (!node) {
         return;
       }
 
-      const newRect = rect.current || ref.current.getBoundingClientRect();
+      const newRect = rect.current || node.getBoundingClientRect();
       const cb = linearScale([0, newRect.width], [min, max]);
 
       rect.current = newRect;
       return cb(pointerPosition - newRect.left);
     };
+
+    const initialValuesRef = useRef(values);
+
+    useEffect(() => {
+      const form = node?.closest('form');
+      if (form) {
+        const reset = () => setValues(initialValuesRef.current);
+        form.addEventListener('reset', reset);
+        return () => form.removeEventListener('reset', reset);
+      }
+    }, [node, setValues]);
 
     return (
       <FlexBox
@@ -175,7 +195,7 @@ const Slider = forwardRef<
           sx={sliderProgressWrapperStyle({ disabled })}
           data-role="slider-progress-wrapper"
           as="span"
-          ref={ref}
+          ref={setNode}
           onKeyDown={composeEventHandlers(onKeyDown, (e) => {
             if (disabled) return;
 
@@ -271,6 +291,7 @@ const Slider = forwardRef<
               value={v}
               min={min}
               max={max}
+              aria-labelledby={labelId}
               onFocus={() => (currentFocusedIndex.current = index)}
               thumbs={thumbRefs.current}
             />
@@ -382,7 +403,7 @@ const SliderThumb = ({
         />
 
         {isFormControl && (
-          <BubbleInput
+          <VirtualValueInput
             type="range"
             name={length > 1 ? `${name}[]` : name}
             value={value}
@@ -395,32 +416,5 @@ const SliderThumb = ({
 };
 
 SliderThumb.displayName = 'SliderThumb';
-
-const BubbleInput = ({
-  value,
-  ...props
-}: DefaultComponentProps<{ value: number }, 'input'>) => {
-  const ref = useRef<HTMLInputElement>(null);
-  const prevValue = useRef(value);
-
-  useEffect(() => {
-    const input = ref.current!;
-    const inputProto = window.HTMLInputElement.prototype;
-    const descriptor = Object.getOwnPropertyDescriptor(
-      inputProto,
-      'value',
-    ) as PropertyDescriptor;
-    const setValue = descriptor.set;
-    if (prevValue.current !== value && setValue) {
-      const event = new Event('input', { bubbles: true });
-      setValue.call(input, value);
-      input.dispatchEvent(event);
-    }
-
-    prevValue.current = value;
-  }, [value]);
-
-  return <Box ref={ref} as="input" sx={{ display: 'none' }} {...props} />;
-};
 
 export { Slider, SliderTitleProps, SliderLabelProps };

--- a/packages/wds/src/components/switch/index.tsx
+++ b/packages/wds/src/components/switch/index.tsx
@@ -2,11 +2,10 @@ import { forwardRef, useEffect, useRef, useState } from 'react';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { useSize } from '@radix-ui/react-use-size';
-import { usePrevious } from '@radix-ui/react-use-previous';
 import { Box } from '@wanteddev/wds-engine';
 
 import WithInteraction from '../with-interaction';
+import { VirtualCheckboxInput } from '../virtual-input';
 
 import { switchStyle } from './style';
 
@@ -59,14 +58,10 @@ const Switch = forwardRef<
     return (
       <>
         {isFormControl && (
-          <BubbleInput
+          <VirtualCheckboxInput
             name={name}
             value={checked ? 'on' : 'off'}
-            type="checkbox"
             checked={checked}
-            defaultChecked={defaultChecked}
-            sx={{ display: 'none', pointerEvents: 'none' }}
-            control={button}
             bubbles={!hasConsumerStoppedPropagationRef.current}
           />
         )}
@@ -118,63 +113,3 @@ const Switch = forwardRef<
 Switch.displayName = 'Switch';
 
 export default Switch;
-
-type BubbleInputProps = DefaultComponentProps<
-  {
-    checked: boolean;
-    control: HTMLElement | null;
-    bubbles: boolean;
-  },
-  'input'
->;
-
-const BubbleInput = ({
-  control,
-  checked,
-  bubbles = true,
-  sx,
-  ...inputProps
-}: BubbleInputProps) => {
-  const ref = useRef<HTMLInputElement>(null);
-  const prevChecked = usePrevious(checked);
-  const controlSize = useSize(control);
-
-  useEffect(() => {
-    const input = ref.current!;
-    const inputProto = window.HTMLInputElement.prototype;
-    const descriptor = Object.getOwnPropertyDescriptor(
-      inputProto,
-      'checked',
-    ) as PropertyDescriptor;
-    const setChecked = descriptor.set;
-
-    if (prevChecked !== checked && setChecked) {
-      const event = new Event('click', { bubbles });
-      setChecked.call(input, checked);
-      input.dispatchEvent(event);
-    }
-  }, [prevChecked, checked, bubbles]);
-
-  return (
-    <Box
-      as="input"
-      type="checkbox"
-      aria-hidden
-      defaultChecked={checked}
-      {...inputProps}
-      tabIndex={-1}
-      ref={ref}
-      sx={[
-        {
-          ...controlSize,
-          transform: 'translateX(-100%)',
-          position: 'absolute',
-          pointerEvents: 'none',
-          opacity: 0,
-          margin: 0,
-        },
-        sx,
-      ]}
-    />
-  );
-};

--- a/packages/wds/src/components/virtual-input/index.tsx
+++ b/packages/wds/src/components/virtual-input/index.tsx
@@ -1,0 +1,113 @@
+import { Box } from '@wanteddev/wds-engine';
+import { forwardRef, useEffect, useRef } from 'react';
+import { usePrevious } from '@radix-ui/react-use-previous';
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+
+import type {
+  VirtualCheckboxInputProps,
+  VirtualValueInputProps,
+} from './types';
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+
+const VirtualCheckboxInput = forwardRef<
+  HTMLInputElement,
+  DefaultComponentProps<VirtualCheckboxInputProps, 'input'>
+>(({ checked, bubbles, ...props }, forwardedRef) => {
+  const ref = useRef<HTMLInputElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  const prevChecked = usePrevious(checked);
+
+  useEffect(() => {
+    const input = ref.current!;
+    const inputProto = window.HTMLInputElement.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(
+      inputProto,
+      'checked',
+    ) as PropertyDescriptor;
+    const setChecked = descriptor.set;
+    if (prevChecked !== checked && setChecked) {
+      const event = new Event('click', { bubbles });
+      setChecked.call(input, checked);
+      input.dispatchEvent(event);
+    }
+  }, [prevChecked, checked, bubbles]);
+
+  return (
+    <Box
+      as="input"
+      type="radio"
+      aria-hidden
+      defaultChecked={checked}
+      {...props}
+      tabIndex={-1}
+      ref={composedRefs}
+      sx={[
+        {
+          transform: 'translateX(-100%)',
+          position: 'absolute',
+          pointerEvents: 'none',
+          display: 'none',
+          opacity: 0,
+          margin: 0,
+        },
+        props.sx,
+      ]}
+    />
+  );
+});
+
+VirtualCheckboxInput.displayName = 'VirtualCheckboxInput';
+
+const VirtualValueInput = forwardRef<
+  HTMLInputElement,
+  DefaultComponentProps<VirtualValueInputProps, 'input'>
+>(({ value, bubbles, ...props }, forwardedRef) => {
+  const ref = useRef<HTMLInputElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  const prevValue = useRef(value);
+
+  useEffect(() => {
+    const input = ref.current!;
+    const inputProto = window.HTMLInputElement.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(
+      inputProto,
+      'value',
+    ) as PropertyDescriptor;
+    const setValue = descriptor.set;
+    if (prevValue.current !== value && setValue) {
+      const event = new Event('input', { bubbles: true });
+      setValue.call(input, value);
+      input.dispatchEvent(event);
+    }
+
+    prevValue.current = value;
+  }, [value, bubbles]);
+
+  return (
+    <Box
+      as="input"
+      type="text"
+      aria-hidden
+      {...props}
+      tabIndex={-1}
+      ref={composedRefs}
+      sx={[
+        {
+          transform: 'translateX(-100%)',
+          position: 'absolute',
+          pointerEvents: 'none',
+          display: 'none',
+          opacity: 0,
+          margin: 0,
+        },
+        props.sx,
+      ]}
+    />
+  );
+});
+
+VirtualValueInput.displayName = 'VirtualValueInput';
+
+export { VirtualCheckboxInput, VirtualValueInput };

--- a/packages/wds/src/components/virtual-input/types.ts
+++ b/packages/wds/src/components/virtual-input/types.ts
@@ -1,0 +1,9 @@
+export type VirtualCheckboxInputProps = {
+  checked?: boolean;
+  bubbles?: boolean;
+};
+
+export type VirtualValueInputProps = {
+  value?: string | number;
+  bubbles?: boolean;
+};


### PR DESCRIPTION
uncontrolled component 를 위해 표시하던 숨김처리된 input을 공통 컴포넌트로 분리하였습니다.

- VirtualValueInput
  - value 로 상태를 관리
- VirtualCheckboxInput
  - checked 로 상태를 관리

SegmentedControl의 role을 radiogroup으로 설정하였고, uncontrolled component로 사용할 때 form reset에 반영되도록 수정하였습니다.

Slider에 labelled-by 필드를 추가하였고,  uncontrolled component로 사용할 때 form reset에 반영되도록 수정하였습니다.
