### PR TITLE
fix(wds): list cell content로 text button을 사용할 경우 색상이 올바르지 않음

### DIFF
--- a/packages/wds/src/components/text-button/style.ts
+++ b/packages/wds/src/components/text-button/style.ts
@@ -93,7 +93,7 @@ const getColorTheme = (
         background-color: transparent;
         border: none;
         box-shadow: none;
-        ${color
+        color: ${color
           ? getColorByToken(theme, color)
           : theme.semantic.label.alternative};
 

--- a/packages/wds/src/components/text-button/style.ts
+++ b/packages/wds/src/components/text-button/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@wanteddev/wds-engine';
+import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
 import { createResponsiveStyle } from '../../utils';
@@ -72,7 +72,9 @@ const getColorTheme = (
   switch (variant) {
     case 'primary':
       return css`
-        color: ${color ?? theme.semantic.primary.normal};
+        color: ${color
+          ? getColorByToken(theme, color)
+          : theme.semantic.primary.normal};
         background-color: transparent;
         border: none;
         box-shadow: none;
@@ -91,7 +93,9 @@ const getColorTheme = (
         background-color: transparent;
         border: none;
         box-shadow: none;
-        color: ${color ?? theme.semantic.label.alternative};
+        ${color
+          ? getColorByToken(theme, color)
+          : theme.semantic.label.alternative};
 
         [data-role='text-button-loading'] {
           color: ${theme.semantic.label.assistive};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fa8ab657-78ac-475e-9baa-f2cb359c2917)


이렇게 색상이 토큰으로만 설정되는 이슈가 있어서 getColorByToken을 사용하도록 변경하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **스타일**
  * 텍스트 버튼의 primary 및 assistive 스타일에서 색상 지정 방식이 개선되어, 지정된 색상 토큰이 보다 정확하게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->