### PR TITLE
fix(wds): text area SSR 환경에서 기본 높이가 올바르게 적용되지 않음

### DIFF
--- a/packages/wds/src/components/text-area/helpers.ts
+++ b/packages/wds/src/components/text-area/helpers.ts
@@ -8,7 +8,7 @@ export const getTextAreaDefaultHeight = ({
   minRows = 2,
 }: Pick<TextAreaProps, 'minRows'>) => {
   return {
-    '--wds-text-area-scroll-height': minRows * DEFAULT_LINE_HEIGHT,
-    '--wds-text-area-height': minRows * DEFAULT_LINE_HEIGHT,
+    '--wds-text-area-scroll-height': `${minRows * DEFAULT_LINE_HEIGHT}px`,
+    '--wds-text-area-height': `${minRows * DEFAULT_LINE_HEIGHT}px`,
   } as CSSProperties;
 };


### PR DESCRIPTION
원래 minRows 만큼 기본 높이를 차지해야하는데

```
style="--wds-text-area-scroll-height: 26;"
```

이렇게 px 단위 없이 들어가서 올바르게 적용되지 않던 이슈 수정하였습니다.