### PR TITLE
feat(wds): add background color in text field, text area

### DIFF
--- a/docs/src/docs/components/text-field.mdx
+++ b/docs/src/docs/components/text-field.mdx
@@ -134,49 +134,24 @@ export default Demo;`}
 
 ### TextFieldButton
 
-```css
-.textfield {
-  // bad
-  border-radius: 12px 12px 0px 0px;
-}
-
-.textfield {
-  // good
-  border-top-left-radius: 0px;
-  border-bottom-left-radius: 0px;
-}
-```
-
-TextField의 border radius 코너 두 부분을 커스텀 하여서 함께 사용합니다.
-`border-top-right-radius` 이런식의 명확한 코너의 radius를 0으로 설정해야합니다.
-
+`trailingButton` prop을 사용하여 우측에 버튼을 추가할 수 있어요.
 
 <Demo code={`import { TextField, FlexBox, TextFieldButton } from '@wanteddev/wds';
 
 const Demo = () => {
   return (
     <FlexBox flexDirection="column" gap="20px">
-      <FlexBox>
-        <TextField
-          placeholder="입력하세요."
-          width="300px"
-          sx={{ borderTopRightRadius: 0, borderBottomRightRadius: 0, }}
-        />
-        <TextFieldButton>
-          텍스트
-        </TextFieldButton>
-      </FlexBox>
 
-      <FlexBox>
-        <TextFieldButton position="left">
-          텍스트
-        </TextFieldButton>
-        <TextField
-          placeholder="입력하세요."
-          width="300px"
-          sx={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0, }}
-        />
-      </FlexBox>
+      <TextField
+        placeholder="입력하세요."
+        width="300px"
+        trailingButton={
+          <TextFieldButton>
+            텍스트
+          </TextFieldButton>
+        }
+      />
+        
     </FlexBox>
   )
 }

--- a/packages/wds/src/components/pagination/style.ts
+++ b/packages/wds/src/components/pagination/style.ts
@@ -55,8 +55,11 @@ export const pageButtonStyle = (theme: Theme) => css`
 `;
 
 export const paginationFieldStyle = css`
-  padding: 6px;
   border-radius: 8px;
+
+  [data-role='text-field-wrapper'] {
+    padding: 6px;
+  }
 
   input {
     ${typographyStyle('label1', 'medium')}

--- a/packages/wds/src/components/text-area/style.ts
+++ b/packages/wds/src/components/text-area/style.ts
@@ -28,7 +28,8 @@ export const textAreaWrapperStyle =
       inset 0 0 0 1px ${theme.semantic.line.normal.neutral},
       ${theme.semantic.elevation.shadow.xsmall};
     border-radius: 12px;
-    background-color: transparent;
+    background-color: ${theme.semantic.background.transparent.normal};
+    backdrop-filter: blur(32px);
     padding: 12px;
 
     ${invalid &&
@@ -41,7 +42,8 @@ export const textAreaWrapperStyle =
 
     ${disabled
       ? css`
-          background-color: ${theme.semantic.interaction.disable};
+          background-color: ${theme.semantic.fill.alternative};
+          backdrop-filter: none;
           box-shadow:
             inset 0 0 0 1px ${theme.semantic.line.normal.alternative},
             ${theme.semantic.elevation.shadow.xsmall};

--- a/packages/wds/src/components/text-field/index.tsx
+++ b/packages/wds/src/components/text-field/index.tsx
@@ -41,6 +41,7 @@ const TextField = forwardRef<
       invalid,
       leadingContent,
       trailingContent,
+      trailingButton,
       positive,
       readOnly,
       disabled,
@@ -114,82 +115,86 @@ const TextField = forwardRef<
           sx,
         ]}
       >
-        {leadingContent}
-        <input
-          ref={composedRefs}
-          type={type}
-          readOnly={readOnly}
-          disabled={disabled}
-          aria-readonly={readOnly}
-          aria-invalid={invalid}
-          aria-disabled={disabled}
-          {...props}
-        />
-        {invalid ? (
-          <TextFieldContent
-            data-role="text-field-invalid"
-            sx={invalidIconWrapperStyle}
-            variant="icon"
-          >
-            <IconCircleExclamationFill />
-          </TextFieldContent>
-        ) : (
-          positive && (
+        <FlexBox gap="8px" data-role="text-field-wrapper">
+          {leadingContent}
+          <input
+            ref={composedRefs}
+            type={type}
+            readOnly={readOnly}
+            disabled={disabled}
+            aria-readonly={readOnly}
+            aria-invalid={invalid}
+            aria-disabled={disabled}
+            {...props}
+          />
+          {invalid ? (
             <TextFieldContent
-              data-role="text-field-positive"
-              sx={positiveIconWrapperStyle}
+              data-role="text-field-invalid"
+              sx={invalidIconWrapperStyle}
               variant="icon"
             >
-              <IconCircleCheckFill />
+              <IconCircleExclamationFill />
             </TextFieldContent>
-          )
-        )}
+          ) : (
+            positive && (
+              <TextFieldContent
+                data-role="text-field-positive"
+                sx={positiveIconWrapperStyle}
+                variant="icon"
+              >
+                <IconCircleCheckFill />
+              </TextFieldContent>
+            )
+          )}
 
-        <TextFieldContent
-          data-role="text-field-reset"
-          variant="icon-button"
-          onPointerDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const input = inputRef.current;
+          <TextFieldContent
+            data-role="text-field-reset"
+            variant="icon-button"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => {
+              const input = inputRef.current;
 
-            if (!input) return;
+              if (!input) return;
 
-            requestAnimationFrame(() => {
-              const prevValue = input.value;
+              requestAnimationFrame(() => {
+                const prevValue = input.value;
 
-              const event = new Event('change', { bubbles: true });
-              input.value = '';
+                const event = new Event('change', { bubbles: true });
+                input.value = '';
 
-              props.onChange?.({
-                ...event,
-                target: input as EventTarget & HTMLInputElement,
-                currentTarget: input as EventTarget & HTMLInputElement,
-                nativeEvent: {
+                props.onChange?.({
                   ...event,
-                  target: input as EventTarget,
-                  currentTarget: input as EventTarget,
-                },
-                isDefaultPrevented: () => false,
-                isPropagationStopped: () => false,
-                persist: (): void => {},
+                  target: input as EventTarget & HTMLInputElement,
+                  currentTarget: input as EventTarget & HTMLInputElement,
+                  nativeEvent: {
+                    ...event,
+                    target: input as EventTarget,
+                    currentTarget: input as EventTarget,
+                  },
+                  isDefaultPrevented: () => false,
+                  isPropagationStopped: () => false,
+                  persist: (): void => {},
+                });
+
+                onReset?.(prevValue);
+
+                input.focus();
               });
-
-              onReset?.(prevValue);
-
-              input.focus();
-            });
-          }}
-        >
-          <IconButton
-            type="button"
-            size={22}
-            tabIndex={-1}
-            sx={(theme) => ({ color: theme.semantic.label.assistive })}
+            }}
           >
-            <IconCircleCloseFill />
-          </IconButton>
-        </TextFieldContent>
-        {trailingContent}
+            <IconButton
+              type="button"
+              size={22}
+              tabIndex={-1}
+              sx={(theme) => ({ color: theme.semantic.label.assistive })}
+            >
+              <IconCircleCloseFill />
+            </IconButton>
+          </TextFieldContent>
+          {trailingContent}
+        </FlexBox>
+
+        {trailingButton}
       </Box>
     );
   },
@@ -315,7 +320,6 @@ const TextFieldButton = forwardRef(
     {
       type = 'button',
       as,
-      position = 'right',
       variant = 'normal',
       disabled,
       ...props
@@ -331,8 +335,9 @@ const TextFieldButton = forwardRef(
         ref={ref}
         disabled={disabled}
         size="large"
+        data-role="text-field-button"
         {...props}
-        sx={[textFieldButtonStyle({ variant, position, disabled }), props.sx]}
+        sx={[textFieldButtonStyle({ variant, disabled }), props.sx]}
       />
     );
   },

--- a/packages/wds/src/components/text-field/style.ts
+++ b/packages/wds/src/components/text-field/style.ts
@@ -319,6 +319,7 @@ export const textFieldButtonStyle =
     overflow: hidden;
     background-color: transparent;
     flex-shrink: 0;
+    position: relative;
 
     &:disabled {
       box-shadow: none;

--- a/packages/wds/src/components/text-field/style.ts
+++ b/packages/wds/src/components/text-field/style.ts
@@ -34,16 +34,28 @@ export const textFieldWrapperStyle =
     align-items: center;
     border-radius: 12px;
     border: none;
-    box-shadow:
-      inset 0 0 0 1px ${theme.semantic.line.normal.neutral},
-      ${theme.semantic.elevation.shadow.xsmall};
-    background-color: transparent;
+    box-shadow: ${theme.semantic.elevation.shadow.xsmall};
+    background-color: ${theme.semantic.background.transparent.normal};
+    backdrop-filter: blur(32px);
     width: ${toCssValue(width)};
     height: ${toCssValue(height)};
-    padding: 12px;
-    gap: 8px;
-    cursor: text;
-    transition: box-shadow ease 0.2s;
+
+    [data-role='text-field-wrapper'] {
+      padding: 12px;
+      width: 100%;
+      cursor: text;
+      position: relative;
+      transition: box-shadow ease 0.2s;
+      box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.neutral};
+      border-radius: inherit;
+    }
+
+    &:has([data-role='text-field-button']) {
+      [data-role='text-field-wrapper'] {
+        border-top-right-radius: 0px;
+        border-bottom-right-radius: 0px;
+      }
+    }
 
     [data-role='text-field-invalid'],
     [data-role='text-field-positive'] {
@@ -72,18 +84,20 @@ export const textFieldWrapperStyle =
 
     ${invalid &&
     css`
-      box-shadow:
-        inset 0 0 0 1px
-          ${addOpacity(theme.semantic.status.negative, theme.opacity[28])},
-        ${theme.semantic.elevation.shadow.xsmall};
+      [data-role='text-field-wrapper'] {
+        box-shadow: inset 0 0 0 1px
+          ${addOpacity(theme.semantic.status.negative, theme.opacity[28])};
+      }
     `}
 
     ${disabled
       ? css`
-          background-color: ${theme.semantic.interaction.disable};
-          box-shadow:
-            inset 0 0 0 1px ${theme.semantic.line.normal.alternative},
-            ${theme.semantic.elevation.shadow.xsmall};
+          background-color: ${theme.semantic.fill.alternative};
+          backdrop-filter: none;
+          [data-role='text-field-wrapper'] {
+            box-shadow: inset 0 0 0 1px
+              ${theme.semantic.line.normal.alternative};
+          }
           cursor: default;
         `
       : css`
@@ -97,22 +111,22 @@ export const textFieldWrapperStyle =
               ) {
               ${invalid
                 ? css`
-                    box-shadow:
-                      inset 0 0 0 2px
+                    [data-role='text-field-wrapper'] {
+                      box-shadow: inset 0 0 0 2px
                         ${addOpacity(
                           theme.semantic.status.negative,
                           theme.opacity[43],
-                        )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                        )};
+                    }
                   `
                 : css`
-                    box-shadow:
-                      inset 0 0 0 2px
+                    [data-role='text-field-wrapper'] {
+                      box-shadow: inset 0 0 0 2px
                         ${addOpacity(
                           theme.semantic.primary.normal,
                           theme.opacity[43],
-                        )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                        )};
+                    }
                   `}
 
               [data-role='text-field-invalid'],
@@ -146,22 +160,22 @@ export const textFieldWrapperStyle =
               ) {
               ${invalid
                 ? css`
-                    box-shadow:
-                      inset 0 0 0 2px
+                    [data-role='text-field-wrapper'] {
+                      box-shadow: inset 0 0 0 2px
                         ${addOpacity(
                           theme.semantic.status.negative,
                           theme.opacity[43],
-                        )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                        )};
+                    }
                   `
                 : css`
-                    box-shadow:
-                      inset 0 0 0 2px
+                    [data-role='text-field-wrapper'] {
+                      box-shadow: inset 0 0 0 2px
                         ${addOpacity(
                           theme.semantic.primary.normal,
                           theme.opacity[43],
-                        )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                        )};
+                    }
                   `}
 
               [data-role='text-field-invalid'],
@@ -294,74 +308,39 @@ export const textFieldContentStyle = css`
 `;
 
 export const textFieldButtonStyle =
-  ({ position, variant, disabled }: TextFieldButtonProps) =>
+  ({ variant, disabled }: TextFieldButtonProps) =>
   (theme: Theme) => css`
     box-shadow: none;
     padding: 12px 16px;
     min-width: 80px;
+    border-radius: inherit;
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    overflow: hidden;
+    background-color: transparent;
+    flex-shrink: 0;
 
     &:disabled {
       box-shadow: none;
-      background-color: ${theme.semantic.interaction.disable};
     }
 
-    ${textFieldButtonPositionStyle({ position, disabled }, theme)}
+    &::before {
+      content: '';
+      right: 0px;
+      top: 0px;
+      border-radius: inherit;
+      position: absolute;
+      width: calc(100% + 3px);
+      height: calc(100% + 0px);
+      box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.neutral};
 
-    &>span {
+      ${disabled &&
+      css`
+        box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.alternative};
+      `}
+    }
+
+    & > span {
       ${typographyStyle('body1', variant === 'assistive' ? 'medium' : 'bold')};
     }
   `;
-
-export const textFieldButtonPositionStyle = (
-  { position, disabled }: TextFieldButtonProps,
-  theme: Theme,
-) => {
-  switch (position) {
-    case 'right':
-      return css`
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
-        overflow: hidden;
-
-        &::before {
-          content: '';
-          right: 0px;
-          top: 0px;
-          border-radius: inherit;
-          position: absolute;
-          width: calc(100% + 3px);
-          height: calc(100% + 0px);
-          box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.neutral};
-
-          ${disabled &&
-          css`
-            box-shadow: inset 0 0 0 1px
-              ${theme.semantic.line.normal.alternative};
-          `}
-        }
-      `;
-    case 'left':
-      return css`
-        overflow: hidden;
-        border-top-right-radius: 0px;
-        border-bottom-right-radius: 0px;
-
-        &::before {
-          content: '';
-          left: 0px;
-          top: 0px;
-          border-radius: inherit;
-          position: absolute;
-          width: calc(100% + 3px);
-          height: calc(100% + 0px);
-          box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.neutral};
-
-          ${disabled &&
-          css`
-            box-shadow: inset 0 0 0 1px
-              ${theme.semantic.line.normal.alternative};
-          `}
-        }
-      `;
-  }
-};

--- a/packages/wds/src/components/text-field/types.ts
+++ b/packages/wds/src/components/text-field/types.ts
@@ -16,6 +16,7 @@ export type TextFieldDefaultProps = WithSxProps<{
   positive?: boolean;
   leadingContent?: ReactNode;
   trailingContent?: ReactNode;
+  trailingButton?: ReactNode;
   disabled?: boolean;
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
@@ -56,7 +57,6 @@ export type TextFieldButtonProps = WithSxProps<{
   disabled?: boolean;
   leadingContent?: ReactNode;
   trailingContent?: ReactNode;
-  position?: 'right' | 'left';
   children?: ReactNode;
   type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - TextField now supports a trailingButton prop to embed a right-side action directly.

- Refactor
  - TextFieldButton no longer accepts a position prop; aligns with the trailingButton pattern.
  - Reorganized TextField DOM/layout to group input and controls inside an inner wrapper.

- Style
  - TextField: updated wrapper, borders, focused/disabled states, and corner behavior with trailing button.
  - Pagination input: padding moved to inner wrapper.
  - TextArea: translucent background with blur; refined disabled visuals.

- Documentation
  - Updated TextField docs and examples to demonstrate trailingButton usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->