### PR TITLE
feat(wds): change menu max height to 416px

### DIFF
--- a/packages/wds/src/components/menu/style.ts
+++ b/packages/wds/src/components/menu/style.ts
@@ -14,7 +14,7 @@ export const menuPopoverContentStyle = (theme: Theme) => css`
 export const menuScrollAreaStyle = (theme: Theme) => css`
   width: 100%;
   min-width: 140px;
-  max-height: 400px;
+  max-height: 416px;
   height: auto;
   border-radius: inherit;
   border: 1px solid ${theme.semantic.line.solid.neutral};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the menu’s scrollable area height from 400px to 416px, allowing more items to be visible before scrolling. This enhances readability and reduces scrolling friction, especially on medium-sized viewports. No functional behavior changed; the update is purely visual and aims to improve overall menu usability and comfort during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->