### PR TITLE
fix(wds): modal을 2중으로 사용하는 경우 기존 모달이 닫히는 이슈

### DIFF
--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -252,6 +252,7 @@ const ModalContainer = forwardRef(
           isBottomSheetWithHandle ? context.visibility : undefined
         }
         {...wrapperProps}
+        wds-ignore-dismissable-layer="true"
         ref={useComposedRefs<HTMLDivElement>(
           wrapperProps?.ref as RefObject<HTMLDivElement> | undefined,
           context.wrapperRef,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 모달 컨테이너의 해제 레이어 처리 일관성을 개선하여, 다른 모달 구성 요소와 동일한 상호작용 동작을 보장합니다.
  * 특정 환경에서 발생할 수 있던 예기치 않은 닫힘 또는 포커스 이탈을 줄여 안정성을 향상했습니다.
  * 공개 API 변화 없이 동작만 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->