### PR TITLE
feat(wds,wds-codemod)!: change variant of text button to color

### DIFF
--- a/docs/src/docs/components/accordion.mdx
+++ b/docs/src/docs/components/accordion.mdx
@@ -407,7 +407,7 @@ const Demo = () => {
         <AccordionContent>
           <TextButton
             size="small"
-            variant="assistive"
+            color="assistive"
             trailingContent={<IconExternalLink />}
           >
             자세히 알아보기

--- a/docs/src/docs/components/avatar-group.mdx
+++ b/docs/src/docs/components/avatar-group.mdx
@@ -40,7 +40,7 @@ export default Demo;`}
 
 const Demo = () => {
   return (
-    <AvatarGroup trailingContent={<TextButton variant="assistive" size="small">외 0명</TextButton>}>
+    <AvatarGroup trailingContent={<TextButton color="assistive" size="small">외 0명</TextButton>}>
       <Avatar src="https://static.wanted.co.kr/oneid-user/2kcR2ULXRgEC7Rgk5psLTK/BwWtS7ZW8ryS2dpQrAW8Cr.png" alt="User" />
       <Avatar src="https://static.wanted.co.kr/oneid-user/2kcR2ULXRgEC7Rgk5psLTK/BwWtS7ZW8ryS2dpQrAW8Cr.png" alt="User" />
       <Avatar src="https://static.wanted.co.kr/oneid-user/2kcR2ULXRgEC7Rgk5psLTK/BwWtS7ZW8ryS2dpQrAW8Cr.png" alt="User" />

--- a/docs/src/docs/components/list.mdx
+++ b/docs/src/docs/components/list.mdx
@@ -199,7 +199,7 @@ const Demo = () => {
       <ListCell
         trailingContent={
           <ListCellContent variant="button">
-            <TextButton size="small" variant="assistive">
+            <TextButton size="small" color="assistive">
               버튼
             </TextButton>
           </ListCellContent>

--- a/docs/src/docs/components/menu.mdx
+++ b/docs/src/docs/components/menu.mdx
@@ -367,7 +367,7 @@ const Demo = () => {
             leadingContent={
               <MenuActionAreaContent variant="text-button">
                 <TextButton
-                  variant="assistive"
+                  color="assistive"
                   size="small"
                   leadingContent={<IconRefresh />}
                 >

--- a/docs/src/docs/components/section-header.mdx
+++ b/docs/src/docs/components/section-header.mdx
@@ -13,7 +13,7 @@ description: SectionHeader Component
 <Demo code={`import { SectionHeader, TextButton } from '@wanteddev/wds';
 const Demo = () => {
   return (
-    <SectionHeader trailingContent={<TextButton variant="assistive">더보기</TextButton>}>
+    <SectionHeader trailingContent={<TextButton color="assistive">더보기</TextButton>}>
       최근 본 포지션
     </SectionHeader>
   )
@@ -99,7 +99,7 @@ const Demo = () => {
           </ChipFilter>
         }
         trailingContent={
-          <TextButton variant="assistive">
+          <TextButton color="assistive">
             더보기
           </TextButton>
         }

--- a/docs/src/docs/components/text-button.mdx
+++ b/docs/src/docs/components/text-button.mdx
@@ -29,15 +29,15 @@ export default Demo;`}
 
 <PropsTable component="TextButton" />
 
-## Variant
+## Color
 
 <Demo code={`import { FlexBox, TextButton } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
     <FlexBox gap="20px">
-      <TextButton variant="primary">텍스트</TextButton>
-      <TextButton variant="assistive">텍스트</TextButton>
+      <TextButton color="primary">텍스트</TextButton>
+      <TextButton color="assistive">텍스트</TextButton>
     </FlexBox>
   )
 }
@@ -72,12 +72,12 @@ const Demo = () => {
   return (
     <FlexBox gap="16px" flexDirection="column">
       <FlexBox gap="16px">
-        <TextButton variant="primary" loading={loading} size="medium">텍스트</TextButton>
-        <TextButton variant="assistive" loading={loading} size="medium">텍스트</TextButton>
+        <TextButton color="primary" loading={loading} size="medium">텍스트</TextButton>
+        <TextButton color="assistive" loading={loading} size="medium">텍스트</TextButton>
       </FlexBox>
       <FlexBox gap="16px">
-        <TextButton variant="primary" loading={loading} size="small">텍스트</TextButton>
-        <TextButton variant="assistive" loading={loading} size="small">텍스트</TextButton>
+        <TextButton color="primary" loading={loading} size="small">텍스트</TextButton>
+        <TextButton color="assistive" loading={loading} size="small">텍스트</TextButton>
       </FlexBox>
     </FlexBox>
   )

--- a/packages/wds-codemod/src/constants.ts
+++ b/packages/wds-codemod/src/constants.ts
@@ -25,5 +25,6 @@ export const MIGRATION_TRANSFORMS = {
     'dialog-to-alert': 'Dialog to Alert',
     'stepper-migration': 'Progress Tracker to Stepper',
     'list-cell-active-to-selected': 'List Cell Active to Selected',
+    'text-button-variant-to-color': 'TextButton Variant to Color',
   },
 };

--- a/packages/wds-codemod/src/transforms/v2/list-cell-migration.ts
+++ b/packages/wds-codemod/src/transforms/v2/list-cell-migration.ts
@@ -54,7 +54,7 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
       j(listItemImport)
         .find(j.ImportSpecifier, {
           imported: {
-            name: listItemImport.imported.name,
+            name: getLocalName(listItemImport),
           },
         })
         .remove();

--- a/packages/wds-codemod/src/transforms/v2/list-cell-migration.ts
+++ b/packages/wds-codemod/src/transforms/v2/list-cell-migration.ts
@@ -54,7 +54,7 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
       j(listItemImport)
         .find(j.ImportSpecifier, {
           imported: {
-            name: getLocalName(listItemImport),
+            name: listItemImport.imported.name,
           },
         })
         .remove();

--- a/packages/wds-codemod/src/transforms/v3/text-button-variant-to-color.ts
+++ b/packages/wds-codemod/src/transforms/v3/text-button-variant-to-color.ts
@@ -1,0 +1,100 @@
+import { findImportDeclaration, getLocalName } from '../../helpers';
+
+import type { API, FileInfo, JSXAttribute, Options } from 'jscodeshift';
+
+const transformer = (file: FileInfo, api: API, options: Options) => {
+  const j = api.jscodeshift.withParser('tsx');
+  const root = j(file.source);
+  let hasChanges = false;
+
+  const wdsImport = root.find(j.ImportDeclaration, {
+    source: { value: '@wanteddev/wds' },
+  });
+
+  if (wdsImport.length < 1) {
+    return file.source;
+  }
+
+  const textButtonImport = findImportDeclaration(
+    'TextButton',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (textButtonImport) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: { name: getLocalName(textButtonImport) },
+      })
+      .forEach((target) => {
+        const variantAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'variant',
+        );
+
+        if (variantAttribute) {
+          hasChanges = true;
+
+          variantAttribute.name.name = 'color';
+        }
+      });
+  }
+
+  const pickerActionAreaButtonImport = findImportDeclaration(
+    'PickerActionAreaButton',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (pickerActionAreaButtonImport) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: { name: getLocalName(pickerActionAreaButtonImport) },
+      })
+      .forEach((target) => {
+        const variantAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'buttonVariant',
+        );
+
+        if (variantAttribute) {
+          hasChanges = true;
+
+          variantAttribute.name.name = 'color';
+        }
+      });
+  }
+
+  const actionAreaButtonImport = findImportDeclaration(
+    'ActionAreaButton',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (actionAreaButtonImport) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: { name: getLocalName(actionAreaButtonImport) },
+      })
+      .forEach((target) => {
+        const variantAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'textButtonVariant',
+        );
+
+        if (variantAttribute) {
+          hasChanges = true;
+
+          variantAttribute.name.name = 'textButtonColor';
+        }
+      });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return hasChanges ? root.toSource(options) : file.source;
+};
+
+export default transformer;

--- a/packages/wds/src/components/action-area/index.tsx
+++ b/packages/wds/src/components/action-area/index.tsx
@@ -125,7 +125,7 @@ const ActionAreaButton = forwardRef(
   <T extends ElementType = 'button'>(
     {
       variant = 'main',
-      textButtonVariant,
+      textButtonColor,
       buttonVariant,
       buttonColor,
       ...props
@@ -170,7 +170,7 @@ const ActionAreaButton = forwardRef(
         parentVariant === 'strong' ? (
           <TextButton
             ref={ref}
-            variant={textButtonVariant ?? 'assistive'}
+            color={textButtonColor ?? 'assistive'}
             size="small"
             {...props}
             sx={[

--- a/packages/wds/src/components/action-area/types.ts
+++ b/packages/wds/src/components/action-area/types.ts
@@ -35,9 +35,9 @@ export type ActionButtonProps = WithSxProps<{
   iconOnly?: boolean;
   disabled?: boolean;
   /**
-   * When overriding the variant of the `TextButton`.
+   * When overriding the color of the `TextButton`.
    */
-  textButtonVariant?: TextButtonProps['variant'];
+  textButtonColor?: TextButtonProps['color'];
   /**
    * When overriding the variant of the `Button`.
    */

--- a/packages/wds/src/components/alert/index.tsx
+++ b/packages/wds/src/components/alert/index.tsx
@@ -379,7 +379,7 @@ const AlertActionAreaButton = forwardRef(
     return (
       <TextButton
         size="medium"
-        variant={variant === 'normal' ? 'primary' : 'assistive'}
+        color={variant === 'normal' ? 'primary' : 'assistive'}
         ref={ref}
         {...props}
         onClick={composeEventHandlers(props.onClick, () => {

--- a/packages/wds/src/components/alert/types.ts
+++ b/packages/wds/src/components/alert/types.ts
@@ -50,5 +50,5 @@ export type AlertActionAreaButtonProps = Merge<
   {
     variant?: 'normal' | 'assistive' | 'negative';
   },
-  Omit<TextButtonProps, 'color'>
+  Omit<TextButtonProps, 'color' | 'variant'>
 >;

--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -633,7 +633,7 @@ const AutocompleteOption = forwardRef<
           );
           setAttributeSelection(ref.current, items, true);
         })}
-        onMouseMove={composeEventHandlers(props.onMouseEnter, (e) => {
+        onMouseEnter={composeEventHandlers(props.onMouseEnter, (e) => {
           if (disabled) return;
 
           const items = getItems();

--- a/packages/wds/src/components/date-calendar/index.tsx
+++ b/packages/wds/src/components/date-calendar/index.tsx
@@ -238,7 +238,7 @@ const DateCalendar = forwardRef<
                           }
                         });
                       }}
-                      variant="assistive"
+                      color="assistive"
                       size="medium"
                       aria-expanded={headerExpanded}
                       sx={[

--- a/packages/wds/src/components/pagination/index.tsx
+++ b/packages/wds/src/components/pagination/index.tsx
@@ -226,7 +226,7 @@ const PaginationItem = ({
       {type === 'page' ? (
         <TextButton
           size="medium"
-          variant="assistive"
+          color="assistive"
           disabled={disabled}
           disableInteraction={disabled}
           aria-label={`Page ${itemPage}`}

--- a/packages/wds/src/components/picker-action-area/index.tsx
+++ b/packages/wds/src/components/picker-action-area/index.tsx
@@ -40,7 +40,6 @@ const PickerActionAreaButton = forwardRef(
   <T extends ElementType = 'button'>(
     {
       variant,
-      buttonVariant,
       ...props
     }: PolymorphicPropsInternal<PickerActionAreaButtonProps, T>,
     ref: ForwardedRef<T>,
@@ -53,7 +52,7 @@ const PickerActionAreaButton = forwardRef(
         return (
           <TextButton
             ref={ref}
-            variant={buttonVariant ?? 'assistive'}
+            color="assistive"
             size="small"
             {...props}
             onClick={composeEventHandlers(props.onClick, () => {
@@ -71,7 +70,7 @@ const PickerActionAreaButton = forwardRef(
         return (
           <TextButton
             ref={ref}
-            variant={buttonVariant ?? 'assistive'}
+            color="assistive"
             size="small"
             {...props}
             onClick={composeEventHandlers(props.onClick, () => {
@@ -89,7 +88,7 @@ const PickerActionAreaButton = forwardRef(
         return (
           <TextButton
             ref={ref}
-            variant={buttonVariant ?? 'assistive'}
+            color="assistive"
             size="small"
             {...props}
             onClick={composeEventHandlers(props.onClick, () => {
@@ -107,7 +106,7 @@ const PickerActionAreaButton = forwardRef(
         return (
           <TextButton
             ref={ref}
-            variant={buttonVariant ?? 'primary'}
+            color="primary"
             size="small"
             {...props}
             onClick={composeEventHandlers(props.onClick, () => {
@@ -125,7 +124,7 @@ const PickerActionAreaButton = forwardRef(
         return (
           <TextButton
             ref={ref}
-            variant={buttonVariant ?? 'assistive'}
+            color="assistive"
             size="small"
             {...props}
             sx={[

--- a/packages/wds/src/components/picker-action-area/types.ts
+++ b/packages/wds/src/components/picker-action-area/types.ts
@@ -7,7 +7,6 @@ export type PickerActionAreaProps = ActionAreaProps;
 export type PickerActionAreaButtonProps = Merge<
   {
     variant?: 'now' | 'cancel' | 'accept' | 'reset';
-    buttonVariant?: TextButtonProps['variant'];
   },
   TextButtonProps
 >;

--- a/packages/wds/src/components/snackbar/index.tsx
+++ b/packages/wds/src/components/snackbar/index.tsx
@@ -256,7 +256,7 @@ const SnackbarAction = forwardRef<
   return (
     <TextButton
       ref={ref}
-      variant="assistive"
+      color="assistive"
       size="medium"
       {...props}
       sx={[snackbarActionStyle, props.sx]}

--- a/packages/wds/src/components/text-button/contexts.ts
+++ b/packages/wds/src/components/text-button/contexts.ts
@@ -1,10 +1,10 @@
 import createLooseContext from '../../hooks/internal/use-loose-context';
 
 import type { ThemeColorsToken } from '@wanteddev/wds-engine';
-import type { TextButtonVariant } from './types';
+import type { TextButtonColor } from './types';
 
 type TextButtonContextValue = {
-  [key in TextButtonVariant]?: ThemeColorsToken;
+  [key in TextButtonColor]?: ThemeColorsToken;
 };
 
 /**

--- a/packages/wds/src/components/text-button/index.tsx
+++ b/packages/wds/src/components/text-button/index.tsx
@@ -22,7 +22,7 @@ const TextButton = forwardRef(
       as,
       disabled = false,
       disableInteraction = false,
-      variant = 'primary',
+      color = 'primary',
       leadingContent,
       trailingContent,
       size = 'medium',
@@ -42,13 +42,11 @@ const TextButton = forwardRef(
     const context = useTextButtonContext();
 
     const interactionColor: ThemeColorsToken =
-      variant === 'primary'
-        ? 'semantic.primary.normal'
-        : 'semantic.label.normal';
+      color === 'primary' ? 'semantic.primary.normal' : 'semantic.label.normal';
 
-    const color = useMemo(() => {
-      return context?.[variant];
-    }, [context, variant]);
+    const overrideColor = useMemo(() => {
+      return context?.[color];
+    }, [context, color]);
 
     const handlePreventEventsLoading = (e: SyntheticEvent) => {
       if (loading && !disableLoadingPreventEvents) {
@@ -61,13 +59,13 @@ const TextButton = forwardRef(
       <WithInteraction
         color={interactionColor}
         disabled={disableInteraction || disabled}
-        variant={variant === 'primary' ? 'strong' : 'light'}
+        variant={color === 'primary' ? 'strong' : 'light'}
         scale
       >
         <Box
           as={(as || 'button') as T}
           wds-component="text-button"
-          data-variant={variant}
+          data-color={color}
           aria-labelledby={id}
           ref={ref}
           type="button"
@@ -93,10 +91,10 @@ const TextButton = forwardRef(
           }, props.onKeyDown)}
           sx={[
             textButtonStyle({
-              color,
+              overrideColor,
               size,
               loading,
-              variant,
+              color,
               xs,
               sm,
               md,

--- a/packages/wds/src/components/text-button/style.ts
+++ b/packages/wds/src/components/text-button/style.ts
@@ -7,7 +7,7 @@ import type { Theme, ThemeColorsToken } from '@wanteddev/wds-engine';
 import type { TextButtonProps } from './types';
 
 type TextButtonStyleProps = TextButtonProps & {
-  color?: ThemeColorsToken;
+  overrideColor?: ThemeColorsToken;
 };
 
 export const textButtonStyle =
@@ -66,14 +66,14 @@ export const textButtonStyle =
   `;
 
 const getColorTheme = (
-  { variant, color }: TextButtonStyleProps,
+  { color, overrideColor }: TextButtonStyleProps,
   theme: Theme,
 ) => {
-  switch (variant) {
+  switch (color) {
     case 'primary':
       return css`
-        color: ${color
-          ? getColorByToken(theme, color)
+        color: ${overrideColor
+          ? getColorByToken(theme, overrideColor)
           : theme.semantic.primary.normal};
         background-color: transparent;
         border: none;
@@ -93,8 +93,8 @@ const getColorTheme = (
         background-color: transparent;
         border: none;
         box-shadow: none;
-        color: ${color
-          ? getColorByToken(theme, color)
+        color: ${overrideColor
+          ? getColorByToken(theme, overrideColor)
           : theme.semantic.label.alternative};
 
         [data-role='text-button-loading'] {

--- a/packages/wds/src/components/text-button/types.ts
+++ b/packages/wds/src/components/text-button/types.ts
@@ -5,10 +5,10 @@ import type {
 } from '@wanteddev/wds-engine';
 import type { ReactNode } from 'react';
 
-export type TextButtonVariant = 'primary' | 'assistive';
+export type TextButtonColor = 'primary' | 'assistive';
 
 export type TextButtonDefaultProps = WithSxProps<{
-  variant?: 'primary' | 'assistive';
+  color?: 'primary' | 'assistive';
   disabled?: boolean;
   size?: 'small' | 'medium';
   disableInteraction?: boolean;

--- a/packages/wds/src/components/top-navigation/index.tsx
+++ b/packages/wds/src/components/top-navigation/index.tsx
@@ -233,7 +233,7 @@ const TopNavigationButton = forwardRef(
 
     return (
       <TextButton
-        variant="assistive"
+        color="assistive"
         size="medium"
         {...props}
         sx={[topNavigationButtonTextStyle, props.sx]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed TextButton prop from variant to color across components.
  - Renamed/adjusted related props (e.g., textButtonVariant → textButtonColor; removed buttonVariant in PickerActionArea).
  - Updated internal styling paths to use color.
  - Changed Autocomplete hover handling from mouse move to mouse enter.

- Documentation
  - Updated all examples and the TextButton docs to use color="…" instead of variant="…".

- Chores
  - Added a codemod to automatically migrate usages from variant-based props to color-based equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->