### PR TITLE
fix(wds): when pinch zoomed slider pointer move not working in safari

### DIFF
--- a/packages/wds/src/components/slider/index.tsx
+++ b/packages/wds/src/components/slider/index.tsx
@@ -231,7 +231,11 @@ const Slider = forwardRef<
             target.setPointerCapture(event.pointerId);
             event.preventDefault();
 
-            if (thumbRefs.current.has(target)) {
+            const closestThumb = target.closest<HTMLSpanElement>(
+              '[data-role="slider-thumb"]',
+            );
+
+            if (closestThumb && thumbRefs.current.has(closestThumb)) {
               target.focus();
             } else {
               const newValue = getValueFromPointer(event.clientX);
@@ -263,6 +267,7 @@ const Slider = forwardRef<
                 slideStartValues.current[currentFocusedIndex.current];
               const nextValue = values[currentFocusedIndex.current];
               const hasChanged = nextValue !== prevValue;
+              rect.current = undefined;
 
               if (hasChanged) {
                 onValueChangeComplete?.(values);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 슬라이더에서 손잡이(thumb) 내부의 자식 요소를 클릭해도 올바르게 손잡이로 인식되도록 포인터 이벤트 처리가 개선되었습니다.
  * 포인터 해제 시 슬라이더의 위치 계산을 위한 캐시가 적절히 초기화되어, 다음 상호작용에서 정확한 위치가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->