### PR TITLE
feat(wds): card typography variant 커스터마이징 편의성 개선

### DIFF
--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -7,9 +7,9 @@ import {
 import { composeEventHandlers } from '@radix-ui/primitive';
 
 import FlexBox from '../flex-box';
-import Typography from '../typography';
 import { Thumbnail, ThumbnailSkeleton } from '../thumbnail';
 import Skeleton from '../skeleton';
+import Typography from '../typography';
 
 import {
   CARD_CAPTION_NAME,
@@ -26,6 +26,7 @@ import {
   CARD_TITLE_SKELETON_NAME,
 } from './constants';
 import {
+  cardCaptionStyle,
   cardContentItemStyle,
   cardContentStyle,
   cardSkeletonStyle,
@@ -35,6 +36,8 @@ import {
   cardThumbnailContentWrapperStyle,
   cardThumbnailSkeletonStyle,
   cardThumbnailStyle,
+  cardTitleSkeletonStyle,
+  cardTitleStyle,
 } from './style';
 
 import type { FlexBoxProps } from '../flex-box/types';
@@ -216,34 +219,50 @@ const CardContentItem = forwardRef(
 CardContentItem.displayName = CARD_CONTENT_ITEM_NAME;
 
 const CardTitle = forwardRef(
-  <E extends ElementType = 'span'>(
+  <E extends ElementType = 'p'>(
     {
-      variant = 'body1',
-      weight = 'bold',
+      variant,
+      weight,
+      color,
+      as,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
       ...props
     }: PolymorphicProps<TypographyProps, E>,
     ref: ForwardedRef<E>,
   ) => {
     return (
       <Typography
+        as={as ?? 'p'}
         ref={ref}
         wds-component="card-title"
-        variant={variant}
-        weight={weight}
         {...props}
+        sx={[
+          cardTitleStyle({ variant, weight, color, xs, sm, md, lg, xl }),
+          props.sx,
+        ]}
       />
     );
   },
-) as PolymorphicComponent<TypographyProps, 'span'>;
+) as PolymorphicComponent<TypographyProps, 'p'>;
 
 CardTitle.displayName = CARD_TITLE_NAME;
 
 const CardCaption = forwardRef(
-  <E extends ElementType = 'span'>(
+  <E extends ElementType = 'p'>(
     {
-      variant = 'label2',
-      weight = 'medium',
+      variant,
+      weight,
       color = 'semantic.label.alternative',
+      as,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
       ...props
     }: PolymorphicProps<TypographyProps, E>,
     ref: ForwardedRef<E>,
@@ -251,15 +270,17 @@ const CardCaption = forwardRef(
     return (
       <Typography
         ref={ref}
+        as={as ?? 'p'}
         wds-component="card-caption"
-        variant={variant}
-        weight={weight}
-        color={color}
         {...props}
+        sx={[
+          cardCaptionStyle({ variant, weight, color, xs, sm, md, lg, xl }),
+          props.sx,
+        ]}
       />
     );
   },
-) as PolymorphicComponent<TypographyProps, 'span'>;
+) as PolymorphicComponent<TypographyProps, 'p'>;
 
 CardCaption.displayName = CARD_CAPTION_NAME;
 
@@ -345,11 +366,28 @@ CardContentItemSkeleton.displayName = CARD_CONTENT_ITEM_SKELETON_NAME;
 
 const CardTitleSkeleton = forwardRef(
   (
-    props: DefaultComponentProps<SkeletonProps, 'div'>,
+    {
+      width,
+      height,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      ...props
+    }: DefaultComponentProps<SkeletonProps, 'div'>,
     ref: ForwardedRef<ElementRef<'div'>>,
   ) => {
     return (
-      <Skeleton ref={ref} wds-component="card-title-skeleton" {...props} />
+      <Skeleton
+        ref={ref}
+        wds-component="card-title-skeleton"
+        {...props}
+        sx={[
+          cardTitleSkeletonStyle({ width, height, xs, sm, md, lg, xl }),
+          props.sx,
+        ]}
+      />
     );
   },
 );

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -423,20 +423,14 @@ export const cardTitleSkeletonStyle =
 const cardSkeletonWidthStyle =
   ({ width, height, xs, sm, md, lg, xl }: SkeletonProps) =>
   (theme: Theme) => {
-    if (width) {
-      return css`
-        width: ${width};
-      `;
-    }
-
     return css`
-      ${Boolean(width) &&
+      ${width !== undefined &&
       css`
-        width: ${width};
+        width: ${toCssValue(width)};
       `}
-      ${Boolean(height) &&
+      ${height !== undefined &&
       css`
-        height: ${height};
+        height: ${toCssValue(height)};
       `}
 
     ${createResponsiveStyle(
@@ -446,11 +440,11 @@ const cardSkeletonWidthStyle =
         (params) => css`
           ${params?.width !== undefined &&
           css`
-            width: ${params.width};
+            width: ${toCssValue(params.width)};
           `}
           ${params?.height !== undefined &&
           css`
-            height: ${params.height};
+            height: ${toCssValue(params.height)};
           `}
         `,
       )}

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@wanteddev/wds-engine';
+import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import {
   createResponsiveStyle,
@@ -7,7 +7,10 @@ import {
   typographyStyle,
 } from '../../utils';
 import { toCssValue } from '../../utils/css';
+import { getWeightMap } from '../typography/style';
 
+import type { SkeletonProps } from '../skeleton/types';
+import type { TypographyProps } from '../typography/types';
 import type { ThumbnailSkeletonProps } from '../thumbnail/types';
 import type { Theme } from '@wanteddev/wds-engine';
 import type {
@@ -118,13 +121,6 @@ export const cardStyle =
     [wds-component='thumbnail-skeleton'] {
       width: 100%;
     }
-    // text
-    [wds-component='card-title'] {
-      ${ellipsisTypographyStyle(2)}
-    }
-    [wds-component='card-caption'] {
-      ${ellipsisTypographyStyle()}
-    }
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
@@ -195,6 +191,7 @@ export const cardThumbnailStyle =
 export const cardThumbnailSkeletonStyle =
   ({ ratio, xs, sm, md, lg, xl }: ThumbnailSkeletonProps) =>
   (theme: Theme) => css`
+    width: 100%;
     ${cardThumbnailRatioStyle({ ratio })}
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
@@ -241,6 +238,65 @@ export const cardThumbnailContentToggleIconStyle = (theme: Theme) => css`
     color: ${theme.semantic.static.white};
   }
 `;
+
+export const cardTitleStyle = (props: TypographyProps) => (theme: Theme) => css`
+  ${ellipsisTypographyStyle(2)}
+
+  &[wds-component='card-title'] {
+    ${cardTypographyStyle(props, 'bold')(theme)}
+  }
+`;
+
+export const cardCaptionStyle =
+  (props: TypographyProps) => (theme: Theme) => css`
+    ${ellipsisTypographyStyle()}
+
+    &[wds-component='card-caption'] {
+      ${cardTypographyStyle(props, 'medium')(theme)}
+    }
+  `;
+
+export const cardTypographyStyle =
+  (props: TypographyProps, defaultWeight?: TypographyProps['weight']) =>
+  (theme: Theme) => {
+    if (Object.keys(props).length === 0) {
+      return undefined;
+    }
+
+    const getTypographyStyle = ({ variant, weight }: TypographyProps) => {
+      if (!variant && !weight) {
+        return undefined;
+      }
+
+      if (!variant) {
+        return css`
+          ${getWeightMap('body1')[weight ?? defaultWeight ?? 'regular']}
+        `;
+      }
+
+      return typographyStyle(variant, weight);
+    };
+
+    const { xs, sm, md, lg, xl } = props;
+
+    return css`
+      ${getTypographyStyle(props)}
+
+      ${Boolean(props.color) &&
+      css`
+        color: ${getColorByToken(theme, props.color!)};
+      `}
+
+    ${createResponsiveStyle(
+        { xs, sm, md, lg, xl },
+        theme,
+      )(
+        (params) => css`
+          ${getTypographyStyle(params ?? {})}
+        `,
+      )}
+    `;
+  };
 
 export const cardContentStyle = css`
   overflow: hidden;
@@ -356,3 +412,47 @@ export const cardSkeletonStyle =
       `,
     )}
   `;
+
+export const cardTitleSkeletonStyle =
+  (props: SkeletonProps) => (theme: Theme) => css`
+    &[wds-component='card-title-skeleton'] {
+      ${cardSkeletonWidthStyle(props)(theme)}
+    }
+  `;
+
+const cardSkeletonWidthStyle =
+  ({ width, height, xs, sm, md, lg, xl }: SkeletonProps) =>
+  (theme: Theme) => {
+    if (width) {
+      return css`
+        width: ${width};
+      `;
+    }
+
+    return css`
+      ${Boolean(width) &&
+      css`
+        width: ${width};
+      `}
+      ${Boolean(height) &&
+      css`
+        height: ${height};
+      `}
+
+    ${createResponsiveStyle(
+        { xs, sm, md, lg, xl },
+        theme,
+      )(
+        (params) => css`
+          ${params?.width !== undefined &&
+          css`
+            width: ${params.width};
+          `}
+          ${params?.height !== undefined &&
+          css`
+            height: ${params.height};
+          `}
+        `,
+      )}
+    `;
+  };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- CardTitle, CardCaption, CardTitleSkeleton 컴포넌트에서 반응형 스타일(props: xs, sm, md, lg, xl)과 as prop을 지원하여 다양한 요소 및 스타일 적용이 가능해졌습니다.
- **Style**
	- 카드 타이틀, 캡션, 스켈레톤에 스타일 함수 기반의 일관된 타이포그래피 및 색상 적용이 도입되었습니다.
	- 스켈레톤 컴포넌트에 width, height, 반응형 스타일 적용이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->