### PR TITLE
fix(wds): push badge is not display when position is middle right

### DIFF
--- a/packages/wds/src/components/push-badge/style.ts
+++ b/packages/wds/src/components/push-badge/style.ts
@@ -117,7 +117,7 @@ const pushBadgePositionStyle = ({ position, invisible }: PushBadgeProps) => {
         top: calc(50% + var(--wds-push-badge-offset-y));
         left: calc(100% + var(--wds-push-badge-offset-x));
         transform: scale(0) translate(-50%, -50%);
-        ${invisible &&
+        ${!invisible &&
         css`
           transform: scale(1) translate(-50%, -50%);
         `}
@@ -186,7 +186,6 @@ const pushBadgeVariantStyle = ({ variant }: PushBadgeProps, theme: Theme) => {
 
         & > [data-role='push-badge-text'] {
           display: block;
-          line-height: 1;
         }
       `;
   }
@@ -220,6 +219,7 @@ const pushBadgeSizeStyle = ({ size, variant }: PushBadgeProps) => {
 
             [data-role='push-badge-text'] {
               ${typographyStyle('caption2', 'bold')}
+              line-height: 1;
             }
           `;
         case 'small':
@@ -230,6 +230,7 @@ const pushBadgeSizeStyle = ({ size, variant }: PushBadgeProps) => {
 
             [data-role='push-badge-text'] {
               ${typographyStyle('caption2', 'bold')}
+              line-height: 1;
             }
           `;
         case 'medium':
@@ -240,6 +241,7 @@ const pushBadgeSizeStyle = ({ size, variant }: PushBadgeProps) => {
 
             [data-role='push-badge-text'] {
               ${typographyStyle('label1', 'bold')}
+              line-height: 1;
             }
           `;
       }
@@ -254,6 +256,7 @@ const pushBadgeSizeStyle = ({ size, variant }: PushBadgeProps) => {
 
             [data-role='push-badge-text'] {
               ${typographyStyle('caption2', 'bold')}
+              line-height: 1;
             }
           `;
         case 'small':
@@ -264,6 +267,7 @@ const pushBadgeSizeStyle = ({ size, variant }: PushBadgeProps) => {
 
             [data-role='push-badge-text'] {
               ${typographyStyle('caption2', 'bold')}
+              line-height: 1;
             }
           `;
         case 'medium':
@@ -274,6 +278,7 @@ const pushBadgeSizeStyle = ({ size, variant }: PushBadgeProps) => {
 
             [data-role='push-badge-text'] {
               ${typographyStyle('label1', 'bold')}
+              line-height: 1;
             }
           `;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected middle-right push badge positioning so it aligns consistently with other positions when visible.

* **Style**
  * Standardized badge text line height for improved readability and alignment on xsmall, small, and medium sizes in “new” and “number” variants.
  * Removed redundant line-height from the default variant to ensure consistent typography across badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->