### PR TITLE
feat(wds): image loader deprecated 처리

### DIFF
--- a/docs/src/docs/routes.ts
+++ b/docs/src/docs/routes.ts
@@ -114,7 +114,7 @@ export const routes: Array<Route> = [
       {
         title: 'ImageLoader',
         slug: '/docs/components/image-loader',
-        alpha: true,
+        deprecated: true,
       },
       { title: 'Label', slug: '/docs/components/label' },
       { title: 'List', slug: '/docs/components/list' },

--- a/packages/wds/src/components/card/index.tsx
+++ b/packages/wds/src/components/card/index.tsx
@@ -95,6 +95,8 @@ const CardThumbnail = forwardRef<HTMLDivElement, CardThumbnailProps>(
       lg,
       xl,
       sx,
+      style,
+      className,
       ...props
     },
     ref,
@@ -106,7 +108,8 @@ const CardThumbnail = forwardRef<HTMLDivElement, CardThumbnailProps>(
     return (
       <Box
         ref={ref}
-        {...props}
+        className={className}
+        style={style}
         sx={[cardThumbnailStyle({ ratio, xs, sm, md, lg, xl }), sx]}
       >
         {hasContent && (
@@ -125,6 +128,7 @@ const CardThumbnail = forwardRef<HTMLDivElement, CardThumbnailProps>(
             </FlexBox>
           </FlexBox>
         )}
+
         <Thumbnail width={width} radius border {...props} />
       </Box>
     );

--- a/packages/wds/src/components/image-loader/index.tsx
+++ b/packages/wds/src/components/image-loader/index.tsx
@@ -15,6 +15,9 @@ const loadImage = (src: string) => {
   });
 };
 
+/**
+ * @deprecated v3.0.0에서 제거될 예정입니다. <Box as="img" /> 사용을 권장합니다.
+ */
 const ImageLoader = forwardRef<
   HTMLImageElement,
   DefaultComponentProps<ImageLoaderProps, 'img'>

--- a/packages/wds/src/components/image-loader/types.ts
+++ b/packages/wds/src/components/image-loader/types.ts
@@ -2,11 +2,14 @@ export type ImageLoaderProps = {
   src: string;
   width: number | string;
   alt: string;
+  /**
+   * @deprecated v3.0.0에서 제거될 예정입니다.
+   */
   quality?: number | string;
   onError?: () => void;
   onLoad?: () => void;
   /**
-   * `ImageLoader` 이미지 최적화를 비활성화 합니다.
+   * @deprecated v3.0.0에서 제거될 예정입니다.
    */
   disableOptimize?: boolean;
 };


### PR DESCRIPTION
ImageLoader 컴포넌트는 원티드 optimize 에 종속되어 있어 범용적으로 사용하고자 하는 원티드 디자인시스템의 목적에 맞지 않아 deprecated 하였습니다.

추가적으로 Avatar, Thumbnail, CardThumbnail 에도 optimize 종속성을 3.0.0에서 제거할 예정입니다.