### PR TITLE
fix(wds): thumbnail reload when src is changed

### DIFF
--- a/packages/wds/src/components/avatar/index.tsx
+++ b/packages/wds/src/components/avatar/index.tsx
@@ -49,9 +49,6 @@ const Avatar = forwardRef<
       'idle' | 'loaded' | 'error'
     >('idle');
 
-    const hasImage = (value: AvatarProps) =>
-      'src' in value && Boolean(value.src);
-
     const prevSrc = useRef(props.src);
 
     useEffect(() => {
@@ -70,7 +67,7 @@ const Avatar = forwardRef<
         data-state={imageLoadingStatus}
         style={style}
       >
-        {imageLoadingStatus !== 'error' && hasImage(props) ? (
+        {imageLoadingStatus !== 'error' && Boolean(props.src) ? (
           <ImageBase
             {...props}
             onLoad={() => {

--- a/packages/wds/src/components/thumbnail/index.test.tsx
+++ b/packages/wds/src/components/thumbnail/index.test.tsx
@@ -23,6 +23,45 @@ describe('when given thumbnail component', () => {
     expect(screen.getByAltText('alt')).toBeInTheDocument();
   });
 
+  it('should render thumbnail with image when src is changed', async () => {
+    const { rerender } = render(
+      <Thumbnail
+        alt="alt"
+        data-testid="thumbnail"
+        src="https://static.wanted.co.kr/favicon/new/favicon.ico"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('thumbnail')).toBeInTheDocument();
+      expect(screen.getByAltText('alt')).toBeInTheDocument();
+    });
+
+    rerender(
+      <Thumbnail
+        alt="alt"
+        data-testid="thumbnail"
+        src="https://static.wanted.co.kr/favicon/favicon.ico"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('thumbnail')).toBeInTheDocument();
+      expect(screen.getByAltText('alt')).toBeInTheDocument();
+    });
+
+    vi.spyOn(imageBaseHelpers, 'loadImage').mockRejectedValue(
+      new Error('test'),
+    );
+
+    rerender(<Thumbnail alt="alt" data-testid="thumbnail" src="/" />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('thumbnail')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('alt')).toBeInTheDocument();
+    });
+  });
+
   it('should render fallback icon when image load failure', async () => {
     vi.spyOn(imageBaseHelpers, 'loadImage').mockRejectedValue(
       new Error('test'),

--- a/packages/wds/src/components/thumbnail/index.tsx
+++ b/packages/wds/src/components/thumbnail/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 import { IconImage } from '@wanteddev/wds-icon';
 
 import { FlexBox } from '../flex-box';
@@ -37,10 +37,19 @@ const Thumbnail = forwardRef<
     ref,
   ) => {
     const [imageLoadingStatus, setImageLoadingStatus] = useState<
-      'idle' | 'loading' | 'loaded' | 'error'
+      'idle' | 'loaded' | 'error'
     >('idle');
 
-    return imageLoadingStatus !== 'error' ? (
+    const prevSrc = useRef(props.src);
+
+    useEffect(() => {
+      if (prevSrc.current !== props.src) {
+        prevSrc.current = props.src;
+        setImageLoadingStatus('idle');
+      }
+    }, [props.src]);
+
+    return imageLoadingStatus !== 'error' && Boolean(props.src) ? (
       <FlexBox
         as="figure"
         wds-component="thumbnail"
@@ -102,6 +111,7 @@ const Thumbnail = forwardRef<
         ]}
       >
         <IconImage
+          role="img"
           aria-label={props.alt}
           sx={{ width: '33.34%', height: 'auto' }}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Thumbnails now update reliably when the image source changes.
  * Properly falls back to a placeholder if an image fails to load after a source change.
  * Prevents blank renders by showing a placeholder when no image source is provided.

* Accessibility
  * Improved screen reader support by marking thumbnails and placeholders with appropriate image roles.

* Tests
  * Added tests covering thumbnail updates on source change and fallback behavior on load failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->