### PR TITLE
feat(wds): text area use trailing content instead of invalid icon

### DIFF
--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -259,17 +259,16 @@ const TextArea = forwardRef<
                 alignItems="center"
                 data-role="text-area-bottom-area-trailing-content"
               >
-                {invalid ? (
-                  <TextAreaContent
-                    data-role="text-area-invalid"
-                    sx={invalidIconWrapperStyle}
-                    variant="icon"
-                  >
-                    <IconCircleExclamationFill />
-                  </TextAreaContent>
-                ) : (
-                  trailingContent
-                )}
+                {trailingContent ||
+                  (invalid && (
+                    <TextAreaContent
+                      data-role="text-area-invalid"
+                      sx={invalidIconWrapperStyle}
+                      variant="icon"
+                    >
+                      <IconCircleExclamationFill />
+                    </TextAreaContent>
+                  ))}
               </FlexBox>
             </FlexBox>
           )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display logic for the text area’s trailing content and invalid icon, ensuring that custom trailing content is shown first if available, with the invalid icon appearing only when no trailing content is present and the input is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->