### PR TITLE
fix(wds): input 컴포넌트의 wrapper를 클릭시 모바일 키보드가 올라오지 않음

### DIFF
--- a/packages/wds/src/components/search-field/index.tsx
+++ b/packages/wds/src/components/search-field/index.tsx
@@ -1,7 +1,7 @@
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { Box, type DefaultComponentProps } from '@wanteddev/wds-engine';
 import { IconCircleCloseFill, IconSearch } from '@wanteddev/wds-icon';
-import { forwardRef, useRef } from 'react';
+import { forwardRef, useEffect, useRef } from 'react';
 
 import FlexBox from '../flex-box';
 import IconButton from '../icon-button';
@@ -18,6 +18,7 @@ const SearchField = forwardRef<
     {
       readOnly,
       className,
+      disabled,
       style,
       onReset,
       width,
@@ -33,18 +34,43 @@ const SearchField = forwardRef<
     },
     ref,
   ) => {
+    const parentRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const composedRefs = useComposedRefs(inputRef, ref);
+
+    useEffect(() => {
+      const container = parentRef.current;
+
+      if (!container || disabled) return;
+
+      const handleClick = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+
+        if (
+          target.closest('input, textarea, button, a') ||
+          target.getAttribute('data-role') === 'search-field-reset'
+        )
+          return;
+
+        inputRef.current?.click();
+        inputRef.current?.focus();
+      };
+
+      container.addEventListener('click', handleClick);
+
+      return () => container.removeEventListener('click', handleClick);
+    }, [disabled]);
 
     return (
       <Box
         className={className}
         style={style}
         wds-component="search-field"
-        ref={wrapperRef}
+        ref={useComposedRefs(parentRef, wrapperRef)}
         sx={[
           searchFieldWrapperStyle({
             readOnly,
+            disabled,
             size,
             width,
             xs,
@@ -56,23 +82,6 @@ const SearchField = forwardRef<
           }),
           sx,
         ]}
-        onClick={(event) => {
-          const target = event.target as HTMLElement;
-          if (target.closest('input, button, a')) return;
-
-          const input = inputRef.current;
-          if (
-            !input ||
-            target.tagName === 'INPUT' ||
-            target.getAttribute('data-role') === 'search-field-reset'
-          )
-            return;
-
-          requestAnimationFrame(() => {
-            input.focus();
-            input.click();
-          });
-        }}
       >
         <FlexBox
           data-role="search-field-icon"
@@ -91,6 +100,8 @@ const SearchField = forwardRef<
           readOnly={readOnly}
           aria-readonly={readOnly}
           autoComplete="off"
+          disabled={disabled}
+          aria-disabled={disabled}
           {...props}
         />
         <FlexBox

--- a/packages/wds/src/components/search-field/index.tsx
+++ b/packages/wds/src/components/search-field/index.tsx
@@ -47,8 +47,9 @@ const SearchField = forwardRef<
         const target = event.target as HTMLElement;
 
         if (
-          target.closest('input, textarea, button, a') ||
-          target.getAttribute('data-role') === 'search-field-reset'
+          target.closest(
+            'input, textarea, button, a, [data-role="search-field-reset"], [contenteditable]',
+          )
         )
           return;
 

--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -157,6 +157,25 @@ const TextArea = forwardRef<
       }
     }, [node, syncTextAreaHeight, setLength]);
 
+    useEffect(() => {
+      const container = parentRef.current;
+
+      if (!container || disabled) return;
+
+      const handleClick = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+
+        if (target.closest('input, textarea, button, a')) return;
+
+        textAreaRef.current?.click();
+        textAreaRef.current?.focus();
+      };
+
+      container.addEventListener('click', handleClick);
+
+      return () => container.removeEventListener('click', handleClick);
+    }, [disabled]);
+
     return (
       <TextAreaProvider length={length}>
         <FlexBox
@@ -169,18 +188,6 @@ const TextArea = forwardRef<
             ...style,
           }}
           gap="12px"
-          onClick={(event) => {
-            const target = event.target as HTMLElement;
-            if (target.closest('input, textarea, button, a')) return;
-
-            const textArea = textAreaRef.current;
-            if (!textArea || target.tagName === 'TEXTAREA') return;
-
-            requestAnimationFrame(() => {
-              textArea.focus();
-              textArea.click();
-            });
-          }}
           sx={[
             textAreaWrapperStyle({
               invalid: invalid,

--- a/packages/wds/src/components/text-area/index.tsx
+++ b/packages/wds/src/components/text-area/index.tsx
@@ -165,7 +165,8 @@ const TextArea = forwardRef<
       const handleClick = (event: MouseEvent) => {
         const target = event.target as HTMLElement;
 
-        if (target.closest('input, textarea, button, a')) return;
+        if (target.closest('input, textarea, button, a, [contenteditable]'))
+          return;
 
         textAreaRef.current?.click();
         textAreaRef.current?.focus();

--- a/packages/wds/src/components/text-field/index.tsx
+++ b/packages/wds/src/components/text-field/index.tsx
@@ -74,8 +74,9 @@ const TextField = forwardRef<
         const target = event.target as HTMLElement;
 
         if (
-          target.closest('input, textarea, button, a') ||
-          target.getAttribute('data-role') === 'text-field-reset'
+          target.closest(
+            'input, textarea, button, a, [data-role="text-field-reset"], [contenteditable]',
+          )
         )
           return;
 

--- a/packages/wds/src/components/text-field/index.tsx
+++ b/packages/wds/src/components/text-field/index.tsx
@@ -5,7 +5,7 @@ import {
   IconCircleCloseFill,
   IconCircleExclamationFill,
 } from '@wanteddev/wds-icon';
-import { forwardRef, useRef } from 'react';
+import { forwardRef, useEffect, useRef } from 'react';
 
 import FlexBox from '../flex-box';
 import IconButton from '../icon-button';
@@ -43,6 +43,7 @@ const TextField = forwardRef<
       trailingContent,
       positive,
       readOnly,
+      disabled,
       className,
       style,
       onReset,
@@ -60,21 +61,46 @@ const TextField = forwardRef<
     },
     ref,
   ) => {
+    const parentRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const composedRefs = useComposedRefs(inputRef, ref);
+
+    useEffect(() => {
+      const container = parentRef.current;
+
+      if (!container || disabled) return;
+
+      const handleClick = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+
+        if (
+          target.closest('input, textarea, button, a') ||
+          target.getAttribute('data-role') === 'text-field-reset'
+        )
+          return;
+
+        inputRef.current?.click();
+        inputRef.current?.focus();
+      };
+
+      container.addEventListener('click', handleClick);
+
+      return () => container.removeEventListener('click', handleClick);
+    }, [disabled]);
 
     return (
       <Box
         className={className}
         style={style}
         wds-component="text-field"
-        ref={wrapperRef}
+        ref={useComposedRefs(parentRef, wrapperRef)}
         sx={[
           textFieldWrapperStyle({
             invalid,
             width,
             height,
             readOnly,
+            disabled,
             type,
             positive,
             xs,
@@ -86,31 +112,16 @@ const TextField = forwardRef<
           }),
           sx,
         ]}
-        onClick={(event) => {
-          const target = event.target as HTMLElement;
-          if (target.closest('input, button, a')) return;
-
-          const input = inputRef.current;
-          if (
-            !input ||
-            target.tagName === 'INPUT' ||
-            target.getAttribute('data-role') === 'text-field-reset'
-          )
-            return;
-
-          requestAnimationFrame(() => {
-            input.focus();
-            input.click();
-          });
-        }}
       >
         {leadingContent}
         <input
           ref={composedRefs}
           type={type}
           readOnly={readOnly}
+          disabled={disabled}
           aria-readonly={readOnly}
           aria-invalid={invalid}
+          aria-disabled={disabled}
           {...props}
         />
         {invalid ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * SearchField, TextField에 비활성화(disabled) 상태 추가. 비활성화 시 스타일과 접근성 속성(aria-disabled, disabled)이 반영되며 리셋 동작이 해당 상태를 준수합니다.
* 리팩터
  * SearchField, TextField, TextArea에서 컨테이너 배경 클릭 시 입력 필드가 포커스/클릭되도록 동작을 통일(입력/텍스트영역/버튼/링크/리셋/콘텐츠편집 가능 요소 클릭은 제외). 기존 wrapper 클릭 핸들러를 제거하고 ref/클릭 위임을 정리하여 UX 일관성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->