### PR TITLE
feat(wds): improve accessibility of snackbar and toast aria-live

### DIFF
--- a/packages/wds/src/components/snackbar/index.tsx
+++ b/packages/wds/src/components/snackbar/index.tsx
@@ -60,6 +60,7 @@ const Snackbar = forwardRef(
       disablePortal,
       forceMount = false,
       disableAnimation,
+      as,
       ...props
     }: PolymorphicPropsInternal<SnackbarProps, T>,
     forwardedRef: ForwardedRef<T>,
@@ -88,7 +89,7 @@ const Snackbar = forwardRef(
     }, [durationProp]);
 
     const {
-      ref,
+      ref: containerRef,
       handleAnimationEnd,
       handleMouseEnter,
       handleMouseLeave,
@@ -113,7 +114,13 @@ const Snackbar = forwardRef(
           }
         >
           <Box
+            aria-atomic
+            role="status"
+            aria-live="polite"
+            aria-describedby={descriptionId}
+            aria-labelledby={headingId}
             {...props}
+            as={(as ?? 'div') as ElementType}
             ref={forwardedRef}
             onMouseEnter={composeEventHandlers(
               props.onMouseEnter,
@@ -123,21 +130,20 @@ const Snackbar = forwardRef(
               props.onMouseLeave,
               handleMouseLeave,
             )}
+            onKeyDown={composeEventHandlers(
+              props.onKeyDown,
+              (e: KeyboardEvent) => {
+                if (e.key === 'Escape') {
+                  setOpen(false);
+                }
+              },
+            )}
             data-status={open ? 'open' : 'close'}
             onAnimationEnd={handleAnimationEnd}
             style={{ ...style, ...props.style }}
             sx={[wrapperStyle({ disableAnimation }), props.sx]}
           >
-            <Box
-              ref={ref}
-              aria-atomic
-              role="status"
-              aria-live="polite"
-              sx={snackbarStyle}
-              aria-describedby={descriptionId}
-              aria-labelledby={headingId}
-              data-role="snackbar"
-            >
+            <Box ref={containerRef} sx={snackbarStyle} data-role="snackbar">
               <Box role="presentation" sx={firstOverlayStyle} />
               <Box role="presentation" sx={secondOverlayStyle} />
               <FlexBox

--- a/packages/wds/src/components/toast/index.tsx
+++ b/packages/wds/src/components/toast/index.tsx
@@ -54,6 +54,7 @@ const Toast = forwardRef(
       disablePortal,
       disableAnimation,
       forceMount,
+      as,
       ...props
     }: PolymorphicPropsInternal<ToastProps, T>,
     forwardedRef: ForwardedRef<T>,
@@ -95,6 +96,20 @@ const Toast = forwardRef(
       component: 'toast',
     });
 
+    const ariaAttributes = useMemo(() => {
+      if (variant === 'negative') {
+        return {
+          role: 'alert',
+          'aria-live': 'assertive',
+        };
+      }
+
+      return {
+        role: variant === 'cautionary' ? 'alert' : 'status',
+        'aria-live': 'polite',
+      };
+    }, [variant]);
+
     return (
       <AnimationPresence present={open || forceMount}>
         <PortalOrFragment
@@ -106,8 +121,12 @@ const Toast = forwardRef(
           }
         >
           <Box
-            {...props}
+            aria-atomic
+            {...ariaAttributes}
+            aria-describedby={contentId}
             ref={forwardedRef}
+            {...props}
+            as={(as ?? 'div') as ElementType}
             onMouseEnter={composeEventHandlers(
               props.onMouseEnter,
               handleMouseEnter,
@@ -121,15 +140,7 @@ const Toast = forwardRef(
             style={{ ...style, ...props.style }}
             sx={[wrapperStyle({ disableAnimation }), props.sx]}
           >
-            <Box
-              ref={ref}
-              aria-atomic
-              role={variant === 'negative' ? 'alert' : 'status'}
-              aria-live={variant === 'negative' ? 'assertive' : 'polite'}
-              sx={toastStyle}
-              aria-describedby={contentId}
-              data-role="toast"
-            >
+            <Box ref={ref} sx={toastStyle} data-role="toast">
               <Box role="presentation" sx={firstOverlayStyle} />
               <Box role="presentation" sx={secondOverlayStyle} />
               <ToastProvider contentId={contentId} variant={variant}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a polymorphic "as" prop to both Snackbar and Toast components, allowing customization of the root element.

* **Accessibility**
  * Improved accessibility by reorganizing ARIA attributes and live region roles for both components.
  * Added keyboard interaction to Snackbar, enabling closure with the Escape key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->