### PR TITLE
feat(wds): add aria label to modal close button

### DIFF
--- a/docs/src/docs/components/modal.mdx
+++ b/docs/src/docs/components/modal.mdx
@@ -32,10 +32,7 @@ description: Modal Component
 
 const Demo = () => {
   return (
-    <Modal
-      open={show}
-      onOpenChange={setShow}
-    >
+    <Modal>
       <ModalTrigger>
         <Button>열기</Button>
       </ModalTrigger>
@@ -151,8 +148,7 @@ Modal 은 여러 컴포넌트를 조합해서 사용합니다.
 
 `variant="bottom"` 일 때 드래그로 숨기고 열 수 있는 옵션을 사용할 수 있습니다.
 
-<Demo code={`import { useState } from 'react';
-import {
+<Demo code={`import {
   Button,
   Modal,
   ActionArea,
@@ -167,37 +163,32 @@ import {
 } from '@wanteddev/wds';
 
 const Demo = () => {
-  const [show, setShow] = useState(false);
-
   return (
-    <>
-      <Modal
-        open={show}
-        onOpenChange={setShow}
-      >
-        <ModalContainer variant="bottom" handle>
-          <ModalNavigation>
-            제목
-          </ModalNavigation>
+    <Modal>
+      <ModalTrigger>
+        <Button>Click me</Button>
+      </ModalTrigger>
 
-          <ModalContent>
-            <ModalContentItem>
-              <ModalHeading>Heading</ModalHeading>
-              <ModalSummary>Summary</ModalSummary>
-              <ModalDescription>Description</ModalDescription>
-            </ModalContentItem>
-          </ModalContent>
+      <ModalContainer variant="bottom" handle>
+        <ModalNavigation>
+          제목
+        </ModalNavigation>
 
-          <ActionArea>
-            <ActionAreaButton>
-              액션
-            </ActionAreaButton>
-          </ActionArea>
-        </ModalContainer>
-      </Modal>
+        <ModalContent>
+          <ModalContentItem>
+            <ModalHeading>Heading</ModalHeading>
+            <ModalSummary>Summary</ModalSummary>
+            <ModalDescription>Description</ModalDescription>
+          </ModalContentItem>
+        </ModalContent>
 
-      <Button onClick={() => setShow(true)}>Click me</Button>
-    </>
+        <ActionArea>
+          <ActionAreaButton>
+            액션
+          </ActionAreaButton>
+        </ActionArea>
+      </ModalContainer>
+    </Modal>
   )
 }
 

--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -590,6 +590,7 @@ const ModalClose = forwardRef(
 
     return (
       <TopNavigationButton
+        aria-label="Close dialog"
         {...props}
         background={background}
         onClick={composeEventHandlers(props.onClick, () => onOpenChange(false))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified modal usage examples to use internal state with a trigger button, making demos easier to follow.

* **Accessibility**
  * Added an accessible label to the modal close button to improve screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->