### PR TITLE
feat(wds,wds-codemod)!: change property show to open in section message

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,7 +54,7 @@ jobs:
         run: pnpm run build
 
       - name: Run Test
-        run: pnpm run test --silent
+        run: pnpm run test --silent --no-cache
   send_slack:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'DO NOT ALERT') }}
     name: Send Slack Notification

--- a/packages/wds-codemod/src/constants.ts
+++ b/packages/wds-codemod/src/constants.ts
@@ -29,5 +29,6 @@ export const MIGRATION_TRANSFORMS = {
     'button-secondary-migration': 'Button Secondary Migration',
     'pagination-migration': 'Pagination Migration',
     'compact-tooltip-migration': 'Compact Tooltip Migration',
+    'section-message-show-to-open': 'Section Message Show to Open',
   },
 };

--- a/packages/wds-codemod/src/transforms/v3/section-message-show-to-open.ts
+++ b/packages/wds-codemod/src/transforms/v3/section-message-show-to-open.ts
@@ -1,0 +1,70 @@
+import { findImportDeclaration, getLocalName } from '../../helpers';
+
+import type { API, FileInfo, JSXAttribute, Options } from 'jscodeshift';
+
+const transformer = (file: FileInfo, api: API, options: Options) => {
+  const j = api.jscodeshift.withParser('tsx');
+  const root = j(file.source);
+  let hasChanges = false;
+
+  const wdsImport = root.find(j.ImportDeclaration, {
+    source: { value: '@wanteddev/wds' },
+  });
+
+  if (wdsImport.length < 1) {
+    return file.source;
+  }
+
+  const sectionMessageImport = findImportDeclaration(
+    'SectionMessage',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (sectionMessageImport) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: { name: getLocalName(sectionMessageImport) },
+      })
+      .forEach((target) => {
+        const showAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'show',
+        );
+
+        if (showAttribute) {
+          hasChanges = true;
+
+          showAttribute.name.name = 'open';
+        }
+
+        const onShowChangeAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'onShowChange',
+        );
+
+        if (onShowChangeAttribute) {
+          hasChanges = true;
+
+          onShowChangeAttribute.name.name = 'onOpenChange';
+        }
+
+        const defaultShowAttribute = target.value.attributes?.find(
+          (v): v is JSXAttribute =>
+            v.type === 'JSXAttribute' && v.name.name === 'defaultShow',
+        );
+
+        if (defaultShowAttribute) {
+          hasChanges = true;
+
+          defaultShowAttribute.name.name = 'defaultOpen';
+        }
+      });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return hasChanges ? root.toSource(options) : file.source;
+};
+
+export default transformer;

--- a/packages/wds/src/components/accordion/index.test.tsx
+++ b/packages/wds/src/components/accordion/index.test.tsx
@@ -1,10 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 
 import {
@@ -51,18 +45,14 @@ describe('when given accordion component', () => {
     expect(screen.queryByTestId('accordion-details')).not.toBeInTheDocument();
   });
 
-  it('should expand accordion when summary is clicked', async () => {
+  it('should expand accordion when summary is clicked', () => {
     fireEvent.click(screen.getByTestId('accordion-summary'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('accordion-details')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('accordion-details')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('accordion-summary'));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('accordion-details')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('accordion-details')).not.toBeInTheDocument();
   });
 
   it('should pass accessibility test', async () => {
@@ -72,9 +62,7 @@ describe('when given accordion component', () => {
 
     fireEvent.click(screen.getByTestId('accordion-summary'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('accordion-details')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('accordion-details')).toBeInTheDocument();
 
     expect(
       await axe(screen.getByTestId('accordion-summary')),
@@ -107,11 +95,9 @@ describe('when given accordion component with disabled prop', () => {
     cleanup();
   });
 
-  it('should not expand accordion when summary is clicked', async () => {
+  it('should not expand accordion when summary is clicked', () => {
     fireEvent.click(screen.getByTestId('accordion-summary'));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('accordion-details')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('accordion-details')).not.toBeInTheDocument();
   });
 });

--- a/packages/wds/src/components/autocomplete/index.test.tsx
+++ b/packages/wds/src/components/autocomplete/index.test.tsx
@@ -1,10 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 
 import { FormControl, FormField, FormLabel, FormMessage } from '../form';
@@ -59,12 +53,10 @@ describe('when given autocomplete component', () => {
     cleanup();
   });
 
-  it('should handle keyboard events', async () => {
+  it('should handle keyboard events', () => {
     fireEvent.click(screen.getByTestId('autocomplete-field'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('autocomplete-option-1')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('autocomplete-option-1')).toBeInTheDocument();
 
     fireEvent.keyDown(screen.getByTestId('autocomplete-field'), {
       key: 'End',
@@ -74,9 +66,7 @@ describe('when given autocomplete component', () => {
       key: 'Enter',
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('autocomplete-field')).toHaveValue('item-2');
-    });
+    expect(screen.getByTestId('autocomplete-field')).toHaveValue('item-2');
 
     fireEvent.click(screen.getByTestId('autocomplete-field'));
 
@@ -88,9 +78,7 @@ describe('when given autocomplete component', () => {
       key: 'Enter',
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('autocomplete-field')).toHaveValue('item-1');
-    });
+    expect(screen.getByTestId('autocomplete-field')).toHaveValue('item-1');
 
     fireEvent.click(screen.getByTestId('autocomplete-field'));
 
@@ -105,9 +93,7 @@ describe('when given autocomplete component', () => {
       key: 'Enter',
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('autocomplete-field')).toHaveValue('item-2');
-    });
+    expect(screen.getByTestId('autocomplete-field')).toHaveValue('item-2');
   });
 });
 
@@ -150,16 +136,14 @@ describe('when given autocomplete component with form field', () => {
 
     fireEvent.click(screen.getByTestId('autocomplete-field'));
 
-    await waitFor(async () => {
-      expect(
-        await axe(screen.getByTestId('autocomplete-list')),
-      ).toHaveNoViolations();
-      expect(
-        await axe(screen.getByTestId('autocomplete-group')),
-      ).toHaveNoViolations();
-      expect(
-        await axe(screen.getByTestId('autocomplete-option-1')),
-      ).toHaveNoViolations();
-    });
+    expect(
+      await axe(screen.getByTestId('autocomplete-list')),
+    ).toHaveNoViolations();
+    expect(
+      await axe(screen.getByTestId('autocomplete-group')),
+    ).toHaveNoViolations();
+    expect(
+      await axe(screen.getByTestId('autocomplete-option-1')),
+    ).toHaveNoViolations();
   });
 });

--- a/packages/wds/src/components/category/index.test.tsx
+++ b/packages/wds/src/components/category/index.test.tsx
@@ -21,10 +21,18 @@ describe('when given category component with panel', () => {
             Category 2
           </CategoryListItem>
         </CategoryList>
-        <CategoryPanel data-testid="category-panel-1" value="1">
+        <CategoryPanel
+          data-testid="category-panel-1"
+          value="1"
+          mountMode="only-active"
+        >
           Panel 1
         </CategoryPanel>
-        <CategoryPanel data-testid="category-panel-2" value="2">
+        <CategoryPanel
+          data-testid="category-panel-2"
+          value="2"
+          mountMode="only-active"
+        >
           Panel 2
         </CategoryPanel>
       </Category>,
@@ -41,10 +49,8 @@ describe('when given category component with panel', () => {
 
     fireEvent.click(screen.getByTestId('category-2'));
 
-    waitFor(() => {
-      expect(screen.queryByTestId('category-panel-1')).not.toBeInTheDocument();
-      expect(screen.getByTestId('category-panel-2')).toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('category-panel-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('category-panel-2')).toBeInTheDocument();
   });
 
   it('should handle keyboard navigation', async () => {

--- a/packages/wds/src/components/date-calendar/index.test.tsx
+++ b/packages/wds/src/components/date-calendar/index.test.tsx
@@ -1,10 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 
 import { DateCalendar } from '.';
@@ -209,34 +203,22 @@ describe('when given date calendar component', () => {
   });
 
   it('should pass accessibility tests', async () => {
-    const { unmount: unmountDay } = render(<DateCalendar {...defaultProps} />);
+    const { rerender } = render(<DateCalendar {...defaultProps} />);
 
-    await waitFor(async () => {
-      expect(await axe(screen.getByRole('rowgroup'))).toHaveNoViolations();
+    expect(await axe(screen.getByRole('rowgroup'))).toHaveNoViolations();
 
-      const rows = screen.getAllByRole('row');
+    const rows = screen.getAllByRole('row');
 
-      for (const row of rows) {
-        expect(await axe(row)).toHaveNoViolations();
-      }
-    });
+    for (const row of rows) {
+      expect(await axe(row)).toHaveNoViolations();
+    }
 
-    unmountDay();
+    rerender(<DateCalendar {...defaultProps} view="year" views={['year']} />);
 
-    const { unmount: unmountYear } = render(
-      <DateCalendar {...defaultProps} view="year" views={['year']} />,
-    );
+    expect(await axe(screen.getByRole('radiogroup'))).toHaveNoViolations();
 
-    await waitFor(async () => {
-      expect(await axe(screen.getByRole('radiogroup'))).toHaveNoViolations();
-    });
+    rerender(<DateCalendar {...defaultProps} view="month" views={['month']} />);
 
-    unmountYear();
-
-    render(<DateCalendar {...defaultProps} view="month" views={['month']} />);
-
-    await waitFor(async () => {
-      expect(await axe(screen.getByRole('radiogroup'))).toHaveNoViolations();
-    });
+    expect(await axe(screen.getByRole('radiogroup'))).toHaveNoViolations();
   });
 });

--- a/packages/wds/src/components/date-picker/index.test.tsx
+++ b/packages/wds/src/components/date-picker/index.test.tsx
@@ -42,27 +42,19 @@ describe('when given date picker component', () => {
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2024.01.01');
-    });
+    expect(input).toHaveValue('2024.01.01');
 
     fireEvent.keyDown(input, { key: 'ArrowUp' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2025.01.01');
-    });
+    expect(input).toHaveValue('2025.01.01');
 
     fireEvent.keyDown(input, { key: 'End' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2100.01.01');
-    });
+    expect(input).toHaveValue('2100.01.01');
 
     fireEvent.keyDown(input, { key: 'Home' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('1900.01.01');
-    });
+    expect(input).toHaveValue('1900.01.01');
 
     fireEvent.keyDown(input, { key: 'ArrowRight' });
 
@@ -126,17 +118,15 @@ describe('when given date picker component', () => {
     expect(screen.getByTestId('date-picker')).toHaveValue('2024.12.31');
   });
 
-  it('should open date calendar when calendar icon is clicked', async () => {
+  it('should open date calendar when calendar icon is clicked', () => {
     render(<DatePicker {...defaultProps} data-testid="date-picker" />);
 
     fireEvent.click(screen.getByLabelText('Toggle date picker'));
 
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('should handle paste events', async () => {
+  it('should handle paste events', () => {
     render(<DatePicker {...defaultProps} data-testid="date-picker" />);
 
     const input = screen.getByTestId<HTMLInputElement>('date-picker');
@@ -150,9 +140,7 @@ describe('when given date picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2025.05.01');
-    });
+    expect(input).toHaveValue('2025.05.01');
 
     input.setSelectionRange(0, input.value.length);
 
@@ -162,9 +150,7 @@ describe('when given date picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2999.12.31');
-    });
+    expect(input).toHaveValue('2999.12.31');
 
     fireEvent.paste(input, {
       clipboardData: {
@@ -172,9 +158,7 @@ describe('when given date picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2999.12.23');
-    });
+    expect(input).toHaveValue('2999.12.23');
 
     input.setSelectionRange(0, input.value.length);
 
@@ -184,8 +168,6 @@ describe('when given date picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('2050.12.01');
-    });
+    expect(input).toHaveValue('2050.12.01');
   });
 });

--- a/packages/wds/src/components/section-message/index.tsx
+++ b/packages/wds/src/components/section-message/index.tsx
@@ -54,6 +54,7 @@ const SectionMessage = forwardRef<
 
     const handleClose = useCallback(() => setOpen(false), [setOpen]);
 
+    const titleId = useId();
     const descriptionId = useId();
 
     const iconComponent: {
@@ -77,6 +78,7 @@ const SectionMessage = forwardRef<
         ref={ref}
         gap="8px"
         role="alert"
+        aria-labelledby={titleId}
         aria-describedby={descriptionId}
         {...props}
         sx={[sectionMessageWrapperStyle, props.sx]}
@@ -101,7 +103,7 @@ const SectionMessage = forwardRef<
             variant="body2"
             weight="medium"
             data-role="section-message-content-title"
-            id={descriptionId}
+            id={titleId}
             as="h2"
           >
             {children}
@@ -112,6 +114,7 @@ const SectionMessage = forwardRef<
               variant="label1-reading"
               weight="regular"
               data-role="section-message-content-description"
+              id={descriptionId}
               color="semantic.label.neutral"
               as="p"
             >

--- a/packages/wds/src/components/section-message/index.tsx
+++ b/packages/wds/src/components/section-message/index.tsx
@@ -32,9 +32,9 @@ const SectionMessage = forwardRef<
 >(
   (
     {
-      show: originShow,
-      defaultShow = true,
-      onShowChange,
+      open: originOpen,
+      defaultOpen = true,
+      onOpenChange,
       variant = 'info',
       children,
       leadingContent,
@@ -46,16 +46,13 @@ const SectionMessage = forwardRef<
     },
     ref,
   ) => {
-    const [show = false, setShow] = useControllableState({
-      prop: originShow,
-      defaultProp: defaultShow,
-      onChange: onShowChange,
+    const [open = false, setOpen] = useControllableState({
+      prop: originOpen,
+      defaultProp: defaultOpen,
+      onChange: onOpenChange,
     });
 
-    const handleShowToggle = useCallback(
-      () => setShow((prevShow) => !prevShow),
-      [setShow],
-    );
+    const handleClose = useCallback(() => setOpen(false), [setOpen]);
 
     const descriptionId = useId();
 
@@ -73,92 +70,91 @@ const SectionMessage = forwardRef<
 
     const renderLeadingContent = leadingContent ?? iconComponent[variant];
 
+    if (!open) return null;
+
     return (
-      <>
-        {show && (
-          <FlexBox
-            ref={ref}
-            gap="8px"
-            role="alert"
-            aria-describedby={descriptionId}
-            {...props}
-            sx={[sectionMessageWrapperStyle, props.sx]}
-          >
-            <Box role="presentation" sx={firstOverlayStyle} />
-            <Box role="presentation" sx={secondOverlayStyle(variant)} />
+      <FlexBox
+        ref={ref}
+        gap="8px"
+        role="alert"
+        aria-describedby={descriptionId}
+        {...props}
+        sx={[sectionMessageWrapperStyle, props.sx]}
+      >
+        <Box role="presentation" sx={firstOverlayStyle} />
+        <Box role="presentation" sx={secondOverlayStyle(variant)} />
 
-            {renderLeadingContent && (
-              <FlexBox flexShrink={0} sx={sectionMessageIconStyle(variant)}>
-                {renderLeadingContent}
-              </FlexBox>
-            )}
-
-            <FlexBox
-              data-role="section-message-content"
-              flexDirection="column"
-              gap="4px"
-              flex="1"
-            >
-              <Typography
-                color="semantic.label.normal"
-                variant="body2"
-                weight="medium"
-                data-role="section-message-content-title"
-                id={descriptionId}
-                as="h2"
-              >
-                {children}
-              </Typography>
-
-              {description && (
-                <Typography
-                  variant="label1-reading"
-                  weight="regular"
-                  data-role="section-message-content-description"
-                  color="semantic.label.neutral"
-                  as="p"
-                >
-                  {description}
-                </Typography>
-              )}
-
-              {bottomButton && (
-                <FlexBox
-                  data-role="section-message-bottom-button"
-                  sx={{ marginTop: 8 }}
-                  gap="16px"
-                >
-                  {bottomButton}
-                </FlexBox>
-              )}
-            </FlexBox>
-
-            {trailingButton && (
-              <FlexBox
-                gap="16px"
-                alignItems="center"
-                sx={sectionMessageTrailingButtonStyle}
-                data-role="section-message-trailing-button"
-              >
-                {trailingButton}
-              </FlexBox>
-            )}
-
-            {closeButton && (
-              <IconButton
-                data-role="section-message-close-icon"
-                color="semantic.label.alternative"
-                interactionColor="semantic.label.alternative"
-                onClick={handleShowToggle}
-                size={20}
-                sx={sectionMessageCloseButtonStyle}
-              >
-                <IconClose />
-              </IconButton>
-            )}
+        {renderLeadingContent && (
+          <FlexBox flexShrink={0} sx={sectionMessageIconStyle(variant)}>
+            {renderLeadingContent}
           </FlexBox>
         )}
-      </>
+
+        <FlexBox
+          data-role="section-message-content"
+          flexDirection="column"
+          gap="4px"
+          flex="1"
+        >
+          <Typography
+            color="semantic.label.normal"
+            variant="body2"
+            weight="medium"
+            data-role="section-message-content-title"
+            id={descriptionId}
+            as="h2"
+          >
+            {children}
+          </Typography>
+
+          {description && (
+            <Typography
+              variant="label1-reading"
+              weight="regular"
+              data-role="section-message-content-description"
+              color="semantic.label.neutral"
+              as="p"
+            >
+              {description}
+            </Typography>
+          )}
+
+          {bottomButton && (
+            <FlexBox
+              data-role="section-message-bottom-button"
+              sx={{ marginTop: 8 }}
+              gap="16px"
+            >
+              {bottomButton}
+            </FlexBox>
+          )}
+        </FlexBox>
+
+        {trailingButton && (
+          <FlexBox
+            gap="16px"
+            alignItems="center"
+            sx={sectionMessageTrailingButtonStyle}
+            data-role="section-message-trailing-button"
+          >
+            {trailingButton}
+          </FlexBox>
+        )}
+
+        {closeButton && (
+          <IconButton
+            data-role="section-message-close-icon"
+            color="semantic.label.alternative"
+            interactionColor="semantic.label.alternative"
+            onClick={handleClose}
+            size={20}
+            aria-label="Close message"
+            sx={sectionMessageCloseButtonStyle}
+          >
+            <IconClose />
+          </IconButton>
+        )}
+      </FlexBox>
     );
   },
 );

--- a/packages/wds/src/components/section-message/types.ts
+++ b/packages/wds/src/components/section-message/types.ts
@@ -4,9 +4,9 @@ import type { ReactNode } from 'react';
 export type SectionMessageProps = WithSxProps<{
   variant?: 'info' | 'positive' | 'cautionary' | 'negative' | 'custom';
   children?: ReactNode;
-  show?: boolean;
-  defaultShow?: boolean;
-  onShowChange?: (state: boolean) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (state: boolean) => void;
   /**
    * Displays the close button.
    */

--- a/packages/wds/src/components/snackbar/index.test.tsx
+++ b/packages/wds/src/components/snackbar/index.test.tsx
@@ -4,7 +4,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
 } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 
@@ -55,36 +54,30 @@ describe('when given snackbar component', () => {
     cleanup();
   });
 
-  it(`should render toast component and ${DEFAULT_DURATION}ms after close`, async () => {
+  it(`should render toast component and ${DEFAULT_DURATION}ms after close`, () => {
     expect(screen.getByTestId('snackbar')).toBeInTheDocument();
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('snackbar')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('snackbar')).not.toBeInTheDocument();
   });
 
-  it('should not close snackbar if mouse is over the toast container after open', async () => {
+  it('should not close snackbar if mouse is over the toast container after open', () => {
     expect(screen.getByTestId('snackbar')).toBeInTheDocument();
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
 
     fireEvent.mouseEnter(screen.getByTestId('snackbar'));
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('snackbar')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('snackbar')).toBeInTheDocument();
 
     fireEvent.mouseLeave(screen.getByTestId('snackbar'));
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('snackbar')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('snackbar')).not.toBeInTheDocument();
   });
 
   it('should pass accessibility test', async () => {

--- a/packages/wds/src/components/tab/index.test.tsx
+++ b/packages/wds/src/components/tab/index.test.tsx
@@ -21,10 +21,10 @@ describe('when given tab component with panel', () => {
             Tab 2
           </TabListItem>
         </TabList>
-        <TabPanel data-testid="tab-panel-1" value="1">
+        <TabPanel data-testid="tab-panel-1" value="1" mountMode="only-active">
           Panel 1
         </TabPanel>
-        <TabPanel data-testid="tab-panel-2" value="2">
+        <TabPanel data-testid="tab-panel-2" value="2" mountMode="only-active">
           Panel 2
         </TabPanel>
       </Tab>,
@@ -41,10 +41,8 @@ describe('when given tab component with panel', () => {
 
     fireEvent.click(screen.getByTestId('tab-2'));
 
-    waitFor(() => {
-      expect(screen.queryByTestId('tab-panel-1')).not.toBeInTheDocument();
-      expect(screen.getByTestId('tab-panel-2')).toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('tab-panel-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tab-panel-2')).toBeInTheDocument();
   });
 
   it('should handle keyboard navigation', async () => {
@@ -52,8 +50,8 @@ describe('when given tab component with panel', () => {
     fireEvent.keyDown(screen.getByTestId('tab-1'), { key: 'ArrowRight' });
 
     await waitFor(() => {
-      expect(screen.getByTestId('tab-2')).toHaveFocus();
       expect(screen.getByTestId('tab-panel-2')).toBeInTheDocument();
+      expect(screen.getByTestId('tab-2')).toHaveFocus();
     });
   });
 

--- a/packages/wds/src/components/time-picker/index.test.tsx
+++ b/packages/wds/src/components/time-picker/index.test.tsx
@@ -42,27 +42,19 @@ describe('when given time picker component', () => {
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('09:30:00');
-    });
+    expect(input).toHaveValue('09:30:00');
 
     fireEvent.keyDown(input, { key: 'ArrowUp' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('10:30:00');
-    });
+    expect(input).toHaveValue('10:30:00');
 
     fireEvent.keyDown(input, { key: 'End' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('23:30:00');
-    });
+    expect(input).toHaveValue('23:30:00');
 
     fireEvent.keyDown(input, { key: 'Home' });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('00:30:00');
-    });
+    expect(input).toHaveValue('00:30:00');
 
     fireEvent.keyDown(input, { key: 'ArrowRight' });
 
@@ -153,9 +145,7 @@ describe('when given time picker component', () => {
 
     fireEvent.keyDown(input, { key: 'End' });
 
-    waitFor(() => {
-      expect(input).toHaveValue('12:30');
-    });
+    expect(input).toHaveValue('12:30');
   });
 
   it('should open time-view when clock icon is clicked', async () => {
@@ -165,13 +155,11 @@ describe('when given time picker component', () => {
 
     fireEvent.click(screen.getByLabelText('Toggle time picker'));
 
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(document.activeElement).toHaveTextContent('10');
-    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(document.activeElement).toHaveTextContent('10');
   });
 
-  it('should handle paste events', async () => {
+  it('should handle paste events', () => {
     render(<TimePicker {...defaultProps} data-testid="time-picker" />);
 
     const input = screen.getByTestId<HTMLInputElement>('time-picker');
@@ -185,9 +173,7 @@ describe('when given time picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('14:30:00');
-    });
+    expect(input).toHaveValue('14:30:00');
 
     input.setSelectionRange(0, input.value.length);
 
@@ -197,9 +183,7 @@ describe('when given time picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('14:30:00');
-    });
+    expect(input).toHaveValue('14:30:00');
 
     fireEvent.paste(input, {
       clipboardData: {
@@ -207,9 +191,7 @@ describe('when given time picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('14:30:23');
-    });
+    expect(input).toHaveValue('14:30:23');
 
     input.setSelectionRange(0, input.value.length);
 
@@ -219,8 +201,6 @@ describe('when given time picker component', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(input).toHaveValue('10:00:00');
-    });
+    expect(input).toHaveValue('10:00:00');
   });
 });

--- a/packages/wds/src/components/time-view/index.test.tsx
+++ b/packages/wds/src/components/time-view/index.test.tsx
@@ -1,11 +1,5 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import { TimeView } from '.';
@@ -22,11 +16,8 @@ describe('when given time view component', () => {
     onChange: vi.fn(),
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   afterEach(() => {
+    vi.clearAllMocks();
     cleanup();
   });
 
@@ -53,7 +44,7 @@ describe('when given time view component', () => {
     expect(screen.getAllByRole('option')).toHaveLength(12 + 60 / 5 + 2);
   });
 
-  it('should call onChangeComplete when last view is selected', async () => {
+  it('should call onChangeComplete when last view is selected', () => {
     const onChangeComplete = vi.fn();
 
     render(
@@ -64,12 +55,10 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      const minuteItem = screen.getByText('30');
-      fireEvent.click(minuteItem);
+    const minuteItem = screen.getByText('30');
+    fireEvent.click(minuteItem);
 
-      expect(onChangeComplete).toHaveBeenCalledWith(expect.any(Date));
-    });
+    expect(onChangeComplete).toHaveBeenCalledWith(expect.any(Date));
   });
 
   it('should handle minTime and maxTime props', async () => {
@@ -85,12 +74,10 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByRole('listbox')).toHaveLength(2);
-    });
+    expect(screen.getAllByRole('listbox')).toHaveLength(2);
   });
 
-  it('should handle minTime only', async () => {
+  it('should handle minTime only', () => {
     const minTime = new Date('2025-01-01T12:00:00');
 
     render(
@@ -101,12 +88,10 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByRole('listbox')).toHaveLength(2);
-    });
+    expect(screen.getAllByRole('listbox')).toHaveLength(2);
   });
 
-  it('should handle maxTime only', async () => {
+  it('should handle maxTime only', () => {
     const maxTime = new Date('2025-01-01T15:00:00');
 
     render(
@@ -117,12 +102,10 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByRole('listbox')).toHaveLength(2);
-    });
+    expect(screen.getAllByRole('listbox')).toHaveLength(2);
   });
 
-  it('should work with 12-hour format', async () => {
+  it('should work with 12-hour format', () => {
     const minTime = new Date('2025-01-01T09:00:00');
     const maxTime = new Date('2025-01-01T18:00:00');
 
@@ -135,12 +118,10 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByRole('listbox')).toHaveLength(3);
-    });
+    expect(screen.getAllByRole('listbox')).toHaveLength(3);
   });
 
-  it('should disable hours outside minTime and maxTime range', async () => {
+  it('should disable hours outside minTime and maxTime range', () => {
     const minTime = new Date('2025-01-01T09:00:00'); // 09:00
     const maxTime = new Date('2025-01-01T18:00:00'); // 18:00
 
@@ -153,27 +134,23 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      const hour8 = screen.getByText('8');
-      expect(hour8.closest('[role="option"]')).toHaveAttribute('disabled');
+    const hour8 = screen.getByText('8');
+    expect(hour8.closest('[role="option"]')).toHaveAttribute('disabled');
 
-      const hour19 = screen.getByText('19');
-      expect(hour19.closest('[role="option"]')).toHaveAttribute('disabled');
+    const hour19 = screen.getByText('19');
+    expect(hour19.closest('[role="option"]')).toHaveAttribute('disabled');
 
-      const hour10Elements = screen.getAllByText('10');
-      const hour10 = hour10Elements.find((el) =>
-        el
-          .closest('[role="option"]')
-          ?.getAttribute('data-role')
-          ?.includes('hour'),
-      );
-      expect(hour10?.closest('[role="option"]')).not.toHaveAttribute(
-        'disabled',
-      );
-    });
+    const hour10Elements = screen.getAllByText('10');
+    const hour10 = hour10Elements.find((el) =>
+      el
+        .closest('[role="option"]')
+        ?.getAttribute('data-role')
+        ?.includes('hour'),
+    );
+    expect(hour10?.closest('[role="option"]')).not.toHaveAttribute('disabled');
   });
 
-  it('should not call onChange when clicking disabled time items', async () => {
+  it('should not call onChange when clicking disabled time items', () => {
     const onChange = vi.fn();
     const minTime = new Date('2025-01-01T10:00:00');
     const maxTime = new Date('2025-01-01T18:00:00');
@@ -188,15 +165,13 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      const hour8 = screen.getByText('8');
-      fireEvent.click(hour8);
+    const hour8 = screen.getByText('8');
+    fireEvent.click(hour8);
 
-      expect(onChange).not.toHaveBeenCalled();
-    });
+    expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('should call onChange when clicking enabled time items', async () => {
+  it('should call onChange when clicking enabled time items', () => {
     const onChange = vi.fn();
     const minTime = new Date('2025-01-01T09:00:00');
     const maxTime = new Date('2025-01-01T18:00:00');
@@ -211,15 +186,13 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      const hour12 = screen.getByText('12');
-      fireEvent.click(hour12);
+    const hour12 = screen.getByText('12');
+    fireEvent.click(hour12);
 
-      expect(onChange).toHaveBeenCalledWith(expect.any(Date));
-    });
+    expect(onChange).toHaveBeenCalledWith(expect.any(Date));
   });
 
-  it('should ignore date part and only compare time', async () => {
+  it('should ignore date part and only compare time', () => {
     const minTime = new Date('2024-12-31T09:00:00');
     const maxTime = new Date('2026-01-02T18:00:00');
 
@@ -232,11 +205,9 @@ describe('when given time view component', () => {
       />,
     );
 
-    await waitFor(() => {
-      const hour8 = screen.getByText('8');
+    const hour8 = screen.getByText('8');
 
-      expect(hour8.closest('[role="option"]')).toHaveAttribute('disabled');
-    });
+    expect(hour8.closest('[role="option"]')).toHaveAttribute('disabled');
 
     const hour19 = screen.getByText('19');
     expect(hour19.closest('[role="option"]')).toHaveAttribute('disabled');
@@ -254,20 +225,16 @@ describe('when given time view component', () => {
   it('should pass accessibility tests', async () => {
     render(<TimeView {...defaultProps} />);
 
-    await waitFor(async () => {
-      // rendering check
-      expect(screen.getAllByRole('listbox').at(0)).toBeInTheDocument();
-    });
-
     const timeLists = screen.getAllByRole('listbox');
-
-    for (const timeList of timeLists) {
-      expect(await axe(timeList)).toHaveNoViolations();
-    }
-
     const timeItems = screen.getAllByRole('option');
 
+    for (const list of timeLists) {
+      expect(list).toBeInTheDocument();
+      expect(await axe(list)).toHaveNoViolations();
+    }
+
     for (const item of timeItems) {
+      expect(item).toBeInTheDocument();
       expect(await axe(item)).toHaveNoViolations();
     }
   });

--- a/packages/wds/src/components/toast/index.test.tsx
+++ b/packages/wds/src/components/toast/index.test.tsx
@@ -4,7 +4,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
 } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 
@@ -49,31 +48,25 @@ describe('when given toast component', () => {
 
     await act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('toast-container')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('toast-container')).not.toBeInTheDocument();
   });
 
-  it('should not close toast if mouse is over the toast container after open', async () => {
+  it('should not close toast if mouse is over the toast container after open', () => {
     expect(screen.getByTestId('toast-container')).toBeInTheDocument();
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
 
     fireEvent.mouseEnter(screen.getByTestId('toast-container'));
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('toast-container')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('toast-container')).toBeInTheDocument();
 
     fireEvent.mouseLeave(screen.getByTestId('toast-container'));
 
-    await act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('toast-container')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('toast-container')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/wds/src/components/tooltip/index.test.tsx
+++ b/packages/wds/src/components/tooltip/index.test.tsx
@@ -4,7 +4,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
 } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 
@@ -44,7 +43,7 @@ describe('when given hover mode tooltip component', () => {
     vi.useRealTimers();
   });
 
-  it('should render tooltip content with mouse enter', async () => {
+  it('should render tooltip content with mouse enter', () => {
     expect(screen.getByTestId('tooltip-trigger')).toBeInTheDocument();
     expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
 
@@ -53,21 +52,17 @@ describe('when given hover mode tooltip component', () => {
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
 
     act(() => {
       fireEvent.mouseLeave(screen.getByTestId('tooltip-trigger'));
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
   });
 
-  it('should render tooltip content with focus', async () => {
+  it('should render tooltip content with focus', () => {
     expect(screen.getByTestId('tooltip-trigger')).toBeInTheDocument();
     expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
 
@@ -76,18 +71,14 @@ describe('when given hover mode tooltip component', () => {
       vi.advanceTimersByTime(0);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
 
     act(() => {
       fireEvent.blur(screen.getByTestId('tooltip-trigger'));
       vi.advanceTimersByTime(0);
     });
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
   });
 
   it('should pass accessibility tests', async () => {
@@ -100,9 +91,7 @@ describe('when given hover mode tooltip component', () => {
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
 
     expect(
       await axe(screen.getByTestId('tooltip-content')),
@@ -132,7 +121,7 @@ describe('when given click mode tooltip component', () => {
     vi.useRealTimers();
   });
 
-  it('should render tooltip content with click', async () => {
+  it('should render tooltip content with click', () => {
     expect(screen.getByTestId('tooltip-trigger')).toBeInTheDocument();
     expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
 
@@ -141,9 +130,7 @@ describe('when given click mode tooltip component', () => {
       vi.runAllTimers();
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
   });
 });
 
@@ -167,18 +154,14 @@ describe('when given always mode tooltip component', () => {
     vi.useRealTimers();
   });
 
-  it('should keep open state', async () => {
+  it('should keep open state', () => {
     expect(screen.getByTestId('tooltip-trigger')).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
 
-    act(() => {
-      fireEvent.mouseEnter(screen.getByTestId('tooltip-trigger'));
-      fireEvent.mouseLeave(screen.getByTestId('tooltip-trigger'));
-      fireEvent.click(screen.getByTestId('tooltip-trigger'));
-    });
+    fireEvent.mouseEnter(screen.getByTestId('tooltip-trigger'));
+    fireEvent.mouseLeave(screen.getByTestId('tooltip-trigger'));
+    fireEvent.click(screen.getByTestId('tooltip-trigger'));
 
     expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
   });
@@ -216,26 +199,22 @@ describe('when given tooltip with tooltip group component', () => {
     vi.useRealTimers();
   });
 
-  it('should open the first tooltip after enter delay', async () => {
+  it('should open the first tooltip after enter delay', () => {
     act(() => {
       fireEvent.mouseEnter(screen.getByTestId('tooltip-trigger-1'));
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content-1')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content-1')).toBeInTheDocument();
   });
 
-  it('should open the second tooltip immediately when moving from the first to the second within skipDelayDuration', async () => {
+  it('should open the second tooltip immediately when moving from the first to the second within skipDelayDuration', () => {
     act(() => {
       fireEvent.mouseEnter(screen.getByTestId('tooltip-trigger-1'));
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content-1')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content-1')).toBeInTheDocument();
 
     act(() => {
       fireEvent.mouseLeave(screen.getByTestId('tooltip-trigger-1'));
@@ -243,20 +222,16 @@ describe('when given tooltip with tooltip group component', () => {
       vi.advanceTimersByTime(0);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content-2')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content-2')).toBeInTheDocument();
   });
 
-  it('should apply enter delay again if moving to another tooltip after skipDelayDuration', async () => {
+  it('should apply enter delay again if moving to another tooltip after skipDelayDuration', () => {
     act(() => {
       fireEvent.mouseEnter(screen.getByTestId('tooltip-trigger-1'));
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content-1')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content-1')).toBeInTheDocument();
 
     act(() => {
       fireEvent.mouseLeave(screen.getByTestId('tooltip-trigger-1'));
@@ -270,8 +245,6 @@ describe('when given tooltip with tooltip group component', () => {
       vi.advanceTimersByTime(200);
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('tooltip-content-2')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('tooltip-content-2')).toBeInTheDocument();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    setupFiles: ['./.vitest/setup-tests.ts'],
+    setupFiles: ['.vitest/setup-tests.ts'],
     environment: 'jsdom',
     include: ['**/*.test.?(c|m)[jt]s?(x)'],
     globals: true,
+    testTimeout: 10000,
+    dangerouslyIgnoreUnhandledErrors: true,
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - SectionMessage now uses open/defaultOpen/onOpenChange for visibility and has a clearer, accessible content layout with explicit regions and aria support.
  - TabPanel and CategoryPanel support an optional mountMode for controlled mounting behavior.

- Refactor
  - Visibility logic moved from show-based to open-driven rendering and state handling.

- Chores
  - Added migration tooling to rename show props to open.
  - Tests and CI: converted many tests to synchronous assertions and tightened test/runtime config (no-cache, timeouts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->