### PR TITLE
fix(wds): accordion hover시 divider가 사라지지 않음

### DIFF
--- a/packages/wds/src/components/accordion/index.tsx
+++ b/packages/wds/src/components/accordion/index.tsx
@@ -61,6 +61,7 @@ const Accordion = forwardRef<
       divider = true,
       sx,
       children,
+      ...props
     },
     ref,
   ) => {
@@ -82,13 +83,17 @@ const Accordion = forwardRef<
         detailsId={detailsId}
         disableAnimation={disableAnimation}
       >
-        <Box ref={ref} sx={[accordionStyle({ disabled }), sx]}>
+        <Box
+          ref={ref}
+          {...props}
+          sx={[accordionStyle({ disabled, expanded }), sx]}
+        >
           {children}
           {divider && (
             <Divider
               data-role="accordion-divider"
               color="semantic.line.normal.alternative"
-              sx={accordionDividerStyle({ expanded, disableAnimation })}
+              sx={accordionDividerStyle({ disableAnimation })}
             />
           )}
         </Box>

--- a/packages/wds/src/components/accordion/style.ts
+++ b/packages/wds/src/components/accordion/style.ts
@@ -1,9 +1,27 @@
 import { css } from '@wanteddev/wds-engine';
 
-export const accordionStyle = ({ disabled }: { disabled: boolean }) => css`
+export const accordionStyle = ({
+  disabled,
+  expanded,
+}: {
+  disabled: boolean;
+  expanded: boolean;
+}) => css`
   & > *:not([data-role='accordion-divider']) {
     opacity: ${disabled ? 0.2 : 1};
   }
+
+  ${!expanded &&
+  css`
+    &:has(:hover),
+    &:has(:active),
+    &:hover,
+    &:active {
+      [data-role='accordion-divider'] {
+        opacity: 0;
+      }
+    }
+  `}
 `;
 
 export const accordionSummaryStyle = ({
@@ -95,10 +113,8 @@ export const accordionDetailsWrapperStyle = css`
 `;
 
 export const accordionDividerStyle = ({
-  expanded,
   disableAnimation,
 }: {
-  expanded: boolean;
   disableAnimation: boolean;
 }) => css`
   margin: 0 auto;
@@ -108,14 +124,6 @@ export const accordionDividerStyle = ({
   ${!disableAnimation &&
   css`
     transition: opacity 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
-  `}
-
-  ${!expanded &&
-  css`
-    &:hover,
-    &:active {
-      opacity: 0;
-    }
   `}
 `;
 


### PR DESCRIPTION
아코디언에 호버 했을 때 divider가 사라지는 것을 의도하였지만, 디바이더에 호버 했을 때 사라지고 있어서 요 부분 수정했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Accordion 컴포넌트에 추가 속성 및 이벤트 핸들러 전달이 가능해졌습니다.

* **스타일**
  * Accordion의 확장 상태에 따라 동적으로 스타일이 적용됩니다.
  * Divider의 스타일이 단순화되어, 확장 상태와 상호작용에 따른 불투명도 변화가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->