### PR TITLE
fix(wds): dot 형태 push-badge를 아이콘 버튼과 함께 사용할 때 크기가 올바르게 적용되지 않음

### DIFF
--- a/packages/wds/src/components/push-badge/style.ts
+++ b/packages/wds/src/components/push-badge/style.ts
@@ -165,6 +165,11 @@ const pushBadgeVariantStyle = ({ variant }: PushBadgeProps, theme: Theme) => {
         flex-shrink: 0;
         align-items: center;
         color: ${theme.semantic.primary.normal};
+
+        svg {
+          width: 1em !important;
+          height: 1em !important;
+        }
       `;
     case 'new':
     case 'number':


### PR DESCRIPTION
IconButton과 함께 PushBadge dot 형태를 사용할 때 icon button의 svg 스타일 적용 때문에 올바르게 반영되지 않던 버그 수정하였습니다.

![image](https://github.com/user-attachments/assets/af75d118-3b02-48cf-8e86-591f4df86aa8)
