### PR TITLE
fix(wds): in popover add interface for dismissable layer

### DIFF
--- a/packages/wds/src/components/menu/types.ts
+++ b/packages/wds/src/components/menu/types.ts
@@ -31,6 +31,11 @@ export type MenuContentProps = Pick<
   | 'setContext'
   | 'wrapperProps'
   | 'forceMount'
+  | 'onInteractOutside'
+  | 'onFocusOutside'
+  | 'onPointerDownOutside'
+  | 'onDismiss'
+  | 'disableOutsidePointerEvents'
 >;
 
 export type MenuGroupDefaultProps = {

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -131,6 +131,11 @@ const PopoverContent = forwardRef(
       wrapperProps,
       forceMount = false,
       as,
+      onInteractOutside,
+      onFocusOutside,
+      onPointerDownOutside,
+      onDismiss,
+      disableOutsidePointerEvents = true,
       __scopePopover = 'Popover',
       ...props
     }: PolymorphicProps<ScopedProps<PopoverContentProps, 'Popover'>, T>,
@@ -166,9 +171,13 @@ const PopoverContent = forwardRef(
           >
             <DismissableLayer
               asChild
-              disableOutsidePointerEvents
+              disableOutsidePointerEvents={disableOutsidePointerEvents}
+              onInteractOutside={onInteractOutside}
+              onFocusOutside={onFocusOutside}
+              onPointerDownOutside={onPointerDownOutside}
               onDismiss={() => {
                 onOpenChange(false);
+                onDismiss?.();
               }}
             >
               <Box

--- a/packages/wds/src/components/popover/types.ts
+++ b/packages/wds/src/components/popover/types.ts
@@ -1,3 +1,4 @@
+import type { DismissableLayerProps } from '@radix-ui/react-dismissable-layer';
 import type { FocusScopeProps } from '../focus-scope/types';
 import type { ReactNode } from 'react';
 import type { PopperContentProps } from '../popper/types';
@@ -39,4 +40,12 @@ export type PopoverContentProps = {
   | 'onUnmountAutoFocus'
   | 'trapped'
   | 'loop'
->;
+> &
+  Pick<
+    DismissableLayerProps,
+    | 'onInteractOutside'
+    | 'onFocusOutside'
+    | 'onPointerDownOutside'
+    | 'onDismiss'
+    | 'disableOutsidePointerEvents'
+  >;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메뉴 및 팝오버 컴포넌트에 외부 상호작용 및 닫힘 이벤트에 대한 세밀한 제어 기능이 추가되었습니다. 이제 외부 클릭, 포커스, 포인터 다운, 닫힘 이벤트에 대한 콜백과 외부 포인터 이벤트 비활성화 옵션을 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->