### PR TITLE
feat(wds): tooltip hover 모드일 때 enableOpenOnFocusVisibleOnly 옵션 추가

### DIFF
--- a/packages/wds/src/components/tooltip/hooks.ts
+++ b/packages/wds/src/components/tooltip/hooks.ts
@@ -16,6 +16,7 @@ export const useTooltip = ({
   leaveDelay,
   disableCloseOnPointDown,
   disableOpenOnFocus,
+  enableOpenOnFocusVisibleOnly,
 }: TooltipProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const groupContext = useTooltipGroupContext();
@@ -122,12 +123,18 @@ export const useTooltip = ({
       return;
     }
 
-    if (!latestOpen.current && !isMouseDownTriggered.current) {
+    if (
+      !latestOpen.current &&
+      !isMouseDownTriggered.current &&
+      (enableOpenOnFocusVisibleOnly
+        ? triggerRef.current?.matches(':focus-visible')
+        : true)
+    ) {
       handleOpen(0);
     }
 
     isMouseDownTriggered.current = false;
-  }, [handleOpen, mode, disableOpenOnFocus]);
+  }, [handleOpen, mode, disableOpenOnFocus, enableOpenOnFocusVisibleOnly]);
 
   const handleBlur = useCallback(() => {
     if (mode === 'hover') {

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -90,6 +90,7 @@ const Tooltip = ({
   leaveDelay = 250,
   disableCloseOnPointDown = false,
   disableOpenOnFocus = false,
+  enableOpenOnFocusVisibleOnly = false,
 }: TooltipProps) => {
   const containerId = useId();
   const {
@@ -113,6 +114,7 @@ const Tooltip = ({
     leaveDelay,
     disableCloseOnPointDown,
     disableOpenOnFocus,
+    enableOpenOnFocusVisibleOnly,
   });
 
   const scopes = useTooltipScope('Tooltip');

--- a/packages/wds/src/components/tooltip/types.ts
+++ b/packages/wds/src/components/tooltip/types.ts
@@ -23,9 +23,14 @@ export type TooltipProps = {
    */
   disableCloseOnPointDown?: boolean;
   /**
-   *  mode="hover" 일 때 focus 이벤트 시 툴팁 열림 여부
+   * mode="hover" 일 때 focus 이벤트 시 툴팁 열림 여부
    */
   disableOpenOnFocus?: boolean;
+  /**
+   * mode="hover" 일 때 focus 이벤트가 아닌
+   * focus-visible 일 때만 툴팁 열림 여부
+   */
+  enableOpenOnFocusVisibleOnly?: boolean;
   children?: ReactNode;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Tooltip 컴포넌트에 `enableOpenOnFocusVisibleOnly` 옵션이 추가되어, 포커스가 `focus-visible` 상태일 때만 툴팁이 열리도록 세밀하게 제어할 수 있습니다.  
- **기타**
  - Tooltip 관련 옵션이 확장되어 접근성 및 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->