### PR TITLE
feat(wds,wds-codemod)!: list cell active to selected

### DIFF
--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -106,9 +106,9 @@ const Demo = () => {
 export default Demo;`}
 />
 
-### Active, Disabled
+### Selected, Disabled
 
-active, disabled, disableInteraction 으로 상태를 표시해요.
+selected, disabled, disableInteraction 으로 상태를 표시해요.
 
 <Demo code={`import { List, ListCell } from '@wanteddev/wds';
 
@@ -121,8 +121,8 @@ const Demo = () => {
       <ListCell disableInteraction>
         텍스트, disableInteraction
       </ListCell>
-      <ListCell active>
-        텍스트, active
+      <ListCell selected>
+        텍스트, selected
       </ListCell>
       <ListCell disabled>
         텍스트, disabled

--- a/packages/wds-codemod/src/constants.ts
+++ b/packages/wds-codemod/src/constants.ts
@@ -24,5 +24,6 @@ export const MIGRATION_TRANSFORMS = {
     'empty-state-to-fallback-view': 'Empty State to Fallback View',
     'dialog-button-migration': 'Dialog Button to Dialog Action Area Button',
     'stepper-migration': 'Progress Tracker to Stepper',
+    'list-cell-active-to-selected': 'List Cell Active to Selected',
   },
 };

--- a/packages/wds-codemod/src/transforms/v3/list-cell-active-to-selected.ts
+++ b/packages/wds-codemod/src/transforms/v3/list-cell-active-to-selected.ts
@@ -1,0 +1,50 @@
+import { findImportDeclaration } from '../../helpers';
+
+import type { API, FileInfo, JSXAttribute, Options } from 'jscodeshift';
+
+const transformer = (file: FileInfo, api: API, options: Options) => {
+  const j = api.jscodeshift.withParser('tsx');
+  const root = j(file.source);
+  let hasChanges = false;
+
+  const wdsImport = root.find(j.ImportDeclaration, {
+    source: { value: '@wanteddev/wds' },
+  });
+
+  if (wdsImport.length < 1) {
+    return file.source;
+  }
+
+  const targetImports = [
+    findImportDeclaration('ListCell', '@wanteddev/wds', j, root),
+    findImportDeclaration('MenuItem', '@wanteddev/wds', j, root),
+    findImportDeclaration('AutocompleteOption', '@wanteddev/wds', j, root),
+    findImportDeclaration('Option', '@wanteddev/wds', j, root),
+  ];
+
+  for (const targetImport of targetImports) {
+    if (!targetImport) continue;
+
+    root
+      .find(j.JSXOpeningElement, {
+        name: { name: targetImport.imported.name },
+      })
+      .forEach((target) => {
+        const activeAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'active',
+        );
+
+        if (activeAttribute) {
+          hasChanges = true;
+
+          activeAttribute.name.name = 'selected';
+        }
+      });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return hasChanges ? root.toSource(options) : file.source;
+};
+
+export default transformer;

--- a/packages/wds/src/components/accordion/types.ts
+++ b/packages/wds/src/components/accordion/types.ts
@@ -12,7 +12,7 @@ export type AccordionProps = WithSxProps<{
   disableAnimation?: boolean;
 }>;
 
-export type AccordionSummaryProps = ListCellProps;
+export type AccordionSummaryProps = Omit<ListCellProps, 'selected'>;
 
 export type AccordionSummaryContentProps = Merge<
   {

--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -613,10 +613,11 @@ const AutocompleteOption = forwardRef<
         ref={composedRefs}
         disabled={disabled}
         aria-disabled={disabled}
-        active={active}
+        selected={active}
         role="option"
         id={id}
         aria-selected={active}
+        aria-current={undefined}
         {...props}
         sx={[autocompleteOptionStyle, props.sx]}
         onTouchStart={composeEventHandlers(props.onTouchStart, (e) => {

--- a/packages/wds/src/components/list/contexts.ts
+++ b/packages/wds/src/components/list/contexts.ts
@@ -5,7 +5,7 @@ import { LIST_CELL_NAME } from './constants';
 import type { ListCellProps } from './types';
 
 type ListCellContextType = Required<
-  Pick<ListCellProps, 'active' | 'disabled' | 'ellipsis' | 'alignItems'>
+  Pick<ListCellProps, 'selected' | 'disabled' | 'ellipsis' | 'alignItems'>
 > & {
   textId: string;
   captionId: string;

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -80,7 +80,7 @@ const ListCell = forwardRef(
       interactionPadding = fillWidth ? undefined : '12px',
       alignItems = 'flex-start',
 
-      active = false,
+      selected = false,
       disabled = false,
       disableInteraction = false,
 
@@ -113,7 +113,7 @@ const ListCell = forwardRef(
 
     return (
       <ListCellProvider
-        active={active}
+        selected={selected}
         disabled={disabled}
         ellipsis={ellipsis}
         alignItems={alignItems}
@@ -136,6 +136,7 @@ const ListCell = forwardRef(
             tabIndex={clickable ? 0 : undefined}
             aria-labelledby={textId}
             aria-describedby={captionId}
+            aria-current={selected}
             {...props}
             onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
               if (
@@ -182,7 +183,7 @@ const ListCell = forwardRef(
                 verticalPadding,
                 fillWidth,
                 interactionPadding,
-                active,
+                selected,
                 disabled,
                 disableInteraction,
                 xl,
@@ -365,22 +366,22 @@ const ListText = forwardRef(
     }: PolymorphicPropsInternal<ListTextProps, T>,
     ref: ForwardedRef<T>,
   ) => {
-    const { active, disabled, ellipsis, textId, captionId } =
+    const { selected, disabled, ellipsis, textId, captionId } =
       useListCellContext(LIST_TEXT_NAME);
-    const { active: menuItemActive } = useMenuItemContext() || {};
+    const { selected: menuItemSelected } = useMenuItemContext() || {};
 
     if (!children) {
       return null;
     }
 
     const weight: TypographyWeight =
-      givenWeight ?? (active || menuItemActive ? 'medium' : 'regular');
+      givenWeight ?? (selected || menuItemSelected ? 'medium' : 'regular');
 
     const getTextColor = (): ThemeColorsToken => {
       if (disabled) {
         return 'semantic.label.alternative';
       }
-      if (active) {
+      if (selected) {
         return 'semantic.primary.normal';
       }
 

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -22,7 +22,7 @@ export const listCellStyle =
     verticalPadding,
     fillWidth,
     interactionPadding,
-    active,
+    selected,
     disabled,
     disableInteraction,
     xs,
@@ -46,7 +46,7 @@ export const listCellStyle =
           opacity: ${theme.opacity[43]};
         `
       : css`
-          color: ${active
+          color: ${selected
             ? theme.semantic.primary.normal
             : theme.semantic.label.normal};
 

--- a/packages/wds/src/components/list/types.ts
+++ b/packages/wds/src/components/list/types.ts
@@ -22,7 +22,11 @@ export type ListCellDefaultProps = WithSxProps<{
   ellipsis?: boolean;
   divider?: boolean;
 
-  active?: boolean;
+  /**
+   /**
+    * Used to indicate the selected style.
+    */
+  selected?: boolean;
   disabled?: boolean;
   disableInteraction?: boolean;
 

--- a/packages/wds/src/components/menu/contexts.ts
+++ b/packages/wds/src/components/menu/contexts.ts
@@ -15,7 +15,7 @@ export const [MenuProvider, useMenuContext] =
   createContext<MenuContextType>(MENU_NAME);
 
 type MenuItemContextType = {
-  active?: boolean;
+  selected?: boolean;
 };
 
 export const [MenuItemProvider, useMenuItemContext] =

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -244,7 +244,8 @@ const MenuItem = forwardRef<any, MenuItemProps>(
           disabled={disabled}
           role="menuitemradio"
           ref={ref}
-          active={normalActive}
+          selected={normalActive}
+          aria-current={undefined}
           aria-checked={normalActive}
           trailingContent={
             normalActive ? (
@@ -277,7 +278,7 @@ const MenuItem = forwardRef<any, MenuItemProps>(
 
     return (
       <MenuItemProvider
-        active={variant === 'normal' ? normalActive : undefined}
+        selected={variant === 'normal' ? normalActive : undefined}
       >
         <RovingFocusGroupItem
           asChild
@@ -319,6 +320,7 @@ const MenuItemRadio = forwardRef<any, MenuItemRadioProps>(
             <Radio tabIndex={-1} checked={checked} value={value} />
           </ListCellContent>
         }
+        aria-current={undefined}
         {...props}
         onClick={composeEventHandlers(props.onClick, (e) => {
           if (!e.defaultPrevented) {
@@ -365,6 +367,7 @@ const MenuItemCheckbox = forwardRef<any, MenuItemRadioProps>(
             />
           </ListCellContent>
         }
+        aria-current={undefined}
         {...props}
         onClick={composeEventHandlers(props.onClick, (e) => {
           if (!e.defaultPrevented) {

--- a/packages/wds/src/components/time-view/index.tsx
+++ b/packages/wds/src/components/time-view/index.tsx
@@ -340,9 +340,10 @@ const TimeItem = forwardRef<
           ref={ref}
           fillWidth
           verticalPadding="small"
-          active={active}
+          selected={active}
           value={value}
           role="option"
+          aria-current={undefined}
           aria-selected={active}
           aria-label={text}
           data-role={`time-item-${view}`}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed "Active" state to "Selected" across List, Menu, Autocomplete and related contexts/props; styling and typography now follow selected, and aria-current is driven by selected on list items.
* **Documentation**
  * Updated docs and examples from "Active, Disabled" to "Selected, Disabled."
* **Chores**
  * Added a codemod to migrate usages from active → selected.
* **Bug Fixes**
  * Improved accessibility by omitting aria-current on menu radio/checkbox items while preserving aria-selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->