### PR TITLE
fix(wds): incorrect z-index of action area within modal

### DIFF
--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -123,6 +123,7 @@ export const modalContainerStyle =
 
     [wds-component='action-area'] {
       position: sticky;
+      z-index: 5;
       bottom: 0;
       left: 0;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the stacking order of the action area in modals to ensure it aligns with the top navigation layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->