### PR TITLE
feat(wds): improve detail in switch interaction style

### DIFF
--- a/packages/wds/src/components/switch/index.tsx
+++ b/packages/wds/src/components/switch/index.tsx
@@ -69,7 +69,10 @@ const Switch = forwardRef<
           />
         )}
 
-        <WithInteraction disabled={disabled}>
+        <WithInteraction
+          disabled={disabled}
+          color={checked ? 'semantic.static.white' : 'semantic.label.normal'}
+        >
           <Box
             as="button"
             type="button"
@@ -105,7 +108,11 @@ const Switch = forwardRef<
               }
             })}
           >
-            <span />
+            <span
+              data-role="switch-knob"
+              data-checked={checked}
+              data-disabled={disabled}
+            />
           </Box>
         </WithInteraction>
       </>

--- a/packages/wds/src/components/switch/style.ts
+++ b/packages/wds/src/components/switch/style.ts
@@ -1,6 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
 import { createResponsiveStyle } from '../../utils/responsive-props';
+import { hoverInteractionStyle } from '../with-interaction/style';
 
 import type { SwitchProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';
@@ -17,27 +18,69 @@ export const switchStyle =
     cursor: pointer;
     height: fit-content;
     flex-shrink: 0;
+    padding: var(--wds-switch-padding, 4px);
+    transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+
+    & > [wds-component='with-interaction'] {
+      transition:
+        opacity 200ms cubic-bezier(0.4, 0, 0.2, 1),
+        background-color 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    &:active > [wds-component='with-interaction'] {
+      ${hoverInteractionStyle(theme, 'normal')}
+    }
 
     span {
+      z-index: 1;
       border-radius: 1000px;
       flex-shrink: 0;
       position: relative;
       background-color: ${theme.semantic.static.white};
-      transition: transform 100ms;
+      transition:
+        margin-left 200ms cubic-bezier(0.4, 0, 0.2, 1),
+        width 200ms cubic-bezier(0.4, 0, 0.2, 1);
+      display: block;
+      transform-origin: 100%;
+      width: var(--wds-switch-thumb-size, 24px);
+      height: var(--wds-switch-thumb-size, 24px);
+      margin-left: 0px;
     }
 
-    ${switchSizeStyle({ size, checked })}
+    ${switchSizeStyle({ size })}
+
+    &:hover:active {
+      span {
+        width: calc(
+          var(--wds-switch-thumb-size, 24px) + var(--wds-switch-padding, 4px)
+        );
+      }
+    }
 
     ${checked &&
     css`
       background-color: ${theme.semantic.primary.normal};
 
       span {
-        transform: translateX(calc(100% - 4px));
+        margin-left: calc(
+          var(--wds-switch-thumb-size, 24px) - var(--wds-switch-padding, 4px)
+        );
+      }
+
+      &:hover:active {
+        span {
+          width: calc(
+            var(--wds-switch-thumb-size, 24px) + var(--wds-switch-padding, 4px)
+          );
+          margin-left: calc(
+            var(--wds-switch-thumb-size, 24px) -
+              (var(--wds-switch-padding, 4px) * 2)
+          );
+        }
       }
     `}
 
-  ${disabled &&
+    ${disabled &&
     css`
       opacity: ${theme.opacity[43]};
       cursor: initial;
@@ -49,18 +92,14 @@ export const switchStyle =
     )(
       (params) => css`
         ${switchSizeStyle({
-          size: params?.size || size,
-          checked,
+          size: params?.size,
         })}
         ${params?.sx}
       `,
     )}
   `;
 
-const switchSizeStyle = ({
-  size,
-  checked,
-}: Pick<SwitchProps, 'size' | 'checked'>) => {
+const switchSizeStyle = ({ size }: Pick<SwitchProps, 'size'>) => {
   switch (size) {
     case 'medium':
       return css`
@@ -68,35 +107,17 @@ const switchSizeStyle = ({
         width: 52px;
         padding: 4px;
 
-        ${checked &&
-        css`
-          span {
-            transform: translateX(calc(100% - 4px));
-          }
-        `}
-        & span {
-          width: 24px;
-          height: 24px;
-        }
+        --wds-switch-padding: 4px;
+        --wds-switch-thumb-size: 24px;
       `;
 
     case 'small':
       return css`
         border-radius: 75px;
         width: 39px;
-        padding: 3px;
 
-        ${checked &&
-        css`
-          span {
-            transform: translateX(calc(100% - 3px));
-          }
-        `}
-
-        & span {
-          width: 18px;
-          height: 18px;
-        }
+        --wds-switch-padding: 3px;
+        --wds-switch-thumb-size: 18px;
       `;
   }
 };

--- a/packages/wds/src/components/switch/style.ts
+++ b/packages/wds/src/components/switch/style.ts
@@ -19,6 +19,7 @@ export const switchStyle =
     height: fit-content;
     flex-shrink: 0;
     padding: var(--wds-switch-padding, 4px);
+    width: var(--wds-switch-width, 52px);
     transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1);
 
     & > [wds-component='with-interaction'] {
@@ -63,7 +64,8 @@ export const switchStyle =
 
       span {
         margin-left: calc(
-          var(--wds-switch-thumb-size, 24px) - var(--wds-switch-padding, 4px)
+          var(--wds-switch-width, 52px) - var(--wds-switch-thumb-size, 24px) -
+            (var(--wds-switch-padding, 4px) * 2)
         );
       }
 
@@ -73,8 +75,8 @@ export const switchStyle =
             var(--wds-switch-thumb-size, 24px) + var(--wds-switch-padding, 4px)
           );
           margin-left: calc(
-            var(--wds-switch-thumb-size, 24px) -
-              (var(--wds-switch-padding, 4px) * 2)
+            var(--wds-switch-width, 52px) - var(--wds-switch-thumb-size, 24px) -
+              (var(--wds-switch-padding, 4px) * 3)
           );
         }
       }
@@ -104,9 +106,8 @@ const switchSizeStyle = ({ size }: Pick<SwitchProps, 'size'>) => {
     case 'medium':
       return css`
         border-radius: 100px;
-        width: 52px;
-        padding: 4px;
 
+        --wds-switch-width: 52px;
         --wds-switch-padding: 4px;
         --wds-switch-thumb-size: 24px;
       `;
@@ -114,8 +115,8 @@ const switchSizeStyle = ({ size }: Pick<SwitchProps, 'size'>) => {
     case 'small':
       return css`
         border-radius: 75px;
-        width: 39px;
 
+        --wds-switch-width: 39px;
         --wds-switch-padding: 3px;
         --wds-switch-thumb-size: 18px;
       `;


### PR DESCRIPTION

https://github.com/user-attachments/assets/28c2b391-c8fc-40d9-a528-6ec9b9cb77df

Some parts may appear broken when using a custom switch size.
Need to modify it to customize it through a css variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The switch knob now includes semantic data attributes to indicate its role, checked, and disabled state, improving accessibility and state awareness.

* **Style**
  * Switch component styling now uses CSS custom properties for padding and thumb size, resulting in smoother transitions and a more interactive visual effect when toggling or hovering over the switch.
  * The switch color changes dynamically when toggled, enhancing visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->