### PR TITLE
fix(wds): card thumbnail leading content가 비어 있을 때 정렬이 올바르게 되지 않음

### DIFF
--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -117,8 +117,12 @@ const CardThumbnail = forwardRef<HTMLDivElement, CardThumbnailProps>(
             justifyContent="space-between"
             sx={cardThumbnailContentWrapperStyle}
           >
-            {hasLeadingContent && leadingContent}
-            {hasTrailingContent && trailingContent}
+            <FlexBox data-role="card-thumbnail-leading-content-wrapper">
+              {leadingContent}
+            </FlexBox>
+            <FlexBox data-role="card-thumbnail-trailing-content-wrapper">
+              {trailingContent}
+            </FlexBox>
           </FlexBox>
         )}
         <Thumbnail width={width} radius border {...props} />


### PR DESCRIPTION
`CardThumbnail` 컴포넌트에 leadingContent 없이 trailingContent만 넣었을 경우 우측에 오지 않는 현상이 있어서

`space-between` 레이아웃이 반영될 수 있게 한번 wrapper로 감싸두었습니다.

```tsx
<CardThumbnail
  trailingContent={...}
/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 카드 썸네일 컴포넌트에서 leading/trailing 콘텐츠의 렌더링 구조를 개선하여, 항상 별도의 래퍼로 감싸도록 변경되었습니다. (콘텐츠가 없을 경우에도 빈 래퍼가 표시될 수 있습니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->