### PR TITLE
fix(wds): flexbox responsive 타입에 children이 잡히는 이슈

### DIFF
--- a/packages/wds/src/components/flex-box/types.ts
+++ b/packages/wds/src/components/flex-box/types.ts
@@ -19,6 +19,8 @@ export type FlexBoxDefaultProps = {
   children?: ReactNode;
 };
 
-type FlexBoxResponsiveProps = ResponsiveProps<FlexBoxDefaultProps>;
+type FlexBoxResponsiveProps = ResponsiveProps<
+  Omit<FlexBoxDefaultProps, 'children'>
+>;
 
 export type FlexBoxProps = Merge<FlexBoxDefaultProps, FlexBoxResponsiveProps>;


### PR DESCRIPTION
FlexBox에 ResponsiveProps로 children이 들어있던 부분 제거했습니다.