### PR TITLE
fix(wds): slider thumb border to outer border

### DIFF
--- a/packages/wds/src/components/slider/index.tsx
+++ b/packages/wds/src/components/slider/index.tsx
@@ -25,7 +25,6 @@ import {
   sliderProgressStyle,
   sliderProgressWrapperStyle,
   sliderThumbInteractionStyle,
-  sliderThumbKnobStyle,
   sliderThumbStyle,
 } from './style';
 
@@ -385,6 +384,7 @@ const SliderThumb = ({
           left: convertValueToPercentage(value, min, max) + '%',
           transform: `translateX(${convertValueToPercentage(value, min, max) * -1}%)`,
         }}
+        data-role="slider-thumb"
         sx={sliderThumbStyle}
         {...props}
         onPointerDown={composeEventHandlers(props.onPointerDown, () => {
@@ -395,11 +395,6 @@ const SliderThumb = ({
           data-role="slider-thumb-interaction"
           as="span"
           sx={sliderThumbInteractionStyle}
-        />
-        <Box
-          data-role="slider-thumb-knob"
-          as="span"
-          sx={sliderThumbKnobStyle}
         />
 
         {isFormControl && (

--- a/packages/wds/src/components/slider/style.ts
+++ b/packages/wds/src/components/slider/style.ts
@@ -54,6 +54,8 @@ export const sliderThumbStyle = (theme: Theme) => css`
   height: 20px;
   border-radius: 9999px;
   position: absolute;
+  background-color: ${theme.semantic.primary.normal};
+  box-shadow: 0 0 0 2px ${theme.semantic.background.normal.normal};
   top: 0px;
   display: block;
   cursor: pointer;
@@ -61,15 +63,17 @@ export const sliderThumbStyle = (theme: Theme) => css`
   &[aria-disabled='true'] {
     pointer-events: none;
     cursor: initial;
+    background-color: ${theme.semantic.interaction.disable};
 
-    [data-role='slider-thumb-knob'] {
-      background-color: ${theme.semantic.interaction.disable};
+    & > [data-role='slider-thumb-interaction'] {
+      opacity: 0;
     }
   }
 
   &:hover [data-role='slider-thumb-interaction'] {
     opacity: 0.075;
   }
+
   &:focus,
   &:focus-visible {
     outline: none;
@@ -95,14 +99,4 @@ export const sliderThumbInteractionStyle = (theme: Theme) => css`
   border-radius: inherit;
   display: inline-block;
   transition: opacity 0.15s ease;
-`;
-
-export const sliderThumbKnobStyle = (theme: Theme) => css`
-  background-color: ${theme.semantic.primary.normal};
-  border: 2px solid ${theme.semantic.background.normal.normal};
-  border-radius: inherit;
-  width: 100%;
-  height: 100%;
-  display: inline-block;
-  position: relative;
 `;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 슬라이더 썸(thumb)의 배경색과 그림자 스타일이 개선되었습니다.
  * 비활성화 상태에서 썸의 시각적 표현이 변경되었습니다.
  * 썸 내부의 불필요한 시각적 요소가 제거되어 더 깔끔한 디자인을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->