### PR TITLE
fix(wds): fixed align to center tooltip close button

### DIFF
--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -288,10 +288,15 @@ const TooltipContent = forwardRef(
                     </FlexBox>
 
                     {closeButton && (
-                      <FlexBox sx={{ padding: '0 2px' }}>
+                      <FlexBox
+                        sx={{ padding: '0 2px', height: 'fit-content' }}
+                        flexShrink="0"
+                        alignItems="center"
+                      >
                         <IconButton
                           variant="normal"
                           size={16}
+                          aria-label="Close tooltip"
                           onClick={handleDismiss}
                         >
                           <IconClose />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility: the tooltip close button now includes an aria-label (“Close tooltip”) for screen readers.
* **Bug Fixes**
  * Refined close button layout in tooltips to prevent shrinking and ensure vertical centering, improving alignment and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->