### PR TITLE
feat(wds): provide ListCellContent as a subcomponent instead of ListCellContent

### DIFF
--- a/docs/src/docs/components/autocomplete.mdx
+++ b/docs/src/docs/components/autocomplete.mdx
@@ -10,7 +10,7 @@ description: Autocomplete Component
 - 입력 가능한 요소에 자동완성을 지원할 때 사용해요.
 - text 입력을 도와주는 역할로 사용할 수 있고, `asSelect` 옵션을 활용해 select 요소처럼 사용할 수 있어요.
 - option 종류가 많을 경우 `debounce` 를 활용해서 속도를 최적화해서 사용하면 좋습니다.
-- `AutocompleteOption` 내에서 leadingContent, trailingContent를 사용할 때에는 `ListCellContent` 로 감싸서 사용해요.
+- `AutocompleteOption` 내에서 leadingContent, trailingContent를 사용할 때에는 `AutocompleteOptionContent` 로 감싸서 사용해요.
 
 <Demo code={`import { Typography, Autocomplete, AutocompleteField, AutocompleteList, TextField, AutocompleteOption } from '@wanteddev/wds';
 import { useState, useEffect, useMemo } from 'react';
@@ -105,6 +105,10 @@ Autocomplete는 여러 컴포넌트를 조합해서 사용합니다.
 ### AutocompleteOption
 
 <PropsTable component="AutocompleteOption" />
+
+### AutocompleteOptionContent
+
+<PropsTable component="AutocompleteOptionContent" />
 
 ## Examples
 

--- a/docs/src/docs/components/menu.mdx
+++ b/docs/src/docs/components/menu.mdx
@@ -11,7 +11,7 @@ description: Menu Component
 
 - `Menu`의 값은 `MenuItem`의 variant에 따라 달라져요.
   - normal, radio, variant를 선택하면 value는 문자열이고, checkbox variant를 선택하면 value는 Array\<value\> 입니다.
-- `MenuItem` 의 leadingContent, trailingContent에 요소를 추가 할 때는 `ListCellContent`로 감싸서 사용합니다.
+- `MenuItem` 의 leadingContent, trailingContent에 요소를 추가 할 때는 `MenuItemContent`로 감싸서 사용합니다.
 - `MenuActionArea`의 leadingContent, trailingContent에 요소를 추가 할 때는 `MenuActionAreaContent`로 감싸서 사용합니다.
 
 <Demo code={`import { Button, Menu, MenuTrigger, MenuContent, MenuActionArea, MenuActionAreaContent, MenuGroup, MenuItem, MenuList } from '@wanteddev/wds';
@@ -144,6 +144,10 @@ export default Demo;`}
 ### MenuItem
 
 <PropsTable component="MenuItem" />
+
+### MenuItemContent
+
+<PropsTable component="MenuItemContent" />
 
 ### MenuActionArea
 

--- a/docs/src/docs/components/select-multiple.mdx
+++ b/docs/src/docs/components/select-multiple.mdx
@@ -12,6 +12,7 @@ description: Select Multiple Component
 - 여러 옵션 중 하나의 값을 선택할 수 있어요.
 - leadingContent에 요소를 추가 할 때는 `SelectContent`로 감싸서 사용합니다.
 - 모든 옵션을 스크롤 없이 노출할 때는 overflow=true로 설정해주세요.
+- Option에 leadingContent, trailingContent 요소를 추가 할 때는 `OptionContent`로 감싸서 사용합니다.
 
 <Demo code={`import { SelectMultiple, Option, OptionGroup, Label, FlexBox } from '@wanteddev/wds';
 
@@ -79,6 +80,10 @@ export default Demo;`}
 `MenuItem`과 동일한 props를 사용합니다.
 
 <PropsTable component="Option" />
+
+### OptionContent
+
+`MenuItemContent`와 동일한 props를 사용합니다.
 
 ## Examples
 

--- a/docs/src/docs/components/select.mdx
+++ b/docs/src/docs/components/select.mdx
@@ -11,6 +11,7 @@ description: Select Component
 
 - 여러 옵션 중 하나의 값을 선택할 수 있어요.
 - leadingContent에 요소를 추가 할 때는 `SelectContent`로 감싸서 사용합니다.
+- Option에 leadingContent, trailingContent 요소를 추가 할 때는 `OptionContent`로 감싸서 사용합니다.
 
 <Demo code={`import { Select, Option, OptionGroup, Label, FlexBox } from '@wanteddev/wds';
 
@@ -78,6 +79,12 @@ export default Demo;`}
 `MenuItem`과 동일한 props를 사용합니다.
 
 <PropsTable component="Option" />
+
+### OptionContent
+
+`MenuItemContent`와 동일한 props를 사용합니다.
+
+<PropsTable component="OptionContent" />
 
 ## Examples
 

--- a/packages/wds/src/components/autocomplete/constants.ts
+++ b/packages/wds/src/components/autocomplete/constants.ts
@@ -5,3 +5,4 @@ export const AUTOCOMPLETE_ROOT_NAME = 'AutocompleteRoot';
 export const AUTOCOMPLETE_FIELD_NAME = 'AutocompleteField';
 export const AUTOCOMPLETE_LIST_NAME = 'AutocompleteList';
 export const AUTOCOMPLETE_OPTION_NAME = 'AutocompleteOption';
+export const AUTOCOMPLETE_OPTION_CONTENT_NAME = 'AutocompleteOptionContent';

--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -28,6 +28,7 @@ import {
   AUTOCOMPLETE_FIELD_NAME,
   AUTOCOMPLETE_LIST_NAME,
   AUTOCOMPLETE_NAME,
+  AUTOCOMPLETE_OPTION_CONTENT_NAME,
   AUTOCOMPLETE_OPTION_NAME,
   AUTOCOMPLETE_ROOT_NAME,
   AUTOCOMPLETE_SCOPE,
@@ -42,6 +43,7 @@ import {
 } from './style';
 import { focusSelectedOption, setAttributeSelection } from './helpers';
 
+import type { ListCellContentProps } from '../list';
 import type {
   DefaultComponentProps,
   DefaultComponentPropsInternal,
@@ -658,12 +660,17 @@ const AutocompleteOption = forwardRef<
 
 AutocompleteOption.displayName = AUTOCOMPLETE_OPTION_NAME;
 
+const AutocompleteOptionContent = ListCellContent;
+
+AutocompleteOptionContent.displayName = AUTOCOMPLETE_OPTION_CONTENT_NAME;
+
 export {
   Autocomplete,
   AutocompleteField,
   AutocompleteList,
   AutocompleteGroup,
   AutocompleteOption,
+  AutocompleteOptionContent,
 };
 
 export type {
@@ -672,4 +679,5 @@ export type {
   AutocompleteListProps,
   AutocompleteOptionProps,
   AutocompleteGroupProps,
+  ListCellContentProps as AutocompleteOptionContentProps,
 };

--- a/packages/wds/src/components/menu/constants.ts
+++ b/packages/wds/src/components/menu/constants.ts
@@ -6,6 +6,7 @@ export const MENU_LIST_NAME = 'MenuList';
 export const MENU_GROUP_NAME = 'MenuGroup';
 
 export const MENU_ITEM_NAME = 'MenuItem';
+export const MENU_ITEM_CONTENT_NAME = 'MenuItemContent';
 export const MENU_ITEM_RADIO_NAME = 'MenuItemRadio';
 export const MENU_ITEM_CHECKBOX_NAME = 'MenuItemCheckbox';
 

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -23,6 +23,7 @@ import {
   MENU_CONTENT_NAME,
   MENU_GROUP_NAME,
   MENU_ITEM_CHECKBOX_NAME,
+  MENU_ITEM_CONTENT_NAME,
   MENU_ITEM_NAME,
   MENU_ITEM_RADIO_NAME,
   MENU_LIST_NAME,
@@ -41,6 +42,7 @@ import {
 } from './style';
 import { MenuItemProvider, MenuProvider, useMenuContext } from './contexts';
 
+import type { ListCellContentProps } from '../list';
 import type {
   MenuActionAreaContentProps,
   MenuActionAreaProps,
@@ -374,6 +376,10 @@ const MenuItemCheckbox = forwardRef<any, MenuItemRadioProps>(
 
 MenuItemCheckbox.displayName = MENU_ITEM_RADIO_NAME;
 
+const MenuItemContent = ListCellContent;
+
+MenuItemContent.displayName = MENU_ITEM_CONTENT_NAME;
+
 const MenuActionArea = forwardRef<
   HTMLDivElement,
   DefaultComponentPropsInternal<MenuActionAreaProps, 'div'>
@@ -459,6 +465,7 @@ export {
   MenuList,
   MenuGroup,
   MenuItem,
+  MenuItemContent,
   MenuActionArea,
   MenuActionAreaContent,
 };
@@ -470,6 +477,7 @@ export type {
   MenuListProps,
   MenuGroupProps,
   MenuItemProps,
+  ListCellContentProps as MenuItemContentProps,
   MenuActionAreaProps,
   MenuActionAreaContentProps,
 };

--- a/packages/wds/src/components/select/constants.ts
+++ b/packages/wds/src/components/select/constants.ts
@@ -1,4 +1,5 @@
 export const SELECT_NAME = 'Select';
+export const SELECT_CONTENT_NAME = 'SelectContent';
 export const OPTION_GROUP_NAME = 'OptionGroup';
 export const OPTION_NAME = 'Option';
-export const SELECT_CONTENT_NAME = 'SelectContent';
+export const OPTION_CONTENT_NAME = 'OptionContent';

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -36,6 +36,7 @@ import { ListCellContent } from '../list';
 import { selectIconStyle, selectStyle, selectTextStyle } from './style';
 import { convertChildrenToData } from './helpers';
 import {
+  OPTION_CONTENT_NAME,
   OPTION_GROUP_NAME,
   OPTION_NAME,
   SELECT_CONTENT_NAME,
@@ -354,6 +355,8 @@ const SelectContent = TextFieldContent;
 SelectContent.displayName = SELECT_CONTENT_NAME;
 
 const OptionContent = ListCellContent;
+
+OptionContent.displayName = OPTION_CONTENT_NAME;
 
 export { Select, SelectContent, Option, OptionGroup, OptionContent };
 

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -31,6 +31,7 @@ import { FlexBox } from '../flex-box';
 import { Typography } from '../typography';
 import { invalidIconWrapperStyle } from '../text-field/style';
 import { VirtualValueInput } from '../virtual-input';
+import { ListCellContent } from '../list';
 
 import { selectIconStyle, selectStyle, selectTextStyle } from './style';
 import { convertChildrenToData } from './helpers';
@@ -42,6 +43,7 @@ import {
 } from './constants';
 import { SelectProvider, useSelectContext } from './context';
 
+import type { ListCellContentProps } from '../list';
 import type { TextFieldContentProps } from '../text-field';
 import type {
   DefaultComponentPropsInternal,
@@ -351,11 +353,14 @@ const SelectContent = TextFieldContent;
 
 SelectContent.displayName = SELECT_CONTENT_NAME;
 
-export { Select, SelectContent, Option, OptionGroup };
+const OptionContent = ListCellContent;
+
+export { Select, SelectContent, Option, OptionGroup, OptionContent };
 
 export type {
   SelectProps,
   OptionGroupProps,
   TextFieldContentProps as SelectContentProps,
+  ListCellContentProps as OptionContentProps,
   OptionProps,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new wrapper components: `AutocompleteOptionContent`, `MenuItemContent`, and `OptionContent` for improved customization of leading and trailing content in Autocomplete, Menu, and Select components.
  * Added corresponding prop types for these new components.

* **Documentation**
  * Updated component documentation to reference the new content wrapper components and added detailed usage sections and prop tables for each.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->