### PR TITLE
fix(wds): time picker prop으로 주입된 views 가 반영되지 않음

### DIFF
--- a/packages/wds/src/components/time-picker/index.tsx
+++ b/packages/wds/src/components/time-picker/index.tsx
@@ -109,7 +109,10 @@ const TimePicker = forwardRef<
 
     const composedInputRef = useComposedRefs(originInputRef, inputRef);
 
-    const views = useMemo(() => sectionsToViews(sections), [sections]);
+    const views = useMemo(
+      () => props.views ?? sectionsToViews(sections),
+      [sections, props.views],
+    );
 
     const invalid =
       originInvalid ||

--- a/packages/wds/src/components/time-picker/index.tsx
+++ b/packages/wds/src/components/time-picker/index.tsx
@@ -51,6 +51,7 @@ const TimePicker = forwardRef<
       inputRef: originInputRef,
       disableLastUnitClickClose,
       actionArea,
+      views: originViews,
       ...props
     },
     forwardedRef,
@@ -110,8 +111,8 @@ const TimePicker = forwardRef<
     const composedInputRef = useComposedRefs(originInputRef, inputRef);
 
     const views = useMemo(
-      () => props.views ?? sectionsToViews(sections),
-      [sections, props.views],
+      () => originViews ?? sectionsToViews(sections),
+      [sections, originViews],
     );
 
     const invalid =


### PR DESCRIPTION
`TimePicker` 를 사용할 때 views를 props로 전달 하여도 format에 맞게 변경되는 현상이 있어 수정하였습니다.