### PR TITLE
feat(wds,wds-theme,wds-codemod): add spread shadow theme, update popover design

### DIFF
--- a/packages/wds-codemod/src/transforms/v3/shadow-migration.ts
+++ b/packages/wds-codemod/src/transforms/v3/shadow-migration.ts
@@ -43,7 +43,8 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
         parent.parent.value.object.type !== 'MemberExpression' ||
         parent.parent.value.object.property.type !== 'Identifier' ||
         parent.parent.value.object.property.name !== 'shadow' ||
-        parent.parent.value.property.type !== 'Identifier'
+        parent.parent.value.property.type !== 'Identifier' ||
+        parent.parent.parent.value.type === 'MemberExpression'
       ) {
         return;
       }
@@ -51,7 +52,15 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
       const name = parent.parent.value.property.name;
 
       if (migrationSet.has(name)) {
-        parent.parent.value.property.name = migrationSet.get(name);
+        j(parent.parent).replaceWith(
+          j.memberExpression(
+            j.memberExpression(
+              parent.parent.value.object,
+              j.identifier('normal'),
+            ),
+            j.identifier(migrationSet.get(name)!),
+          ),
+        );
       }
     });
 

--- a/packages/wds-theme/src/theme/index.ts
+++ b/packages/wds-theme/src/theme/index.ts
@@ -59,7 +59,10 @@ const addVarPrefix = (obj: any, prefix: string) => {
 
     if (typeof obj[key] === 'object') {
       newObj[key] = addVarPrefix(obj[key], originPrefix);
-    } else if (typeof obj[key] === 'string' && obj[key].startsWith('#')) {
+    } else if (
+      typeof obj[key] === 'string' &&
+      (obj[key].startsWith('#') || prefix.includes('shadow'))
+    ) {
       newObj[key] = `var(--${originPrefix})`;
     } else {
       newObj[key] = obj[key];

--- a/packages/wds-theme/src/theme/semantic/index.ts
+++ b/packages/wds-theme/src/theme/semantic/index.ts
@@ -94,18 +94,24 @@ export const light = {
   },
   elevation: {
     shadow: {
-      xsmall: `0px 1px 2px -1px ${addHexOpacity(atomic.neutral[10], 0.1)}`,
-      small: `0px 2px 4px -2px ${addHexOpacity(atomic.neutral[10], 0.06)}, 0px 4px 6px -1px ${addHexOpacity(atomic.neutral[10], 0.06)}`,
-      medium: `0px 4px 6px -2px ${addHexOpacity(atomic.neutral[10], 0.07)}, 0px 10px 15px -3px ${addHexOpacity(atomic.neutral[10], 0.07)}`,
-      large: `0px 6px 10px -4px ${addHexOpacity(atomic.neutral[10], 0.08)}, 0px 16px 24px -6px ${addHexOpacity(atomic.neutral[10], 0.08)}`,
-      xlarge: `0px 10px 15px -5px ${addHexOpacity(atomic.neutral[10], 0.1)}, 0px 24px 38px -10px ${addHexOpacity(atomic.neutral[10], 0.12)}`,
-    },
-    dropShadow: {
-      xsmall: `drop-shadow(0px 1px 0.5px ${addHexOpacity(atomic.neutral[10], 0.05)})`,
-      small: `drop-shadow(0px 2px 1px ${addHexOpacity(atomic.neutral[10], 0.03)}) drop-shadow(0px 4px 2.5px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
-      medium: `drop-shadow(0px 4px 2px ${addHexOpacity(atomic.neutral[10], 0.035)}) drop-shadow(0px 10px 6px ${addHexOpacity(atomic.neutral[10], 0.035)})`,
-      large: `drop-shadow(0px 6px 3px ${addHexOpacity(atomic.neutral[10], 0.04)}) drop-shadow(0px 16px 9px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
-      xlarge: `drop-shadow(0px 10px 5px ${addHexOpacity(atomic.neutral[10], 0.05)}) drop-shadow(0px 24px 14px ${addHexOpacity(atomic.neutral[10], 0.06)})`,
+      normal: {
+        xsmall: `0px 1px 2px -1px ${addHexOpacity(atomic.neutral[10], 0.1)}`,
+        small: `0px 2px 4px -2px ${addHexOpacity(atomic.neutral[10], 0.06)}, 0px 4px 6px -1px ${addHexOpacity(atomic.neutral[10], 0.06)}`,
+        medium: `0px 4px 6px -2px ${addHexOpacity(atomic.neutral[10], 0.07)}, 0px 10px 15px -3px ${addHexOpacity(atomic.neutral[10], 0.07)}`,
+        large: `0px 6px 10px -4px ${addHexOpacity(atomic.neutral[10], 0.08)}, 0px 16px 24px -6px ${addHexOpacity(atomic.neutral[10], 0.08)}`,
+        xlarge: `0px 10px 15px -5px ${addHexOpacity(atomic.neutral[10], 0.1)}, 0px 24px 38px -10px ${addHexOpacity(atomic.neutral[10], 0.12)}`,
+      },
+      drop: {
+        xsmall: `drop-shadow(0px 1px 0.5px ${addHexOpacity(atomic.neutral[10], 0.05)})`,
+        small: `drop-shadow(0px 2px 1px ${addHexOpacity(atomic.neutral[10], 0.03)}) drop-shadow(0px 4px 2.5px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
+        medium: `drop-shadow(0px 4px 2px ${addHexOpacity(atomic.neutral[10], 0.035)}) drop-shadow(0px 10px 6px ${addHexOpacity(atomic.neutral[10], 0.035)})`,
+        large: `drop-shadow(0px 6px 3px ${addHexOpacity(atomic.neutral[10], 0.04)}) drop-shadow(0px 16px 9px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
+        xlarge: `drop-shadow(0px 10px 5px ${addHexOpacity(atomic.neutral[10], 0.05)}) drop-shadow(0px 24px 14px ${addHexOpacity(atomic.neutral[10], 0.06)})`,
+      },
+      spread: {
+        small: `0px 0px 60px 0px ${addHexOpacity(atomic.neutral[10], 0.1)}`,
+        medium: `0px 15px 75px 0px ${addHexOpacity(atomic.neutral[10], 0.16)}`,
+      },
     },
   },
 };
@@ -202,18 +208,24 @@ export const dark = {
   },
   elevation: {
     shadow: {
-      xsmall: `0px 1px 2px -1px ${addHexOpacity(atomic.neutral[10], 0.1)}`,
-      small: `0px 2px 4px -2px ${addHexOpacity(atomic.neutral[10], 0.06)}, 0px 4px 6px -1px ${addHexOpacity(atomic.neutral[10], 0.06)}`,
-      medium: `0px 4px 6px -2px ${addHexOpacity(atomic.neutral[10], 0.07)}, 0px 10px 15px -3px ${addHexOpacity(atomic.neutral[10], 0.07)}`,
-      large: `0px 6px 10px -4px ${addHexOpacity(atomic.neutral[10], 0.08)}, 0px 16px 24px -6px ${addHexOpacity(atomic.neutral[10], 0.08)}`,
-      xlarge: `0px 10px 15px -5px ${addHexOpacity(atomic.neutral[10], 0.1)}, 0px 24px 38px -10px ${addHexOpacity(atomic.neutral[10], 0.12)}`,
-    },
-    dropShadow: {
-      xsmall: `drop-shadow(0px 1px 0.5px ${addHexOpacity(atomic.neutral[10], 0.05)})`,
-      small: `drop-shadow(0px 2px 1px ${addHexOpacity(atomic.neutral[10], 0.03)}) drop-shadow(0px 4px 2.5px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
-      medium: `drop-shadow(0px 4px 2px ${addHexOpacity(atomic.neutral[10], 0.035)}) drop-shadow(0px 10px 6px ${addHexOpacity(atomic.neutral[10], 0.035)})`,
-      large: `drop-shadow(0px 6px 3px ${addHexOpacity(atomic.neutral[10], 0.04)}) drop-shadow(0px 16px 9px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
-      xlarge: `drop-shadow(0px 10px 5px ${addHexOpacity(atomic.neutral[10], 0.05)}) drop-shadow(0px 24px 14px ${addHexOpacity(atomic.neutral[10], 0.06)})`,
+      normal: {
+        xsmall: `0px 1px 2px -1px ${addHexOpacity(atomic.neutral[10], 0.1)}`,
+        small: `0px 2px 4px -2px ${addHexOpacity(atomic.neutral[10], 0.06)}, 0px 4px 6px -1px ${addHexOpacity(atomic.neutral[10], 0.06)}`,
+        medium: `0px 4px 6px -2px ${addHexOpacity(atomic.neutral[10], 0.07)}, 0px 10px 15px -3px ${addHexOpacity(atomic.neutral[10], 0.07)}`,
+        large: `0px 6px 10px -4px ${addHexOpacity(atomic.neutral[10], 0.08)}, 0px 16px 24px -6px ${addHexOpacity(atomic.neutral[10], 0.08)}`,
+        xlarge: `0px 10px 15px -5px ${addHexOpacity(atomic.neutral[10], 0.1)}, 0px 24px 38px -10px ${addHexOpacity(atomic.neutral[10], 0.12)}`,
+      },
+      drop: {
+        xsmall: `drop-shadow(0px 1px 0.5px ${addHexOpacity(atomic.neutral[10], 0.05)})`,
+        small: `drop-shadow(0px 2px 1px ${addHexOpacity(atomic.neutral[10], 0.03)}) drop-shadow(0px 4px 2.5px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
+        medium: `drop-shadow(0px 4px 2px ${addHexOpacity(atomic.neutral[10], 0.035)}) drop-shadow(0px 10px 6px ${addHexOpacity(atomic.neutral[10], 0.035)})`,
+        large: `drop-shadow(0px 6px 3px ${addHexOpacity(atomic.neutral[10], 0.04)}) drop-shadow(0px 16px 9px ${addHexOpacity(atomic.neutral[10], 0.03)})`,
+        xlarge: `drop-shadow(0px 10px 5px ${addHexOpacity(atomic.neutral[10], 0.05)}) drop-shadow(0px 24px 14px ${addHexOpacity(atomic.neutral[10], 0.06)})`,
+      },
+      spread: {
+        small: `0px 0px 60px 0px ${addHexOpacity(atomic.neutral[10], 0.1)}`,
+        medium: `0px 15px 75px 0px ${addHexOpacity(atomic.neutral[10], 0.16)}`,
+      },
     },
   },
 };

--- a/packages/wds-theme/src/types/index.ts
+++ b/packages/wds-theme/src/types/index.ts
@@ -30,20 +30,10 @@ export type ThemeShadowToken = PickThemeShadowToken<
   ObjectToNestedKeys<Pick<Theme, 'semantic'>>
 >;
 
-type PickThemeDropShadowToken<T extends string> =
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  T extends `semantic.elevation.dropShadow.${infer _}` ? T : never;
-
-export type ThemeDropShadowToken = PickThemeDropShadowToken<
-  ObjectToNestedKeys<Pick<Theme, 'semantic'>>
->;
-
 export type ThemeColorsToken =
   | ObjectToNestedKeys<Pick<Theme, 'atomic'>>
   | Exclude<
       ObjectToNestedKeys<Pick<Theme, 'semantic'>>,
-      | 'semantic.platform.ios.navigation'
-      | ThemeShadowToken
-      | ThemeDropShadowToken
+      'semantic.platform.ios.navigation' | ThemeShadowToken
     >;
 export type ThemeOpacityToken = ObjectToNestedKeys<Pick<Theme, 'opacity'>>;

--- a/packages/wds/scripts/build.ts
+++ b/packages/wds/scripts/build.ts
@@ -6,10 +6,10 @@ import { darkOriginTheme, lightOriginTheme } from '@wanteddev/wds-engine';
 import reset from './reset';
 
 const isHexColor = (value: string) =>
-  /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})/i.test(value);
+  /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})/i.test(value);
 
 const isHexWithOpacity = (hexColor: string) =>
-  /#([a-f0-9]{8}|[a-f0-9]{4})\b/i.test(hexColor);
+  /^#([a-f0-9]{8}|[a-f0-9]{4})\b/i.test(hexColor);
 
 const hexToRgb = (hexColor: string) => {
   const parsedColor = hexColor.replace(

--- a/packages/wds/src/components/autocomplete/style.ts
+++ b/packages/wds/src/components/autocomplete/style.ts
@@ -4,7 +4,7 @@ import type { Theme } from '@wanteddev/wds-engine';
 
 export const autocompleteListStyle = (theme: Theme) => css`
   padding: 0px;
-  box-shadow: ${theme.semantic.elevation.shadow.small};
+  box-shadow: ${theme.semantic.elevation.shadow.normal.small};
   border-radius: 16px;
   background-color: ${theme.semantic.background.elevated.normal};
 `;

--- a/packages/wds/src/components/date-picker/style.ts
+++ b/packages/wds/src/components/date-picker/style.ts
@@ -4,7 +4,7 @@ import type { Theme } from '@wanteddev/wds-engine';
 
 export const datePopperStyle = (theme: Theme) => css`
   background-color: ${theme.semantic.background.elevated.normal};
-  box-shadow: ${theme.semantic.elevation.shadow.small};
+  box-shadow: ${theme.semantic.elevation.shadow.normal.small};
   border-radius: 12px;
   border: 1px solid ${theme.semantic.line.solid.neutral};
   overflow: hidden;

--- a/packages/wds/src/components/list/index.tsx
+++ b/packages/wds/src/components/list/index.tsx
@@ -19,6 +19,7 @@ import { IconButtonProvider } from '../icon-button/contexts';
 import { TextButtonProvider } from '../text-button/contexts';
 import { CheckboxProvider } from '../checkbox/contexts';
 import { RadioProvider } from '../radio/contexts';
+import { isElementDisabled } from '../../utils/internal/element';
 
 import {
   LIST_CELL_CONTENT_NAME,
@@ -149,14 +150,11 @@ const ListCell = forwardRef(
               }
             })}
             onClick={composeEventHandlers(props.onClick, (e) => {
+              const target = e.target as HTMLElement;
               if (
-                (e.target as HTMLElement)
-                  .getAttribute('disabled')
-                  ?.toString() === 'true' ||
-                (e.target as HTMLElement).ariaDisabled?.toString() === 'true' ||
-                (e.target as HTMLElement).ariaHidden?.toString() === 'true' ||
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                (e.target as HTMLElement).hidden?.toString() === 'true'
+                isElementDisabled(target) ||
+                target.ariaHidden?.toString() === 'true' ||
+                target.hidden.toString() === 'true'
               ) {
                 return;
               }

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -17,6 +17,7 @@ import { FlexBox } from '../flex-box';
 import { Typography } from '../typography';
 import { usePopoverContext } from '../popover/contexts';
 import { createScope } from '../../hooks/internal/use-scope-context';
+import { isElementDisabled } from '../../utils/internal/element';
 
 import {
   MENU_ACTION_AREA_CONTENT_NAME,
@@ -109,8 +110,7 @@ const MenuTrigger = forwardRef<HTMLElement, MenuTriggerProps>((props, ref) => {
       onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
         if (
           open ||
-          e.currentTarget.ariaDisabled?.toString() === 'true' ||
-          e.currentTarget.getAttribute('disabled')?.toString() === 'true' ||
+          isElementDisabled(e.currentTarget) ||
           !ARROW_KEYS.includes(e.key)
         ) {
           return;

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -151,6 +151,7 @@ const MenuContent = forwardRef(
           disablePortal={disablePortal}
           forceMount={forceMount}
           aria-label="Select menu"
+          variant="custom"
           {...props}
           {...scopes}
           sx={[menuPopoverContentStyle, sx]}

--- a/packages/wds/src/components/menu/style.ts
+++ b/packages/wds/src/components/menu/style.ts
@@ -6,9 +6,10 @@ import type { Theme } from '@wanteddev/wds-engine';
 export const menuPopoverContentStyle = (theme: Theme) => css`
   padding: 0;
   width: 320px;
-  filter: none;
-  box-shadow: ${theme.semantic.elevation.shadow.small};
+  box-shadow: ${theme.semantic.elevation.shadow.normal.small};
   border-radius: 16px;
+  backdrop-filter: none;
+  background-color: transparent;
 `;
 
 export const menuScrollAreaStyle = (theme: Theme) => css`

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -143,6 +143,8 @@ const PopoverContent = forwardRef(
     }: PolymorphicPropsInternal<ScopedProps<PopoverContentProps, 'Popover'>, T>,
     ref: ForwardedRef<T>,
   ) => {
+    const headingId = useId();
+    const descriptionId = useId();
     const { contentId, open, onOpenChange } = usePopoverContext(
       POPOVER_CONTENT_NAME,
       __scopePopover,
@@ -185,6 +187,9 @@ const PopoverContent = forwardRef(
               <FlexBox
                 role="dialog"
                 id={contentId}
+                aria-modal={disableOutsidePointerEvents || trapped}
+                aria-describedby={descriptionId}
+                aria-labelledby={heading ? headingId : undefined}
                 ref={ref}
                 as={as}
                 gap="8px"
@@ -208,6 +213,7 @@ const PopoverContent = forwardRef(
                       >
                         {heading && (
                           <Typography
+                            id={headingId}
                             variant="headline2"
                             weight="bold"
                             color="semantic.label.normal"
@@ -218,6 +224,7 @@ const PopoverContent = forwardRef(
                         )}
 
                         <Typography
+                          id={descriptionId}
                           variant="body2-reading"
                           weight="medium"
                           color="semantic.label.neutral"

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -188,8 +188,12 @@ const PopoverContent = forwardRef(
                 role="dialog"
                 id={contentId}
                 aria-modal={disableOutsidePointerEvents || trapped}
-                aria-describedby={descriptionId}
-                aria-labelledby={heading ? headingId : undefined}
+                aria-describedby={
+                  variant !== 'custom' ? descriptionId : undefined
+                }
+                aria-labelledby={
+                  variant !== 'custom' && heading ? headingId : undefined
+                }
                 ref={ref}
                 as={as}
                 gap="8px"

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -2,14 +2,17 @@ import { forwardRef, useId } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Slot } from '@radix-ui/react-slot';
 import { composeEventHandlers } from '@radix-ui/primitive';
-import { Box } from '@wanteddev/wds-engine';
+import { IconClose } from '@wanteddev/wds-icon';
 
 import { DismissableLayer } from '../dismissable-layer';
-import { Popper, PopperAnchor, PopperArrow, PopperContent } from '../popper';
+import { Popper, PopperAnchor, PopperContent } from '../popper';
 import { FlexBox } from '../flex-box';
 import { FocusScope } from '../focus-scope';
 import { createScope } from '../../hooks/internal/use-scope-context';
 import { AnimationPresence } from '../animation-presence';
+import { IconButton } from '../icon-button';
+import { TextButtonProvider } from '../text-button/contexts';
+import { Typography } from '../typography';
 
 import { PopoverProvider, usePopoverContext } from './contexts';
 import {
@@ -110,7 +113,6 @@ PopoverTrigger.displayName = POPOVER_TRIGGER_NAME;
 const PopoverContent = forwardRef(
   <T extends ElementType = 'div'>(
     {
-      arrow,
       position,
       offset = 10,
       loop = true,
@@ -132,6 +134,10 @@ const PopoverContent = forwardRef(
       onPointerDownOutside,
       onDismiss,
       disableOutsidePointerEvents = true,
+      closeButton = false,
+      action,
+      variant = 'normal',
+      title,
       __scopePopover = 'Popover',
       ...props
     }: PolymorphicPropsInternal<ScopedProps<PopoverContentProps, 'Popover'>, T>,
@@ -176,18 +182,78 @@ const PopoverContent = forwardRef(
                 onDismiss?.();
               }}
             >
-              <Box
+              <FlexBox
                 role="dialog"
                 id={contentId}
                 ref={ref}
-                as={as ?? FlexBox}
+                as={as}
+                gap="8px"
                 {...props}
                 sx={[popoverStyle, props.sx]}
               >
-                {children}
+                {variant === 'custom' ? (
+                  children
+                ) : (
+                  <>
+                    <FlexBox
+                      flexDirection="column"
+                      gap="6px"
+                      data-role="popover-content-wrapper"
+                      sx={{ paddingInline: '4px' }}
+                    >
+                      {title && (
+                        <Typography
+                          variant="headline2"
+                          weight="bold"
+                          color="semantic.label.normal"
+                        >
+                          {title}
+                        </Typography>
+                      )}
 
-                {arrow && <PopperArrow {...scopes} />}
-              </Box>
+                      <Typography
+                        variant="body2-reading"
+                        weight="medium"
+                        color="semantic.label.neutral"
+                      >
+                        {children}
+                      </Typography>
+
+                      {action && (
+                        <TextButtonProvider assistive="semantic.label.alternative">
+                          <FlexBox
+                            data-role="popover-content-action"
+                            flexShrink="0"
+                            alignItems="center"
+                            gap="16px"
+                            sx={{ marginTop: '4px', height: '20px' }}
+                          >
+                            {action}
+                          </FlexBox>
+                        </TextButtonProvider>
+                      )}
+                    </FlexBox>
+
+                    {closeButton && (
+                      <FlexBox
+                        data-role="popover-content-close-button"
+                        flexShrink="0"
+                        alignItems="center"
+                        justifyContent="center"
+                        sx={{ padding: '4px', height: 'fit-content' }}
+                      >
+                        <IconButton
+                          size={16}
+                          onClick={() => onOpenChange(false)}
+                          aria-label="Close dialog"
+                        >
+                          <IconClose />
+                        </IconButton>
+                      </FlexBox>
+                    )}
+                  </>
+                )}
+              </FlexBox>
             </DismissableLayer>
           </FocusScope>
         </PopperContent>

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -13,6 +13,7 @@ import { AnimationPresence } from '../animation-presence';
 import { IconButton } from '../icon-button';
 import { TextButtonProvider } from '../text-button/contexts';
 import { Typography } from '../typography';
+import { isElementDisabled } from '../../utils/internal/element';
 
 import { PopoverProvider, usePopoverContext } from './contexts';
 import {
@@ -94,11 +95,7 @@ const PopoverTrigger = forwardRef<HTMLElement, PopoverTriggerProps>(
           id={triggerId}
           ref={ref}
           onClick={composeEventHandlers(props.onClick, (e) => {
-            if (
-              !open &&
-              e.currentTarget.ariaDisabled?.toString() !== 'true' &&
-              e.currentTarget.getAttribute('disabled')?.toString() !== 'true'
-            ) {
+            if (!open && !isElementDisabled(e.currentTarget)) {
               onOpenChange(true);
             }
           })}

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -137,7 +137,7 @@ const PopoverContent = forwardRef(
       closeButton = false,
       action,
       variant = 'normal',
-      title,
+      heading,
       __scopePopover = 'Popover',
       ...props
     }: PolymorphicPropsInternal<ScopedProps<PopoverContentProps, 'Popover'>, T>,
@@ -197,27 +197,35 @@ const PopoverContent = forwardRef(
                   <>
                     <FlexBox
                       flexDirection="column"
-                      gap="6px"
                       data-role="popover-content-wrapper"
                       sx={{ paddingInline: '4px' }}
+                      gap="10px"
                     >
-                      {title && (
-                        <Typography
-                          variant="headline2"
-                          weight="bold"
-                          color="semantic.label.normal"
-                        >
-                          {title}
-                        </Typography>
-                      )}
-
-                      <Typography
-                        variant="body2-reading"
-                        weight="medium"
-                        color="semantic.label.neutral"
+                      <FlexBox
+                        flexDirection="column"
+                        data-role="popover-content-heading-wrapper"
+                        gap="6px"
                       >
-                        {children}
-                      </Typography>
+                        {heading && (
+                          <Typography
+                            variant="headline2"
+                            weight="bold"
+                            color="semantic.label.normal"
+                            data-role="popover-content-heading"
+                          >
+                            {heading}
+                          </Typography>
+                        )}
+
+                        <Typography
+                          variant="body2-reading"
+                          weight="medium"
+                          color="semantic.label.neutral"
+                          data-role="popover-content-description"
+                        >
+                          {children}
+                        </Typography>
+                      </FlexBox>
 
                       {action && (
                         <TextButtonProvider assistive="semantic.label.alternative">
@@ -226,7 +234,7 @@ const PopoverContent = forwardRef(
                             flexShrink="0"
                             alignItems="center"
                             gap="16px"
-                            sx={{ marginTop: '4px', height: '20px' }}
+                            sx={{ height: '20px' }}
                           >
                             {action}
                           </FlexBox>

--- a/packages/wds/src/components/popover/style.ts
+++ b/packages/wds/src/components/popover/style.ts
@@ -1,17 +1,17 @@
 import { css } from '@wanteddev/wds-engine';
 
+import { addOpacity } from '../../utils';
+
 import type { Theme } from '@wanteddev/wds-engine';
 
 export const popoverStyle = (theme: Theme) => css`
-  background-color: ${theme.semantic.background.elevated.normal};
-  border-radius: 12px;
-  padding: 24px;
+  background-color: ${addOpacity(
+    theme.semantic.background.elevated.normal,
+    theme.opacity[88],
+  )};
+  border-radius: 16px;
+  padding: 16px;
   outline-style: none;
-  filter: drop-shadow(0px 2px 8px rgba(0, 0, 0, 0.12))
-    drop-shadow(0px 1px 4px rgba(0, 0, 0, 0.08))
-    drop-shadow(2px 0px 1px rgba(0, 0, 0, 0.08));
-
-  & [wds-component='popper-arrow'] {
-    color: ${theme.semantic.background.elevated.normal};
-  }
+  box-shadow: ${theme.semantic.elevation.shadow.spread.small};
+  backdrop-filter: blur(32px);
 `;

--- a/packages/wds/src/components/popover/types.ts
+++ b/packages/wds/src/components/popover/types.ts
@@ -31,7 +31,6 @@ export type PopoverContentProps = WithSxProps<
      * The floating ui context can be obtained through a callback.
      */
     setContext?: PopperContentProps['setContext'];
-    arrow?: boolean;
     /**
      * Specifies the container to be displayed by Portal.
      */
@@ -39,6 +38,10 @@ export type PopoverContentProps = WithSxProps<
     disablePortal?: PopperContentProps['disablePortal'];
     wrapperProps?: PopperContentProps['wrapperProps'];
     forceMount?: boolean;
+    closeButton?: boolean;
+    action?: ReactNode;
+    title?: ReactNode;
+    variant?: 'normal' | 'custom';
   } & Pick<
     FocusScopeProps,
     | 'trappedContent'

--- a/packages/wds/src/components/popover/types.ts
+++ b/packages/wds/src/components/popover/types.ts
@@ -40,7 +40,7 @@ export type PopoverContentProps = WithSxProps<
     forceMount?: boolean;
     closeButton?: boolean;
     action?: ReactNode;
-    title?: ReactNode;
+    heading?: ReactNode;
     variant?: 'normal' | 'custom';
   } & Pick<
     FocusScopeProps,

--- a/packages/wds/src/components/select/style.ts
+++ b/packages/wds/src/components/select/style.ts
@@ -28,7 +28,7 @@ export const selectStyle =
     border: none;
     box-shadow:
       inset 0 0 0 1px ${theme.semantic.line.normal.neutral},
-      ${theme.semantic.elevation.shadow.xsmall};
+      ${theme.semantic.elevation.shadow.normal.xsmall};
     background-color: ${theme.semantic.background.transparent.normal};
     backdrop-filter: blur(32px);
     width: ${toCssValue(width)};
@@ -67,7 +67,7 @@ export const selectStyle =
       box-shadow:
         inset 0 0 0 1px
           ${addOpacity(theme.semantic.status.negative, theme.opacity[28])},
-        ${theme.semantic.elevation.shadow.xsmall};
+        ${theme.semantic.elevation.shadow.normal.xsmall};
     `}
 
     ${disabled
@@ -76,7 +76,7 @@ export const selectStyle =
           backdrop-filter: none;
           box-shadow:
             inset 0 0 0 1px ${theme.semantic.line.normal.alternative},
-            ${theme.semantic.elevation.shadow.xsmall};
+            ${theme.semantic.elevation.shadow.normal.xsmall};
           cursor: default;
 
           [data-role='select-placeholder']
@@ -100,7 +100,7 @@ export const selectStyle =
                         theme.semantic.status.negative,
                         theme.opacity[43],
                       )},
-                    ${theme.semantic.elevation.shadow.xsmall};
+                    ${theme.semantic.elevation.shadow.normal.xsmall};
                 `
               : css`
                   box-shadow:
@@ -109,7 +109,7 @@ export const selectStyle =
                         theme.semantic.primary.normal,
                         theme.opacity[43],
                       )},
-                    ${theme.semantic.elevation.shadow.xsmall};
+                    ${theme.semantic.elevation.shadow.normal.xsmall};
                 `}
           }
 

--- a/packages/wds/src/components/text-area/style.ts
+++ b/packages/wds/src/components/text-area/style.ts
@@ -26,7 +26,7 @@ export const textAreaWrapperStyle =
     transition: box-shadow ease 0.2s;
     box-shadow:
       inset 0 0 0 1px ${theme.semantic.line.normal.neutral},
-      ${theme.semantic.elevation.shadow.xsmall};
+      ${theme.semantic.elevation.shadow.normal.xsmall};
     border-radius: 12px;
     background-color: ${theme.semantic.background.transparent.normal};
     backdrop-filter: blur(32px);
@@ -37,7 +37,7 @@ export const textAreaWrapperStyle =
       box-shadow:
         inset 0 0 0 1px
           ${addOpacity(theme.semantic.status.negative, theme.opacity[28])},
-        ${theme.semantic.elevation.shadow.xsmall};
+        ${theme.semantic.elevation.shadow.normal.xsmall};
     `}
 
     ${disabled
@@ -46,7 +46,7 @@ export const textAreaWrapperStyle =
           backdrop-filter: none;
           box-shadow:
             inset 0 0 0 1px ${theme.semantic.line.normal.alternative},
-            ${theme.semantic.elevation.shadow.xsmall};
+            ${theme.semantic.elevation.shadow.normal.xsmall};
           cursor: default;
         `
       : css`
@@ -62,7 +62,7 @@ export const textAreaWrapperStyle =
                           theme.semantic.status.negative,
                           theme.opacity[43],
                         )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                      ${theme.semantic.elevation.shadow.normal.xsmall};
                   `
                 : css`
                     box-shadow:
@@ -71,7 +71,7 @@ export const textAreaWrapperStyle =
                           theme.semantic.primary.normal,
                           theme.opacity[43],
                         )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                      ${theme.semantic.elevation.shadow.normal.xsmall};
                   `}
             }
           }
@@ -86,7 +86,7 @@ export const textAreaWrapperStyle =
                           theme.semantic.status.negative,
                           theme.opacity[43],
                         )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                      ${theme.semantic.elevation.shadow.normal.xsmall};
                   `
                 : css`
                     box-shadow:
@@ -95,7 +95,7 @@ export const textAreaWrapperStyle =
                           theme.semantic.primary.normal,
                           theme.opacity[43],
                         )},
-                      ${theme.semantic.elevation.shadow.xsmall};
+                      ${theme.semantic.elevation.shadow.normal.xsmall};
                   `}
             }
           }

--- a/packages/wds/src/components/text-field/style.ts
+++ b/packages/wds/src/components/text-field/style.ts
@@ -34,7 +34,7 @@ export const textFieldWrapperStyle =
     align-items: center;
     border-radius: 12px;
     border: none;
-    box-shadow: ${theme.semantic.elevation.shadow.xsmall};
+    box-shadow: ${theme.semantic.elevation.shadow.normal.xsmall};
     background-color: ${theme.semantic.background.transparent.normal};
     backdrop-filter: blur(32px);
     width: ${toCssValue(width)};

--- a/packages/wds/src/components/time-picker/style.ts
+++ b/packages/wds/src/components/time-picker/style.ts
@@ -4,7 +4,7 @@ import type { Theme } from '@wanteddev/wds-engine';
 
 export const timePickerStyle = (theme: Theme) => css`
   background-color: ${theme.semantic.background.elevated.normal};
-  box-shadow: ${theme.semantic.elevation.shadow.small};
+  box-shadow: ${theme.semantic.elevation.shadow.normal.small};
   border-radius: 12px;
   border: 1px solid ${theme.semantic.line.solid.neutral};
   overflow: hidden;

--- a/packages/wds/src/components/tooltip/hooks.ts
+++ b/packages/wds/src/components/tooltip/hooks.ts
@@ -1,6 +1,8 @@
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { isElementDisabled } from '../../utils/internal/element';
+
 import { useTooltipGroupContext } from './contexts';
 
 import type { PointerDownOutsideEvent } from '../dismissable-layer/types';
@@ -168,8 +170,7 @@ export const useTooltip = ({
       if (
         latestOpen.current ||
         mode !== 'click' ||
-        e.currentTarget.ariaDisabled?.toString() === 'true' ||
-        e.currentTarget.getAttribute('disabled')?.toString() === 'true'
+        isElementDisabled(e.currentTarget)
       ) {
         return;
       }

--- a/packages/wds/src/utils/framed-style.ts
+++ b/packages/wds/src/utils/framed-style.ts
@@ -15,7 +15,7 @@ export type FramedStyleParams = {
 
 export const framedStyle = (params?: FramedStyleParams) => (theme: Theme) => {
   const {
-    shadow = 'semantic.elevation.shadow.xsmall',
+    shadow = 'semantic.elevation.shadow.normal.xsmall',
     size = 'medium',
     invalid,
     disabled,
@@ -25,7 +25,7 @@ export const framedStyle = (params?: FramedStyleParams) => (theme: Theme) => {
   const givenShadow = objectPath.get(theme, shadow);
   const boxShadow = givenShadow
     ? givenShadow
-    : theme.semantic.elevation.shadow.xsmall;
+    : theme.semantic.elevation.shadow.normal.xsmall;
 
   return css`
     ${getSizeStyle(size)}

--- a/packages/wds/src/utils/internal/element.ts
+++ b/packages/wds/src/utils/internal/element.ts
@@ -1,0 +1,7 @@
+export const isElementDisabled = (element: HTMLElement) => {
+  return (
+    (element.hasAttribute('disabled') &&
+      element.getAttribute('disabled')?.toString() !== 'false') ||
+    element.ariaDisabled?.toString() === 'true'
+  );
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Popover: optional heading, action area, close button, and a new "custom" variant; arrow prop removed.
  - Centralized disabled-state helper introduced and adopted across menu, list, tooltip, popover and related interactions.

- Style
  - Elevation tokens restructured into normal/drop/spread; shadows updated across Autocomplete, Date/Time Picker, Menu, Select, Text Field, Text Area, Framed components, and Popover (larger radius, reduced padding, backdrop blur, refined shadows, transparent menu background).

- Chores
  - Stricter hex validation; broader CSS-var detection for shadow-prefixed keys; some theme types removed; migration transform guard tightened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->