### PR TITLE
fix(wds): fixed design is incorrectly reflected when category is active

### DIFF
--- a/packages/wds/src/components/chip-action/index.tsx
+++ b/packages/wds/src/components/chip-action/index.tsx
@@ -66,7 +66,10 @@ const ChipAction = forwardRef(
           aria-disabled={disabled}
           aria-pressed={active}
           {...props}
-          sx={[actionStyle({ variant, size, xs, sm, md, lg, xl }), props.sx]}
+          sx={[
+            actionStyle({ active, variant, size, xs, sm, md, lg, xl }),
+            props.sx,
+          ]}
         >
           {Boolean(leadingContent) && leadingContent}
           <span id={id}>{children}</span>

--- a/packages/wds/src/components/chip-action/style.ts
+++ b/packages/wds/src/components/chip-action/style.ts
@@ -108,7 +108,7 @@ const actionSizeStyle = ({ size }: ChipActionProps = {}) => {
 };
 
 const actionVariantStyle = (
-  { variant }: ChipActionProps = {},
+  { variant, active }: ChipActionProps = {},
   theme: Theme,
 ) => {
   switch (variant) {
@@ -118,10 +118,11 @@ const actionVariantStyle = (
         background-color: ${theme.semantic.fill.alternative};
         box-shadow: none;
 
-        &[aria-pressed='true'] {
+        ${active &&
+        css`
           color: ${theme.semantic.inverse.label};
           background-color: ${theme.semantic.inverse.background};
-        }
+        `}
 
         &:disabled,
         &[aria-disabled='true'] {
@@ -136,7 +137,8 @@ const actionVariantStyle = (
         background-color: transparent;
         box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.neutral};
 
-        &[aria-pressed='true'] {
+        ${active &&
+        css`
           background-color: ${addOpacity(
             theme.semantic.primary.normal,
             theme.opacity[5],
@@ -144,7 +146,7 @@ const actionVariantStyle = (
           box-shadow: inset 0 0 0 1px
             ${addOpacity(theme.semantic.primary.normal, theme.opacity[43])};
           color: ${theme.semantic.primary.normal};
-        }
+        `}
 
         &:disabled,
         &[aria-disabled='true'] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent “active” visual state for Chip Action across variants and breakpoints.

- Bug Fixes
  - Active styling no longer depends on aria-pressed, preventing missed or inconsistent active visuals.

- Style
  - Clearer color and background treatments when a Chip Action is active; no change when inactive.

- Refactor
  - Internal styling logic updated to use an explicit active state, improving reliability without altering public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->