### PR TITLE
feat(wds,wds-codemod): add tooltip size options

### DIFF
--- a/packages/wds-codemod/src/transforms/v3/compact-tooltip-migration.ts
+++ b/packages/wds-codemod/src/transforms/v3/compact-tooltip-migration.ts
@@ -177,10 +177,7 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
         if (!attributes) return;
 
         attributes.push(
-          j.jsxAttribute(
-            j.jsxIdentifier('arrow'),
-            j.jsxExpressionContainer(j.literal(false)),
-          ),
+          j.jsxAttribute(j.jsxIdentifier('size'), j.literal('small')),
         );
       });
 
@@ -188,6 +185,26 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
       .find(j.Identifier, { name: getLocalName(compactTooltipContentImport) })
       .forEach((compactTooltipContent) => {
         compactTooltipContent.value.name = tooltipContentName;
+      });
+  }
+
+  if (tooltipContentImport) {
+    root
+      .find(j.JSXElement, {
+        openingElement: {
+          name: { name: getLocalName(tooltipContentImport) },
+        },
+      })
+      .forEach((node) => {
+        const arrow = node.value.openingElement.attributes?.find(
+          (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'arrow',
+        ) as JSXAttribute | undefined;
+
+        if (!arrow) return;
+        hasChanges = true;
+        j(node)
+          .find(j.JSXAttribute, { name: { name: 'arrow' } })
+          .remove();
       });
   }
 

--- a/packages/wds/src/components/popper/index.tsx
+++ b/packages/wds/src/components/popper/index.tsx
@@ -22,6 +22,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { Box, useTheme } from '@wanteddev/wds-engine';
 
 import { PortalOrFragment } from '../portal-or-fragment';
+import { FlexBox } from '../flex-box';
 
 import {
   PopperContentProvider,
@@ -95,9 +96,9 @@ const PopperAnchor = forwardRef<
 PopperAnchor.displayName = POPPER_ANCHOR_NAME;
 
 const PopperArrow = forwardRef<
-  SVGSVGElement,
-  DefaultComponentPropsInternal<ScopedProps<PopperArrowProps, 'Popper'>, 'svg'>
->(({ overlay, __scopePopper = 'Popper', ...props }, ref) => {
+  HTMLDivElement,
+  DefaultComponentPropsInternal<ScopedProps<PopperArrowProps, 'Popper'>, 'div'>
+>(({ children, __scopePopper = 'Popper', ...props }, ref) => {
   const { onArrowChange, side, arrowX, arrowY } = usePopperContentContext(
     POPPER_ARROW_NAME,
     __scopePopper,
@@ -105,90 +106,53 @@ const PopperArrow = forwardRef<
 
   const composedRef = useComposedRefs(
     ref,
-    onArrowChange as (node: SVGSVGElement | null) => void,
+    onArrowChange as (node: HTMLDivElement | null) => void,
   );
 
   return (
-    <>
-      <Box
-        as="svg"
-        wds-component="popper-arrow"
-        ref={composedRef}
-        style={{
-          ...props.style,
-          position: 'absolute',
-          width: '24px',
-          height: '8px',
-          display: 'block',
-          left: arrowX,
-          top: arrowY,
-          right: '',
-          bottom: '',
-          [OPPOSITE_SIDE[side]]: '0px',
-          transformOrigin: {
-            top: '',
-            right: '0 0',
-            bottom: 'center 0',
-            left: '100% 0',
-          }[side],
-          transform: {
-            top: 'translateY(100%)',
-            right: 'translateY(50%) rotate(90deg) translateX(-50%)',
-            bottom: `rotate(180deg)`,
-            left: 'translateY(50%) rotate(-90deg) translateX(50%)',
-          }[side],
-        }}
-        viewBox="0 0 24 8"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        {...props}
-      >
-        <path
-          d="M11.2407 6.11563L6 0.00143462H18L12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563Z"
-          fill="currentColor"
-        />
-      </Box>
-
-      {Boolean(overlay) && (
+    <FlexBox
+      ref={composedRef}
+      wds-component="popper-arrow"
+      {...props}
+      sx={[{ width: 'fit-content', height: 'fit-content' }, props.sx]}
+      style={{
+        ...props.style,
+        position: 'absolute',
+        left: arrowX,
+        top: arrowY,
+        right: '',
+        bottom: '',
+        [OPPOSITE_SIDE[side]]: '0px',
+        transformOrigin: {
+          top: '',
+          right: '0 0',
+          bottom: 'center 0',
+          left: '100% 0',
+        }[side],
+        transform: {
+          top: 'translateY(100%)',
+          right: 'translateY(50%) rotate(90deg) translateX(-50%)',
+          bottom: `rotate(180deg)`,
+          left: 'translateY(50%) rotate(-90deg) translateX(50%)',
+        }[side],
+      }}
+    >
+      {children ?? (
         <Box
           as="svg"
-          style={{
-            ...props.style,
-            position: 'absolute',
-            width: '24px',
-            height: '8px',
-            display: 'block',
-            left: arrowX,
-            top: arrowY,
-            color: overlay,
-            right: '',
-            bottom: '',
-            [OPPOSITE_SIDE[side]]: '0px',
-            transformOrigin: {
-              top: '',
-              right: '0 0',
-              bottom: 'center 0',
-              left: '100% 0',
-            }[side],
-            transform: {
-              top: 'translateY(100%)',
-              right: 'translateY(50%) rotate(90deg) translateX(-50%)',
-              bottom: `rotate(180deg)`,
-              left: 'translateY(50%) rotate(-90deg) translateX(50%)',
-            }[side],
-          }}
-          viewBox="0 0 24 8"
+          viewBox="0 0 20 8"
+          width="20"
+          height="8"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
-          {...props}
         >
           <path
-            d="M12.7593 6.11564C12.3602 6.58125 11.6398 6.58125 11.2407 6.11563L6 0.00143462H18L12.7593 6.11564Z"
+            d="M8.07038 4.16544L6.41566 2.23494C5.71105 1.41289 5.35874 1.00187 4.93043 0.706626C4.5509 0.445007 4.129 0.250961 3.68337 0.133056C3.18047 0 2.63912 0 1.55642 0H19.4436C18.3609 0 17.8195 0 17.3166 0.133056C16.871 0.250961 16.4491 0.445007 16.0696 0.706626C15.6413 1.00186 15.289 1.41289 14.5843 2.23493L14.5843 2.23494L12.9296 4.16544L12.9296 4.16545C12.0926 5.14193 11.6741 5.63017 11.1761 5.80906C10.7391 5.96607 10.2609 5.96607 9.82386 5.80906C9.32586 5.63017 8.90737 5.14193 8.07038 4.16545L8.07038 4.16544Z"
             fill="currentColor"
           />
         </Box>
       )}
-    </>
+    </FlexBox>
   );
 });
 
@@ -225,7 +189,7 @@ const PopperContent = forwardRef<
     const [content, setContent] = useState<HTMLElement | null>(null);
     const composedRefs = useComposedRefs(ref, (node) => setContent(node));
 
-    const arrowWidth = Boolean(arrow) ? arrowSize?.width || 24 : 0;
+    const arrowWidth = Boolean(arrow) ? arrowSize?.width || 20 : 0;
     const arrowHeight = Boolean(arrow) ? arrowSize?.height || 8 : 0;
 
     const floatingPlacement = getPlacementMapper(position);
@@ -259,7 +223,7 @@ const PopperContent = forwardRef<
               element: arrow as Element,
               padding:
                 placement.includes('left') || placement.includes('right')
-                  ? 12
+                  ? 8
                   : 6,
             };
           }),
@@ -280,7 +244,7 @@ const PopperContent = forwardRef<
       if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
     }, [content]);
 
-    const [side, align] = getSideAlignFromPlacement(placementResult);
+    const [side] = getSideAlignFromPlacement(placementResult);
 
     useEffect(() => {
       setContext?.(floatingContext);
@@ -319,12 +283,7 @@ const PopperContent = forwardRef<
             arrowX={arrowX}
             arrowY={arrowY}
           >
-            <Slot
-              data-side={side}
-              data-align={align}
-              ref={composedRefs}
-              {...props}
-            />
+            <Slot ref={composedRefs} {...props} />
           </PopperContentProvider>
         </Box>
       </PortalOrFragment>

--- a/packages/wds/src/components/popper/index.tsx
+++ b/packages/wds/src/components/popper/index.tsx
@@ -113,6 +113,7 @@ const PopperArrow = forwardRef<
     <FlexBox
       ref={composedRef}
       wds-component="popper-arrow"
+      aria-hidden
       {...props}
       sx={[{ width: 'fit-content', height: 'fit-content' }, props.sx]}
       style={{
@@ -144,6 +145,7 @@ const PopperArrow = forwardRef<
           width="20"
           height="8"
           fill="none"
+          aria-hidden
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/wds/src/components/popper/types.ts
+++ b/packages/wds/src/components/popper/types.ts
@@ -36,9 +36,5 @@ export type PopperAnchorProps = WithSxProps<{
 }>;
 
 export type PopperArrowProps = WithSxProps<{
-  /**
-   * Normally, it is not used, and only used when coloring the arrow by nesting.
-   * Used in `tooltip`'s `accent`.
-   */
-  overlay?: string;
+  children?: ReactNode;
 }>;

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -341,6 +341,7 @@ const TooltipContent = forwardRef(
                       height="8"
                       fill="none"
                       xmlns="http://www.w3.org/2000/svg"
+                      aria-hidden
                     >
                       <mask id={mediumArrowMaskId} maskUnits="userSpaceOnUse">
                         <path
@@ -372,6 +373,7 @@ const TooltipContent = forwardRef(
                       height="6"
                       fill="none"
                       xmlns="http://www.w3.org/2000/svg"
+                      aria-hidden
                     >
                       <mask id={smallArrowMaskId} maskUnits="userSpaceOnUse">
                         <path

--- a/packages/wds/src/components/tooltip/index.tsx
+++ b/packages/wds/src/components/tooltip/index.tsx
@@ -2,14 +2,12 @@ import { forwardRef, useCallback, useEffect, useId, useRef } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
-import { useTheme } from '@wanteddev/wds-engine';
+import { Box, useTheme } from '@wanteddev/wds-engine';
 import { IconClose } from '@wanteddev/wds-icon';
 
 import { DismissableLayer } from '../dismissable-layer';
 import { Popper, PopperAnchor, PopperArrow, PopperContent } from '../popper';
 import { FlexBox } from '../flex-box';
-import { Typography } from '../typography';
-import { addOpacity } from '../../utils';
 import { IconButton } from '../icon-button';
 import { createScope } from '../../hooks/internal/use-scope-context';
 import { NoSsr } from '../no-ssr';
@@ -27,7 +25,11 @@ import {
   TOOLTIP_NAME,
   TOOLTIP_TRIGGER_NAME,
 } from './constants';
-import { tooltipContentStyle, tooltipWrapperStyle } from './style';
+import {
+  tooltipContentShortcutStyle,
+  tooltipContentStyle,
+  tooltipWrapperStyle,
+} from './style';
 import { useTooltip } from './hooks';
 
 import type {
@@ -183,11 +185,10 @@ TooltipTrigger.displayName = TOOLTIP_TRIGGER_NAME;
 const TooltipContent = forwardRef(
   <T extends ElementType = 'div'>(
     {
-      arrow = true,
       action,
       children,
       position = 'top-center',
-      offset = 2,
+      offset = 4,
       container,
       disablePortal,
       closeButton,
@@ -195,6 +196,13 @@ const TooltipContent = forwardRef(
       referenceHiddenOffsets,
       setContext,
       forceMount = false,
+      shortcut,
+      size = 'medium',
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
       as,
       sx,
       ...props
@@ -216,15 +224,18 @@ const TooltipContent = forwardRef(
       handlePointerDownOutside,
     } = useTooltipContext(TOOLTIP_CONTENT_NAME);
 
+    const id = useId();
+
     const composedRef = useComposedRefs(ref, containerRef as ForwardedRef<T>);
 
     const isAlways = mode === 'always';
 
+    const Component = as ?? Slot;
+
     const theme = useTheme();
 
-    const overlay = addOpacity(theme.semantic.primary.normal, theme.opacity[5]);
-
-    const Component = as ?? Slot;
+    const mediumArrowMaskId = useId();
+    const smallArrowMaskId = useId();
 
     return (
       <AnimationPresence present={open || forceMount}>
@@ -240,6 +251,7 @@ const TooltipContent = forwardRef(
             role="tooltip"
             data-status={open ? 'open' : 'close'}
             id={containerId}
+            aria-labelledby={id}
             container={container}
             disablePortal={disablePortal}
             offset={offset}
@@ -255,26 +267,39 @@ const TooltipContent = forwardRef(
             }}
           >
             <Component ref={composedRef} {...props}>
-              <FlexBox sx={[tooltipWrapperStyle, sx]}>
-                <FlexBox sx={tooltipContentStyle}>
+              <FlexBox
+                sx={[tooltipWrapperStyle({ size, xs, sm, md, lg, xl }), sx]}
+              >
+                <FlexBox data-role="tooltip-content" sx={tooltipContentStyle}>
                   <FlexBox gap="8px" sx={{ zIndex: 1 }}>
                     <FlexBox
                       flexDirection="column"
                       gap="6px"
-                      sx={{
-                        padding: '0px 2px',
-                      }}
+                      data-role="tooltip-content-text-wrapper"
                     >
-                      <Typography
-                        variant="label1"
-                        weight="medium"
-                        sx={{
-                          wordBreak: 'keep-all',
-                          overflowWrap: 'anywhere',
-                        }}
-                      >
-                        {children}
-                      </Typography>
+                      <FlexBox gap="4px">
+                        <Box
+                          id={id}
+                          as="span"
+                          data-role="tooltip-content-text"
+                          sx={{
+                            wordBreak: 'keep-all',
+                            overflowWrap: 'anywhere',
+                          }}
+                        >
+                          {children}
+                        </Box>
+
+                        {shortcut && (
+                          <Box
+                            as="span"
+                            data-role="tooltip-content-shortcut"
+                            sx={tooltipContentShortcutStyle}
+                          >
+                            {shortcut}
+                          </Box>
+                        )}
+                      </FlexBox>
 
                       {Boolean(action) && (
                         <FlexBox
@@ -289,11 +314,13 @@ const TooltipContent = forwardRef(
 
                     {closeButton && (
                       <FlexBox
-                        sx={{ padding: '0 2px', height: 'fit-content' }}
+                        sx={{ height: 'fit-content' }}
                         flexShrink="0"
                         alignItems="center"
+                        data-role="tooltip-content-close-button-wrapper"
                       >
                         <IconButton
+                          data-role="tooltip-content-close-button"
                           variant="normal"
                           size={16}
                           aria-label="Close tooltip"
@@ -305,7 +332,69 @@ const TooltipContent = forwardRef(
                     )}
                   </FlexBox>
 
-                  {arrow && <PopperArrow overlay={overlay} {...scopes} />}
+                  <PopperArrow {...scopes}>
+                    <Box
+                      as="svg"
+                      data-role="tooltip-arrow-medium"
+                      viewBox="0 0 20 8"
+                      width="20"
+                      height="8"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <mask id={mediumArrowMaskId} maskUnits="userSpaceOnUse">
+                        <path
+                          d="M8.07038 4.16544L6.41566 2.23494C5.71105 1.41289 5.35874 1.00187 4.93043 0.706626C4.5509 0.445007 4.129 0.250961 3.68337 0.133056C3.18047 0 2.63912 0 1.55642 0H19.4436C18.3609 0 17.8195 0 17.3166 0.133056C16.871 0.250961 16.4491 0.445007 16.0696 0.706626C15.6413 1.00186 15.289 1.41289 14.5843 2.23493L14.5843 2.23494L12.9296 4.16544L12.9296 4.16545C12.0926 5.14193 11.6741 5.63017 11.1761 5.80906C10.7391 5.96607 10.2609 5.96607 9.82386 5.80906C9.32586 5.63017 8.90737 5.14193 8.07038 4.16545L8.07038 4.16544Z"
+                          fill="white"
+                        />
+                      </mask>
+                      <g mask={`url(#${mediumArrowMaskId})`}>
+                        <rect
+                          opacity="0.88"
+                          width="20"
+                          height="8"
+                          fill={theme.semantic.inverse.background}
+                        />
+                        <rect
+                          opacity="0.05"
+                          width="20"
+                          height="8"
+                          fill={theme.semantic.primary.normal}
+                        />
+                      </g>
+                    </Box>
+
+                    <Box
+                      as="svg"
+                      data-role="tooltip-arrow-small"
+                      viewBox="0 0 14 6"
+                      width="14"
+                      height="6"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <mask id={smallArrowMaskId} maskUnits="userSpaceOnUse">
+                        <path
+                          d="M5.58 3.44L4.92 2.56C4.216 1.62134 3.864 1.15201 3.4179 0.813504C3.02279 0.513696 2.57537 0.289985 2.09846 0.153782C1.55999 0 0.973329 0 -0.2 0H15.2C14.0267 0 13.44 0 12.9015 0.153782C12.4246 0.289985 11.9772 0.513696 11.5821 0.813504C11.136 1.152 10.784 1.62133 10.08 2.55999L10.08 2.56L9.42 3.44L9.41999 3.44001C8.76864 4.30848 8.44296 4.74271 8.04371 4.89799C7.69399 5.034 7.30601 5.034 6.95629 4.89799C6.55703 4.74271 6.23136 4.30848 5.58 3.44Z"
+                          fill="white"
+                        />
+                      </mask>
+                      <g mask={`url(#${smallArrowMaskId})`}>
+                        <rect
+                          opacity="0.88"
+                          width="14"
+                          height="6"
+                          fill={theme.semantic.inverse.background}
+                        />
+                        <rect
+                          opacity="0.05"
+                          width="14"
+                          height="6"
+                          fill={theme.semantic.primary.normal}
+                        />
+                      </g>
+                    </Box>
+                  </PopperArrow>
                 </FlexBox>
               </FlexBox>
             </Component>

--- a/packages/wds/src/components/tooltip/style.ts
+++ b/packages/wds/src/components/tooltip/style.ts
@@ -1,7 +1,12 @@
 import { css, keyframes } from '@wanteddev/wds-engine';
 
-import { addOpacity } from '../../utils';
+import {
+  addOpacity,
+  createResponsiveStyle,
+  typographyStyle,
+} from '../../utils';
 
+import type { TooltipContentProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';
 
 const mountKeyframes = keyframes`
@@ -22,22 +27,117 @@ const unmountKeyframes = keyframes`
   }
 `;
 
-export const tooltipWrapperStyle = css`
-  border-radius: 8px;
-  backdrop-filter: blur(32px);
-  max-width: 280px;
+export const tooltipWrapperStyle =
+  ({ size, xs, sm, md, lg, xl }: TooltipContentProps) =>
+  (theme: Theme) => css`
+    backdrop-filter: blur(32px);
+    max-width: 280px;
 
-  &[data-status='open'] {
-    animation: ${mountKeyframes} 200ms ease-in-out;
-  }
+    &[data-status='open'] {
+      animation: ${mountKeyframes} 200ms ease-in-out;
+    }
 
-  &[data-status='close'] {
-    animation: ${unmountKeyframes} 200ms ease-in-out;
+    &[data-status='close'] {
+      animation: ${unmountKeyframes} 200ms ease-in-out;
+    }
+
+    ${tooltipWrapperSizeStyle({ size })}
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        ${tooltipWrapperSizeStyle({ size: params?.size })}
+        ${params?.sx}
+      `,
+    )}
+  `;
+
+export const tooltipWrapperSizeStyle = ({
+  size,
+}: Pick<TooltipContentProps, 'size'>) => {
+  switch (size) {
+    case 'small':
+      return css`
+        border-radius: 6px;
+
+        [data-role='tooltip-content-text'],
+        [data-role='tooltip-content-shortcut'] {
+          ${typographyStyle('caption2', 'medium')}
+        }
+
+        [data-role='tooltip-content-text-wrapper'] {
+          padding: 0px;
+        }
+
+        [data-role='tooltip-content'] {
+          padding: 5px 8px;
+        }
+
+        [data-role='tooltip-content-close-button'] {
+          font-size: 10px;
+
+          & > [wds-component='with-interaction'] {
+            width: calc(100% + 8px);
+            height: calc(100% + 8px);
+          }
+        }
+
+        [data-role='tooltip-content-close-button-wrapper'] {
+          padding: 2px 0px;
+        }
+
+        [data-role='tooltip-arrow-medium'] {
+          display: none;
+        }
+
+        [data-role='tooltip-arrow-small'] {
+          display: initial;
+        }
+      `;
+    case 'medium':
+      return css`
+        border-radius: 8px;
+
+        [data-role='tooltip-content-text'],
+        [data-role='tooltip-content-shortcut'] {
+          ${typographyStyle('label1', 'medium')}
+        }
+
+        [data-role='tooltip-content-text-wrapper'] {
+          padding: 0px 2px;
+        }
+
+        [data-role='tooltip-content'] {
+          padding: 8px 10px;
+        }
+
+        [data-role='tooltip-content-close-button'] {
+          font-size: 16px;
+
+          & > [wds-component='with-interaction'] {
+            width: calc(100% + 16px);
+            height: calc(100% + 16px);
+          }
+        }
+
+        [data-role='tooltip-content-close-button-wrapper'] {
+          padding: 2px;
+        }
+
+        [data-role='tooltip-arrow-medium'] {
+          display: initial;
+        }
+
+        [data-role='tooltip-arrow-small'] {
+          display: none;
+        }
+      `;
   }
-`;
+};
 
 export const tooltipContentStyle = (theme: Theme) => css`
-  padding: 10px;
   border-radius: inherit;
   background-color: ${addOpacity(
     theme.semantic.inverse.background,
@@ -67,8 +167,10 @@ export const tooltipContentStyle = (theme: Theme) => css`
   [wds-component='with-interaction'] {
     background: ${theme.semantic.inverse.label};
   }
+`;
 
-  & [wds-component='popper-arrow'] {
-    color: ${addOpacity(theme.semantic.inverse.background, theme.opacity[88])};
-  }
+export const tooltipContentShortcutStyle = (theme: Theme) => css`
+  color: ${addOpacity(theme.semantic.inverse.label, theme.opacity[61])};
+  width: fit-content;
+  flex-shrink: 0;
 `;

--- a/packages/wds/src/components/tooltip/types.ts
+++ b/packages/wds/src/components/tooltip/types.ts
@@ -1,4 +1,8 @@
-import type { WithSxProps } from '@wanteddev/wds-engine';
+import type {
+  Merge,
+  ResponsiveProps,
+  WithSxProps,
+} from '@wanteddev/wds-engine';
 import type { SlotProps } from '@radix-ui/react-slot';
 import type { DismissableLayerProps } from '@radix-ui/react-dismissable-layer';
 import type { PropsWithChildren, ReactNode } from 'react';
@@ -38,10 +42,17 @@ export type TooltipProps = {
 
 export type TooltipTriggerProps = SlotProps;
 
-export type TooltipContentProps = WithSxProps<{
-  arrow?: boolean;
-  action?: ReactNode;
+type TooltipDefaultProps = WithSxProps<{
   children?: ReactNode;
+  /**
+   * @deprecated
+   * tooltip should not have a focusable element.
+   */
+  action?: ReactNode;
+  /**
+   * @deprecated
+   * tooltip should not have a focusable element.
+   */
   closeButton?: boolean;
   offset?: PopperContentProps['offset'];
   position?: PopperContentProps['position'];
@@ -60,7 +71,18 @@ export type TooltipContentProps = WithSxProps<{
    */
   setContext?: PopperContentProps['setContext'];
   forceMount?: boolean;
+  size?: 'small' | 'medium';
+  shortcut?: ReactNode;
 }>;
+
+type TooltipResponsiveProps = ResponsiveProps<
+  Pick<TooltipDefaultProps, 'size'>
+>;
+
+export type TooltipContentProps = Merge<
+  TooltipDefaultProps,
+  TooltipResponsiveProps
+>;
 
 export type TooltipContentWrapperProps = {
   isAlways?: boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - TooltipContent adds responsive sizes (small/medium) with breakpoint overrides and an optional shortcut hint; close/action areas remain accessible.

- Style
  - Arrow visuals updated (smaller geometry and refined placement), spacing, typography, and open/close animations improved for consistent rendering.

- Chores
  - Migration automatically removes the deprecated arrow prop and maps tooltip usage to the new sizing model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->