### PR TITLE
fix(wds): fixed modal pointerdownoutside not working, also export focus scope

### DIFF
--- a/packages/wds/src/components/dialog/index.tsx
+++ b/packages/wds/src/components/dialog/index.tsx
@@ -132,7 +132,6 @@ const Dialog = forwardRef(
                     if (isRightClick || disableEscapeKeyDownClose)
                       e.preventDefault();
                   }}
-                  onFocusOutside={(e) => e.preventDefault()}
                   onDismiss={() => {
                     onDismiss?.();
                     setOpen(false);

--- a/packages/wds/src/components/index.ts
+++ b/packages/wds/src/components/index.ts
@@ -24,6 +24,7 @@ export { default as Divider } from './divider';
 export * from './empty-state';
 export { default as FlexBox } from './flex-box';
 export * from './form';
+export { default as FocusScope } from './focus-scope';
 export { default as Grid } from './grid';
 export { default as GridItem } from './grid-item';
 export { default as IconButton } from './icon-button';

--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -57,10 +57,7 @@ import {
 import { useDraggable } from './hooks';
 import { getDefaultCloseIcon } from './helpers';
 
-import type {
-  FocusOutsideEvent,
-  PointerDownOutsideEvent,
-} from '../dismissable-layer/types';
+import type { PointerDownOutsideEvent } from '../dismissable-layer/types';
 import type { TopNavigationButtonProps } from '../top-navigation/types';
 import type {
   DefaultComponentProps,
@@ -194,6 +191,7 @@ const ModalContainer = forwardRef(
     const {
       containerRef,
       disableEscapeKeyDownClose,
+      disableOutsideClickClose,
       onOpenChange,
       ...context
     } = useModalContext(MODAL_CONTAINER_NAME);
@@ -285,12 +283,18 @@ const ModalContainer = forwardRef(
         >
           <DismissableLayer
             asChild
-            onPointerDownOutside={useCallback((e: PointerDownOutsideEvent) => {
-              e.preventDefault();
-            }, [])}
-            onFocusOutside={useCallback(
-              (e: FocusOutsideEvent) => e.preventDefault(),
-              [],
+            onPointerDownOutside={useCallback(
+              (e: PointerDownOutsideEvent) => {
+                const originalEvent = e.detail.originalEvent;
+                const ctrlLeftClick =
+                  originalEvent.button === 0 && originalEvent.ctrlKey === true;
+                const isRightClick =
+                  originalEvent.button === 2 || ctrlLeftClick;
+
+                if (isRightClick || disableOutsideClickClose)
+                  e.preventDefault();
+              },
+              [disableOutsideClickClose],
             )}
             onEscapeKeyDown={useCallback(
               (e: KeyboardEvent) => {
@@ -415,6 +419,7 @@ const ModalDimmer = forwardRef(
         data-visibility={isBottomSheetWithHandle ? visibility : undefined}
         as={as || 'div'}
         {...props}
+        wds-ignore-dismissable-layer="true"
         ref={useComposedRefs(ref, dimmerRef as ForwardedRef<T>)}
         onPointerDown={composeEventHandlers(
           props.onPointerDown,
@@ -427,14 +432,10 @@ const ModalDimmer = forwardRef(
           },
         )}
         onClick={composeEventHandlers(props.onClick, (e: MouseEvent) => {
-          const ctrlLeftClick = e.button === 0 && e.ctrlKey === true;
-          const isRightClick = e.button === 2 || ctrlLeftClick;
-
-          if (isRightClick || disableOutsideClickClose) {
+          e.preventDefault();
+          if (disableOutsideClickClose) {
             return;
           }
-
-          e.preventDefault();
 
           if (!isBottomSheetWithHandle) {
             onOpenChange(false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 모달에서 바깥 클릭으로 닫힘을 비활성화할 수 있는 옵션 추가.
  - FocusScope 컴포넌트를 공개적으로 사용할 수 있도록 제공.

- Bug Fixes
  - 모달에서 오른쪽 클릭(또는 Ctrl+좌클릭)이 의도치 않게 닫히지 않도록 수정.
  - 딤머 클릭 동작을 개선하여 바텀시트 등 구성에 맞게 안정적으로 닫히도록 처리.
  - Dialog의 포커스 처리 개선: 외부 포커스 시 불필요한 차단이 발생하지 않도록 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->