### PR TITLE
fix(wds): 일부 컴포넌트 context scope 분리로 의도치 않은 동작 개선

### DIFF
--- a/docs/scripts/docgen.mjs
+++ b/docs/scripts/docgen.mjs
@@ -12,7 +12,11 @@ const parser = withCustomConfig(
       'PolymorphicButtonComponent',
     ],
     propFilter: (prop) => {
-      if (prop.name === 'css' || prop.name === '__wdsCustomChildren') {
+      if (
+        prop.name === 'css' ||
+        prop.name === '__wdsCustomChildren' ||
+        prop.name.match(/^__scope/)
+      ) {
         return false;
       }
       if (prop.declarations !== undefined && prop.declarations.length > 0) {

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -15,6 +15,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../popover';
 import FlexBox from '../flex-box';
 import Typography from '../typography';
 import { usePopoverContext } from '../popover/contexts';
+import { createScope } from '../../hooks/use-scope-context';
 
 import {
   MENU_ACTION_AREA_CONTENT_NAME,
@@ -60,6 +61,8 @@ import type {
 } from '@wanteddev/wds-engine';
 import type { ElementRef, ElementType, ForwardedRef, ReactNode } from 'react';
 
+const useMenuScope = createScope('Popover');
+
 const ARROW_KEYS = ['ArrowUp', 'ArrowDown'];
 
 const Menu = (props: MenuProps) => {
@@ -77,9 +80,13 @@ const Menu = (props: MenuProps) => {
     onChange: onValueChange,
   });
 
+  const scopes = useMenuScope('Menu');
+
   return (
     <MenuProvider value={value} onValueChange={setValue}>
-      <Popover {...popoverProps}>{children}</Popover>
+      <Popover {...scopes} {...popoverProps}>
+        {children}
+      </Popover>
     </MenuProvider>
   );
 };
@@ -90,11 +97,16 @@ const MenuTrigger = forwardRef<
   ElementRef<typeof PopoverTrigger>,
   MenuTriggerProps
 >((props, ref) => {
-  const { open, onOpenChange } = usePopoverContext(MENU_TRIGGER_NAME);
+  const scopes = useMenuScope('Menu');
+  const { open, onOpenChange } = usePopoverContext(
+    MENU_TRIGGER_NAME,
+    scopes.__scopePopover,
+  );
 
   return (
     <PopoverTrigger
       {...props}
+      {...scopes}
       ref={ref}
       onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
         if (
@@ -131,6 +143,8 @@ const MenuContent = forwardRef<
     },
     ref,
   ) => {
+    const scopes = useMenuScope('Menu');
+
     return (
       <RovingFocusGroup orientation="vertical" dir="ltr" asChild>
         <PopoverContent
@@ -140,6 +154,7 @@ const MenuContent = forwardRef<
           container={container}
           disablePortal={disablePortal}
           {...props}
+          {...scopes}
           sx={[menuPopoverContentStyle, sx]}
         >
           <ScrollArea zIndex={11} sx={menuScrollAreaStyle} size="small">

--- a/packages/wds/src/components/popover/contexts.ts
+++ b/packages/wds/src/components/popover/contexts.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@radix-ui/react-context';
+import { createScopeContext } from '../../hooks/use-scope-context';
 
 import { POPOVER_NAME } from './constants';
 
@@ -12,4 +12,4 @@ type PopoverContextValue = {
 };
 
 export const [PopoverProvider, usePopoverContext] =
-  createContext<PopoverContextValue>(POPOVER_NAME);
+  createScopeContext<PopoverContextValue>(POPOVER_NAME);

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -7,6 +7,7 @@ import DismissableLayer from '../dismissable-layer';
 import { Popper, PopperAnchor, PopperArrow, PopperContent } from '../popper';
 import FlexBox from '../flex-box';
 import FocusScope from '../focus-scope';
+import { createScope } from '../../hooks/use-scope-context';
 
 import { PopoverProvider, usePopoverContext } from './contexts';
 import {
@@ -16,16 +17,20 @@ import {
 } from './constants';
 import { popoverStyle } from './style';
 
+import type { ScopedProps } from '../../hooks/use-scope-context';
 import type { PopoverContentProps, PopoverProps } from './types';
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
+
+const usePopoverScope = createScope('Popper', 'PopperContent');
 
 const Popover = ({
   open: originOpen,
   defaultOpen,
   onOpenChange,
   children,
-}: PropsWithChildren<PopoverProps>) => {
+  __scopePopover = 'Popover',
+}: PropsWithChildren<ScopedProps<PopoverProps, 'Popover'>>) => {
   const triggerId = useId();
   const contentId = useId();
 
@@ -35,14 +40,17 @@ const Popover = ({
     onChange: onOpenChange,
   });
 
+  const scopes = usePopoverScope(__scopePopover);
+
   return (
     <PopoverProvider
+      scope={__scopePopover}
       triggerId={triggerId}
       contentId={contentId}
       open={open}
       onOpenChange={setOpen}
     >
-      <Popper>{children}</Popper>
+      <Popper {...scopes}>{children}</Popper>
     </PopoverProvider>
   );
 };
@@ -52,38 +60,50 @@ Popover.displayName = POPOVER_NAME;
 const PopoverTrigger = forwardRef<
   HTMLElement,
   ComponentPropsWithoutRef<typeof Slot>
->((props, ref) => {
-  const { contentId, triggerId, open, onOpenChange } =
-    usePopoverContext(POPOVER_TRIGGER_NAME);
+>(
+  (
+    {
+      __scopePopover = 'Popover',
+      ...props
+    }: ScopedProps<ComponentPropsWithoutRef<typeof Slot>, 'Popover'>,
+    ref,
+  ) => {
+    const { contentId, triggerId, open, onOpenChange } = usePopoverContext(
+      POPOVER_TRIGGER_NAME,
+      __scopePopover,
+    );
 
-  return (
-    <PopperAnchor>
-      <Slot
-        {...props}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        aria-controls={contentId}
-        id={triggerId}
-        ref={ref}
-        onClick={composeEventHandlers(props.onClick, (e) => {
-          if (
-            !open &&
-            e.currentTarget.ariaDisabled?.toString() !== 'true' &&
-            e.currentTarget.getAttribute('disabled')?.toString() !== 'true'
-          ) {
-            onOpenChange(true);
-          }
-        })}
-      />
-    </PopperAnchor>
-  );
-});
+    const scopes = usePopoverScope(__scopePopover);
+
+    return (
+      <PopperAnchor {...scopes}>
+        <Slot
+          {...props}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-controls={contentId}
+          id={triggerId}
+          ref={ref}
+          onClick={composeEventHandlers(props.onClick, (e) => {
+            if (
+              !open &&
+              e.currentTarget.ariaDisabled?.toString() !== 'true' &&
+              e.currentTarget.getAttribute('disabled')?.toString() !== 'true'
+            ) {
+              onOpenChange(true);
+            }
+          })}
+        />
+      </PopperAnchor>
+    );
+  },
+);
 
 PopoverTrigger.displayName = POPOVER_TRIGGER_NAME;
 
 const PopoverContent = forwardRef<
   HTMLDivElement,
-  DefaultComponentProps<PopoverContentProps, 'div'>
+  DefaultComponentProps<ScopedProps<PopoverContentProps, 'Popover'>, 'div'>
 >(
   (
     {
@@ -102,15 +122,21 @@ const PopoverContent = forwardRef<
       referenceHiddenOffsets,
       setContext,
       wrapperProps,
+      __scopePopover = 'Popover',
       ...props
     },
     ref,
   ) => {
-    const { contentId, open, onOpenChange } =
-      usePopoverContext(POPOVER_CONTENT_NAME);
+    const { contentId, open, onOpenChange } = usePopoverContext(
+      POPOVER_CONTENT_NAME,
+      __scopePopover,
+    );
+
+    const scopes = usePopoverScope(__scopePopover);
 
     return open ? (
       <PopperContent
+        {...scopes}
         position={position}
         offset={offset}
         disablePortal={disablePortal}
@@ -143,7 +169,7 @@ const PopoverContent = forwardRef<
             >
               {children}
 
-              {arrow && <PopperArrow />}
+              {arrow && <PopperArrow {...scopes} />}
             </FlexBox>
           </DismissableLayer>
         </FocusScope>

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -22,7 +22,7 @@ import type { PopoverContentProps, PopoverProps } from './types';
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
-const usePopoverScope = createScope('Popper', 'PopperContent');
+const usePopoverScope = createScope('Popper');
 
 const Popover = ({
   open: originOpen,

--- a/packages/wds/src/components/popper/contexts.ts
+++ b/packages/wds/src/components/popper/contexts.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@radix-ui/react-context';
+import { createScopeContext } from '../../hooks/use-scope-context';
 
 import { POPPER_CONTENT_NAME, POPPER_NAME } from './constants';
 
@@ -10,7 +10,7 @@ type PopperContextValue = {
 };
 
 export const [PopperProvider, usePopperContext] =
-  createContext<PopperContextValue>(POPPER_NAME);
+  createScopeContext<PopperContextValue>(POPPER_NAME);
 
 type PopperContentContextValue = {
   side: Side;
@@ -20,4 +20,4 @@ type PopperContentContextValue = {
 };
 
 export const [PopperContentProvider, usePopperContentContext] =
-  createContext<PopperContentContextValue>(POPPER_CONTENT_NAME);
+  createScopeContext<PopperContentContextValue>(POPPER_CONTENT_NAME);

--- a/packages/wds/src/components/popper/index.tsx
+++ b/packages/wds/src/components/popper/index.tsx
@@ -41,6 +41,7 @@ import {
   POPPER_CONTENT_NAME,
 } from './constants';
 
+import type { ScopedProps } from '../../hooks/use-scope-context';
 import type { DefaultComponentProps } from '@wanteddev/wds-engine';
 import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 import type { PopperArrowProps, PopperContentProps } from './types';
@@ -52,11 +53,20 @@ const OPPOSITE_SIDE = {
   left: 'right',
 } as const;
 
-const Popper = ({ children }: PropsWithChildren) => {
+const Popper = ({
+  children,
+  __scopePopper = 'Popper',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  __scopePopperContent: _,
+}: ScopedProps<PropsWithChildren, 'Popper' | 'PopperContent'>) => {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
   return (
-    <PopperProvider anchor={anchor} onAnchorChange={setAnchor}>
+    <PopperProvider
+      scope={__scopePopper}
+      anchor={anchor}
+      onAnchorChange={setAnchor}
+    >
       {children}
     </PopperProvider>
   );
@@ -64,77 +74,64 @@ const Popper = ({ children }: PropsWithChildren) => {
 
 const PopperAnchor = forwardRef<
   HTMLElement,
-  ComponentPropsWithoutRef<typeof Slot>
->((props, forwardedRef) => {
-  const context = usePopperContext(POPPER_ANCHOR_NAME);
-  const ref = useRef<HTMLElement>(null);
-  const composedRefs = useComposedRefs(forwardedRef, ref);
+  ScopedProps<ComponentPropsWithoutRef<typeof Slot>, 'Popper' | 'PopperContent'>
+>(
+  (
+    {
+      __scopePopper = 'Popper',
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      __scopePopperContent: _,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const context = usePopperContext(POPPER_ANCHOR_NAME, __scopePopper);
+    const ref = useRef<HTMLElement>(null);
+    const composedRefs = useComposedRefs(forwardedRef, ref);
 
-  useEffect(() => {
-    context.onAnchorChange(ref.current);
-  });
+    useEffect(() => {
+      context.onAnchorChange(ref.current);
+    });
 
-  return <Slot ref={composedRefs} {...props} />;
-});
+    return <Slot ref={composedRefs} {...props} />;
+  },
+);
 
 PopperAnchor.displayName = POPPER_ANCHOR_NAME;
 
 const PopperArrow = forwardRef<
   SVGSVGElement,
-  DefaultComponentProps<PopperArrowProps, 'svg'>
->(({ overlay, ...props }, ref) => {
-  const { onArrowChange, side, arrowX, arrowY } =
-    usePopperContentContext(POPPER_ARROW_NAME);
-
-  const composedRef = useComposedRefs(
+  DefaultComponentProps<
+    ScopedProps<PopperArrowProps, 'Popper' | 'PopperContent'>,
+    'svg'
+  >
+>(
+  (
+    {
+      overlay,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      __scopePopper: _,
+      __scopePopperContent = 'PopperContent',
+      ...props
+    },
     ref,
-    onArrowChange as (node: SVGSVGElement | null) => void,
-  );
+  ) => {
+    const { onArrowChange, side, arrowX, arrowY } = usePopperContentContext(
+      POPPER_ARROW_NAME,
+      __scopePopperContent,
+    );
 
-  return (
-    <>
-      <Box
-        as="svg"
-        wds-component="popper-arrow"
-        ref={composedRef}
-        style={{
-          ...props.style,
-          position: 'absolute',
-          width: '24px',
-          height: '8px',
-          display: 'block',
-          left: arrowX,
-          top: arrowY,
-          right: '',
-          bottom: '',
-          [OPPOSITE_SIDE[side]]: '0px',
-          transformOrigin: {
-            top: '',
-            right: '0 0',
-            bottom: 'center 0',
-            left: '100% 0',
-          }[side],
-          transform: {
-            top: 'translateY(100%)',
-            right: 'translateY(50%) rotate(90deg) translateX(-50%)',
-            bottom: `rotate(180deg)`,
-            left: 'translateY(50%) rotate(-90deg) translateX(50%)',
-          }[side],
-        }}
-        viewBox="0 0 24 8"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        {...props}
-      >
-        <path
-          d="M11.2407 6.11563L6 0.00143462H18L12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563Z"
-          fill="currentColor"
-        />
-      </Box>
+    const composedRef = useComposedRefs(
+      ref,
+      onArrowChange as (node: SVGSVGElement | null) => void,
+    );
 
-      {Boolean(overlay) && (
+    return (
+      <>
         <Box
           as="svg"
+          wds-component="popper-arrow"
+          ref={composedRef}
           style={{
             ...props.style,
             position: 'absolute',
@@ -143,7 +140,6 @@ const PopperArrow = forwardRef<
             display: 'block',
             left: arrowX,
             top: arrowY,
-            color: overlay,
             right: '',
             bottom: '',
             [OPPOSITE_SIDE[side]]: '0px',
@@ -166,20 +162,63 @@ const PopperArrow = forwardRef<
           {...props}
         >
           <path
-            d="M12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563L6 0.00143462H18L12.7593 6.11564Z"
+            d="M11.2407 6.11563L6 0.00143462H18L12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563Z"
             fill="currentColor"
           />
         </Box>
-      )}
-    </>
-  );
-});
+
+        {Boolean(overlay) && (
+          <Box
+            as="svg"
+            style={{
+              ...props.style,
+              position: 'absolute',
+              width: '24px',
+              height: '8px',
+              display: 'block',
+              left: arrowX,
+              top: arrowY,
+              color: overlay,
+              right: '',
+              bottom: '',
+              [OPPOSITE_SIDE[side]]: '0px',
+              transformOrigin: {
+                top: '',
+                right: '0 0',
+                bottom: 'center 0',
+                left: '100% 0',
+              }[side],
+              transform: {
+                top: 'translateY(100%)',
+                right: 'translateY(50%) rotate(90deg) translateX(-50%)',
+                bottom: `rotate(180deg)`,
+                left: 'translateY(50%) rotate(-90deg) translateX(50%)',
+              }[side],
+            }}
+            viewBox="0 0 24 8"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+          >
+            <path
+              d="M12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563L6 0.00143462H18L12.7593 6.11564Z"
+              fill="currentColor"
+            />
+          </Box>
+        )}
+      </>
+    );
+  },
+);
 
 PopperArrow.displayName = POPPER_ARROW_NAME;
 
 const PopperContent: ReturnType<
   typeof forwardRef<HTMLElement, PopperContentProps>
-> = forwardRef<HTMLElement, PopperContentProps>(
+> = forwardRef<
+  HTMLElement,
+  ScopedProps<PopperContentProps, 'Popper' | 'PopperContent'>
+>(
   (
     {
       wrapperProps = {},
@@ -190,12 +229,14 @@ const PopperContent: ReturnType<
       setContext,
       container,
       disablePortal,
+      __scopePopper = 'Popper',
+      __scopePopperContent = 'PopperContent',
       ...props
     },
     ref,
   ) => {
     const theme = useTheme();
-    const context = usePopperContext(POPPER_CONTENT_NAME);
+    const context = usePopperContext(POPPER_CONTENT_NAME, __scopePopper);
 
     const [arrow, setArrow] = useState<HTMLElement | null>(null);
     const arrowSize = useSize(arrow);
@@ -291,6 +332,7 @@ const PopperContent: ReturnType<
           dir={props.dir}
         >
           <PopperContentProvider
+            scope={__scopePopperContent}
             side={side}
             onArrowChange={setArrow}
             arrowX={arrowX}

--- a/packages/wds/src/components/popper/index.tsx
+++ b/packages/wds/src/components/popper/index.tsx
@@ -56,9 +56,7 @@ const OPPOSITE_SIDE = {
 const Popper = ({
   children,
   __scopePopper = 'Popper',
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  __scopePopperContent: _,
-}: ScopedProps<PropsWithChildren, 'Popper' | 'PopperContent'>) => {
+}: ScopedProps<PropsWithChildren, 'Popper'>) => {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
 
   return (
@@ -74,64 +72,79 @@ const Popper = ({
 
 const PopperAnchor = forwardRef<
   HTMLElement,
-  ScopedProps<ComponentPropsWithoutRef<typeof Slot>, 'Popper' | 'PopperContent'>
->(
-  (
-    {
-      __scopePopper = 'Popper',
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      __scopePopperContent: _,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    const context = usePopperContext(POPPER_ANCHOR_NAME, __scopePopper);
-    const ref = useRef<HTMLElement>(null);
-    const composedRefs = useComposedRefs(forwardedRef, ref);
+  ScopedProps<ComponentPropsWithoutRef<typeof Slot>, 'Popper'>
+>(({ __scopePopper = 'Popper', ...props }, forwardedRef) => {
+  const context = usePopperContext(POPPER_ANCHOR_NAME, __scopePopper);
+  const ref = useRef<HTMLElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
 
-    useEffect(() => {
-      context.onAnchorChange(ref.current);
-    });
+  useEffect(() => {
+    context.onAnchorChange(ref.current);
+  });
 
-    return <Slot ref={composedRefs} {...props} />;
-  },
-);
+  return <Slot ref={composedRefs} {...props} />;
+});
 
 PopperAnchor.displayName = POPPER_ANCHOR_NAME;
 
 const PopperArrow = forwardRef<
   SVGSVGElement,
-  DefaultComponentProps<
-    ScopedProps<PopperArrowProps, 'Popper' | 'PopperContent'>,
-    'svg'
-  >
->(
-  (
-    {
-      overlay,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      __scopePopper: _,
-      __scopePopperContent = 'PopperContent',
-      ...props
-    },
+  DefaultComponentProps<ScopedProps<PopperArrowProps, 'Popper'>, 'svg'>
+>(({ overlay, __scopePopper = 'Popper', ...props }, ref) => {
+  const { onArrowChange, side, arrowX, arrowY } = usePopperContentContext(
+    POPPER_ARROW_NAME,
+    __scopePopper,
+  );
+
+  const composedRef = useComposedRefs(
     ref,
-  ) => {
-    const { onArrowChange, side, arrowX, arrowY } = usePopperContentContext(
-      POPPER_ARROW_NAME,
-      __scopePopperContent,
-    );
+    onArrowChange as (node: SVGSVGElement | null) => void,
+  );
 
-    const composedRef = useComposedRefs(
-      ref,
-      onArrowChange as (node: SVGSVGElement | null) => void,
-    );
+  return (
+    <>
+      <Box
+        as="svg"
+        wds-component="popper-arrow"
+        ref={composedRef}
+        style={{
+          ...props.style,
+          position: 'absolute',
+          width: '24px',
+          height: '8px',
+          display: 'block',
+          left: arrowX,
+          top: arrowY,
+          right: '',
+          bottom: '',
+          [OPPOSITE_SIDE[side]]: '0px',
+          transformOrigin: {
+            top: '',
+            right: '0 0',
+            bottom: 'center 0',
+            left: '100% 0',
+          }[side],
+          transform: {
+            top: 'translateY(100%)',
+            right: 'translateY(50%) rotate(90deg) translateX(-50%)',
+            bottom: `rotate(180deg)`,
+            left: 'translateY(50%) rotate(-90deg) translateX(50%)',
+          }[side],
+        }}
+        viewBox="0 0 24 8"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}
+      >
+        <path
+          d="M11.2407 6.11563L6 0.00143462H18L12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563Z"
+          fill="currentColor"
+        />
+      </Box>
 
-    return (
-      <>
+      {Boolean(overlay) && (
         <Box
           as="svg"
-          wds-component="popper-arrow"
-          ref={composedRef}
           style={{
             ...props.style,
             position: 'absolute',
@@ -140,6 +153,7 @@ const PopperArrow = forwardRef<
             display: 'block',
             left: arrowX,
             top: arrowY,
+            color: overlay,
             right: '',
             bottom: '',
             [OPPOSITE_SIDE[side]]: '0px',
@@ -162,63 +176,20 @@ const PopperArrow = forwardRef<
           {...props}
         >
           <path
-            d="M11.2407 6.11563L6 0.00143462H18L12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563Z"
+            d="M12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563L6 0.00143462H18L12.7593 6.11564Z"
             fill="currentColor"
           />
         </Box>
-
-        {Boolean(overlay) && (
-          <Box
-            as="svg"
-            style={{
-              ...props.style,
-              position: 'absolute',
-              width: '24px',
-              height: '8px',
-              display: 'block',
-              left: arrowX,
-              top: arrowY,
-              color: overlay,
-              right: '',
-              bottom: '',
-              [OPPOSITE_SIDE[side]]: '0px',
-              transformOrigin: {
-                top: '',
-                right: '0 0',
-                bottom: 'center 0',
-                left: '100% 0',
-              }[side],
-              transform: {
-                top: 'translateY(100%)',
-                right: 'translateY(50%) rotate(90deg) translateX(-50%)',
-                bottom: `rotate(180deg)`,
-                left: 'translateY(50%) rotate(-90deg) translateX(50%)',
-              }[side],
-            }}
-            viewBox="0 0 24 8"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            {...props}
-          >
-            <path
-              d="M12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563L6 0.00143462H18L12.7593 6.11564Z"
-              fill="currentColor"
-            />
-          </Box>
-        )}
-      </>
-    );
-  },
-);
+      )}
+    </>
+  );
+});
 
 PopperArrow.displayName = POPPER_ARROW_NAME;
 
 const PopperContent: ReturnType<
   typeof forwardRef<HTMLElement, PopperContentProps>
-> = forwardRef<
-  HTMLElement,
-  ScopedProps<PopperContentProps, 'Popper' | 'PopperContent'>
->(
+> = forwardRef<HTMLElement, ScopedProps<PopperContentProps, 'Popper'>>(
   (
     {
       wrapperProps = {},
@@ -230,7 +201,6 @@ const PopperContent: ReturnType<
       container,
       disablePortal,
       __scopePopper = 'Popper',
-      __scopePopperContent = 'PopperContent',
       ...props
     },
     ref,
@@ -332,7 +302,7 @@ const PopperContent: ReturnType<
           dir={props.dir}
         >
           <PopperContentProvider
-            scope={__scopePopperContent}
+            scope={__scopePopper}
             side={side}
             onArrowChange={setArrow}
             arrowX={arrowX}

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -21,6 +21,7 @@ import { addOpacity } from '../../utils';
 import IconButton from '../icon-button';
 import useTransitionStatus from '../../hooks/use-transition-status';
 import ComponentOrFragment from '../component-or-fragment';
+import { createScope } from '../../hooks/use-scope-context';
 
 import {
   TooltipGroupProvider,
@@ -43,6 +44,8 @@ import type {
   TooltipProps,
 } from './types';
 import type { CSSProperties } from 'react';
+
+const useTooltipScope = createScope('Popper', 'PopperContent');
 
 const TooltipGroup = ({
   children,
@@ -112,6 +115,8 @@ const Tooltip = ({
     disableOpenOnFocus,
   });
 
+  const scopes = useTooltipScope('Tooltip');
+
   return (
     <TooltipProvider
       triggerRef={triggerRef}
@@ -128,7 +133,7 @@ const Tooltip = ({
       handleClick={handleClick}
       handlePointerDownOutside={handlePointerDownOutside}
     >
-      <Popper>{children}</Popper>
+      <Popper {...scopes}>{children}</Popper>
     </TooltipProvider>
   );
 };
@@ -151,8 +156,10 @@ const TooltipTrigger = forwardRef<
     handleClick,
   } = useTooltipContext(TOOLTIP_TRIGGER_NAME);
 
+  const scopes = useTooltipScope('Tooltip');
+
   return (
-    <PopperAnchor ref={triggerRef}>
+    <PopperAnchor ref={triggerRef} {...scopes}>
       <Slot
         aria-describedby={open ? containerId : undefined}
         {...props}
@@ -196,6 +203,8 @@ const TooltipContent = forwardRef<
     },
     ref,
   ) => {
+    const scopes = useTooltipScope('Tooltip');
+
     const {
       containerRef,
       containerId,
@@ -236,6 +245,7 @@ const TooltipContent = forwardRef<
           onDismiss={handleDismiss}
         >
           <PopperContent
+            {...scopes}
             position={position}
             role="tooltip"
             data-status={status}
@@ -306,7 +316,7 @@ const TooltipContent = forwardRef<
                     )}
                   </FlexBox>
 
-                  {arrow && <PopperArrow overlay={overlay} />}
+                  {arrow && <PopperArrow overlay={overlay} {...scopes} />}
                 </FlexBox>
               </FlexBox>
             )}

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -45,7 +45,7 @@ import type {
 } from './types';
 import type { CSSProperties } from 'react';
 
-const useTooltipScope = createScope('Popper', 'PopperContent');
+const useTooltipScope = createScope('Popper');
 
 const TooltipGroup = ({
   children,

--- a/packages/wds/src/hooks/use-scope-context.tsx
+++ b/packages/wds/src/hooks/use-scope-context.tsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import type { ReactNode } from 'react';
+
+type ScopeObject<T extends ReadonlyArray<string>> = {
+  [K in T[number] as `__scope${Capitalize<K>}`]: string;
+};
+
+export const createScope = <T extends ReadonlyArray<string>>(
+  ...components: T
+) => {
+  const useScope = (scope: string): ScopeObject<T> => {
+    return useMemo(() => {
+      const result = {} as ScopeObject<T>;
+
+      components.forEach((component) => {
+        const scopeKey = `__scope${component}` as keyof ScopeObject<T>;
+        (result as any)[scopeKey] = scope ? `${scope}/${component}` : component;
+      });
+
+      return result;
+    }, [scope]);
+  };
+
+  return useScope;
+};
+
+export const createScopeContext = <ContextValueType extends object | null>(
+  rootComponentName: string,
+  defaultContext?: ContextValueType,
+) => {
+  const contextCache = new Map<
+    string,
+    React.Context<ContextValueType | undefined>
+  >();
+
+  const Provider = (
+    props: ContextValueType & { scope: string; children: ReactNode },
+  ) => {
+    const { children, scope, ...context } = props;
+
+    if (!contextCache.has(scope)) {
+      const Context = createContext<ContextValueType | undefined>(
+        defaultContext,
+      );
+      contextCache.set(scope, Context);
+    }
+
+    const Context = contextCache.get(scope)!;
+
+    const value = useMemo(
+      () => context,
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      Object.values(context),
+    ) as ContextValueType;
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+  };
+
+  const useScopeContext = (consumerName: string, scope: string) => {
+    if (!contextCache.has(scope)) {
+      throw new Error(
+        `${consumerName} must be rendered inside a ${rootComponentName}Provider with scope="${scope}"`,
+      );
+    }
+
+    const Context = contextCache.get(scope)!;
+    const context = useContext(Context);
+
+    if (context) return context;
+    if (defaultContext !== undefined) return defaultContext;
+
+    throw new Error(
+      `${consumerName} must be rendered inside a ${rootComponentName}Provider with scope="${scope}"`,
+    );
+  };
+
+  Provider.displayName = rootComponentName + 'Provider';
+
+  return [Provider, useScopeContext] as const;
+};
+
+export type ScopedProps<T, Scope extends string> = T & {
+  [key in `__scope${Scope}`]?: string;
+};


### PR DESCRIPTION
## 배경

기존에 MenuTrigger에 Tooltip을 함께 사용하면 Menu가 열리지 않던 문제가 있었습니다.

https://github.com/user-attachments/assets/5e2118a7-c4b0-4bb4-a72c-c9218053d72c


```tsx
<Menu>
  <Tooltip>
    <TooltipTrigger>
     {/* 여기서 MenuTrigger (PopperTrigger)는 Tooltip에서 사용하는 Popper context 상태를 사용하게 됩니다. */}
      <MenuTrigger>
        <Button>Click me</Button>
      </MenuTrigger>
    </TooltipTrigger>
    
    <TooltipContent>
      필터입니다.
    </TooltipContent>
  </Tooltip>

  <MenuContent />
</Menu>
```

위와 같은 구조로 사용할 때 Menu, Tooltip 모두 내부적으로 Popper를 사용하기 때문에 제일 가까운 PopperContext를 참조하며 MenuTrigger가 올바르게 동작하지 않던 현상이 있습니다.

## 해결 방법

공통적으로 공유되는 특정 Context 컴포넌트에만 Scope 개념을 추가했습니다.

Popper는 Menu, Tooltip, Popover 등에서 모두 사용합니다.

```tsx
<Popover>
  <Tooltip>
    <TooltipTrigger>
      <PopoverTrigger />
    </TooltipTrigger>
  </Tooltip>
</Popover>
```

이 구조에서 PopoverTrigger의 Popper Context는 제일 가까운 Tooltip( Popper Provider )를 바라보기 때문에 PopoverTrigger로써의 역할을 할 수 없습니다.

![image](https://github.com/user-attachments/assets/207412e8-e9b8-4ecc-9c6a-916f44f81849)


scope 개념이 추가되면 사진에 나오는 `Popover/Popper` 처럼 Context 사용 가능한 영역을 만듭니다.

```tsx
const usePopoverScope = createScope('Popper');

const Component = () => {
  // { __scopePopper: 'Popover/Popper' }
  const scopes = usePopoverScope('Popover');

  return (
    <Popper {...scopes}>
      <PopperTrigger  {...scopes} />
      <PopperContent  {...scopes} />
    </Popper>
  )
}
```

이렇게 Popper 에 scope 영역을 전달합니다.

그러면 Popper는 Provider에 전달받은 scope를 넘겨줍니다.

```tsx
const Popper = ({
  children,
  __scopePopper = 'Popper',
}: ScopedProps<PropsWithChildren, 'Popper'>) => {
  const [anchor, setAnchor] = useState<HTMLElement | null>(null);

  return (
    <PopperProvider
      scope={__scopePopper}
      anchor={anchor}
      onAnchorChange={setAnchor}
    >
      {children}
    </PopperProvider>
  );
};
```


PopperTrigger도 전달받은 scope를 가지고 context를 조회합니다.

```tsx
const PopperAnchor = forwardRef<
  HTMLElement,
  ScopedProps<ComponentPropsWithoutRef<typeof Slot>, 'Popper'>
>(
  (
    {
      __scopePopper = 'Popper',
      ...props
    },
    forwardedRef,
  ) => {
    // 전달받은 scope로 context 조회
    const context = usePopperContext(POPPER_ANCHOR_NAME, __scopePopper);
  },
);
```

이렇게 각각 scope별로 다른 context를 가지게 되므로 위 문제 사항이 해결됩니다.

context scope 개념은 https://github.com/radix-ui/primitives/discussions/1091#discussioncomment-1984109
Radix 에서 이미 사용 중인 개념입니다.

그러나 Radix와는 달리 모든 context를 scope로 관리하지 않고 이렇게 필요한 컴포넌트에 한에서만 적용할 예정입니다.
왜냐하면 scope context가 추가되면 고려해야할 사항이 많아지고 컴포넌트 로직이 다소 복잡해질 수 있기 때문입니다.

Radix에서 제공하는 createContextScope 를 사용하면 컴포넌트 코드가 보다 더 복잡해지는 경향이 있어서 Radix에서 제공하는걸 사용하지 않고 직접 사용하기 편하게 재구성하였습니다.