### PR TITLE
fix(wds): card platform 모바일에서 card-caption typographyStyle 원복

### DIFF
--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -97,6 +97,9 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
         [wds-component='card-title'] {
           ${typographyStyle('body2', 'bold')}
         }
+        [wds-component='card-caption'] {
+          ${typographyStyle('label2', 'medium')}
+        }
       `;
   }
 };


### PR DESCRIPTION
## 작업 내용

오랜만에 PR 올립니닷.. 🙇‍♀️

- Card platform="mobile" 에서 CardCaption 타이포스타일이 누락된 거 같아 추가했어요. 확인 부탁드립니다.

## as-is
<img width="931" height="434" alt="스크린샷 2025-08-18 오후 11 38 50" src="https://github.com/user-attachments/assets/f0d49ceb-fe67-4ccc-aff6-77df8d464a0d" />


## to-be
<img width="931" height="434" alt="스크린샷 2025-08-18 오후 11 38 34" src="https://github.com/user-attachments/assets/7b52c3d1-5536-4c73-a973-bec155abc17c" />

## 관련 이슈

https://wantedlab.atlassian.net/browse/PI-77750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 모바일 카드 컴포넌트의 캡션 타이포그래피를 조정하여 데스크톱과 일관성을 확보했습니다.
  - 가독성과 시각적 균형이 개선되어 작은 화면에서 텍스트가 더 명확하게 보입니다.
  - 기능 동작이나 공개 API에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->