### PR TITLE
feat(wds): add text-button variant in text field content

### DIFF
--- a/packages/wds/src/components/text-field/index.tsx
+++ b/packages/wds/src/components/text-field/index.tsx
@@ -281,6 +281,18 @@ const TextFieldContent = forwardRef<
           </IconButtonProvider>
         </FlexBox>
       );
+    case 'text-button':
+      return (
+        <FlexBox
+          wds-component="text-field-content"
+          ref={ref}
+          sx={[textFieldContentStyle, sx]}
+          alignItems="center"
+          {...props}
+        >
+          {children}
+        </FlexBox>
+      );
     case 'custom':
     default:
       return (

--- a/packages/wds/src/components/text-field/types.ts
+++ b/packages/wds/src/components/text-field/types.ts
@@ -34,7 +34,14 @@ export type TextFieldProps = Merge<
 >;
 
 export type TextFieldContentProps = WithSxProps<{
-  variant?: 'custom' | 'text' | 'timer' | 'badge' | 'icon' | 'icon-button';
+  variant?:
+    | 'custom'
+    | 'text'
+    | 'timer'
+    | 'badge'
+    | 'icon'
+    | 'icon-button'
+    | 'text-button';
   color?: ThemeColorsToken;
   children?: ReactNode;
 }>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new “text-button” variant for TextField content, enabling a horizontally centered layout for text-based interactive elements.
  - Ensures consistent alignment by centering content within the field, improving readability and tap targets for button-like text.
  - Extends existing variant options without affecting current behaviors, offering more flexibility for designing text-driven actions within text fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->