### PR TITLE
feat(wds): add min width for popover

### DIFF
--- a/packages/wds/src/components/popover/style.ts
+++ b/packages/wds/src/components/popover/style.ts
@@ -14,4 +14,5 @@ export const popoverStyle = (theme: Theme) => css`
   outline-style: none;
   box-shadow: ${theme.semantic.elevation.shadow.spread.small};
   backdrop-filter: blur(32px);
+  min-width: 140px;
 `;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated popover styling to enforce a minimum width (140px), ensuring content doesn’t appear cramped or wrap excessively.
  * Improves readability and visual consistency of popovers across the app, especially for shorter labels or dynamic content.
  * Reduces layout shifts by providing a stable baseline width for popovers in various contexts and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->