### PR TITLE
feat(wds): change tooltip min width to unset

### DIFF
--- a/packages/wds/src/components/tooltip/style.ts
+++ b/packages/wds/src/components/tooltip/style.ts
@@ -25,7 +25,6 @@ const unmountKeyframes = keyframes`
 export const tooltipWrapperStyle = css`
   border-radius: 8px;
   backdrop-filter: blur(32px);
-  min-width: 64px;
   max-width: 280px;
 
   &[data-status='open'] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tooltip sizing to remove the fixed minimum width, allowing tooltips to shrink to fit shorter content.
  * Improves visual compactness and reduces unnecessary whitespace, especially on small screens or with brief messages.
  * Preserves existing appearance (border radius, backdrop blur, max width) and open/close animations.
  * No impact on public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->