### PR TITLE
feat(wds): add controllable peek height on bottom sheet

### DIFF
--- a/packages/wds/src/components/alert/index.tsx
+++ b/packages/wds/src/components/alert/index.tsx
@@ -233,6 +233,11 @@ const AlertContainer = forwardRef(
                   if (isRightClick || disableOutsideClickClose)
                     e.preventDefault();
                 }}
+                onFocusOutside={(e) => {
+                  if (disableOutsideClickClose) {
+                    e.preventDefault();
+                  }
+                }}
                 onEscapeKeyDown={(e: KeyboardEvent) => {
                   if (disableEscapeKeyDownClose) {
                     e.preventDefault();

--- a/packages/wds/src/components/modal/constants.ts
+++ b/packages/wds/src/components/modal/constants.ts
@@ -7,3 +7,5 @@ export const MODAL_NAVIGATION_BUTTON_NAME = 'ModalNavigationButton';
 export const MODAL_CLOSE_NAME = 'ModalClose';
 
 export const BOTTOM_SHEET_SHADOW = '0 15px 75px 0 rgba(23, 23, 23, 0.16)';
+
+export const BOTTOM_SHEET_PEEK_PADDING = 12;

--- a/packages/wds/src/components/modal/helpers.tsx
+++ b/packages/wds/src/components/modal/helpers.tsx
@@ -31,3 +31,14 @@ export const calcOpacityRatio = (
 
   return 1 - (input - minPosition) / (maxPosition - minPosition);
 };
+
+export const isMouseDownOnPeek = (
+  e: React.MouseEvent | React.TouchEvent,
+  peekHeight: number,
+) => {
+  const { top } = e.currentTarget.getBoundingClientRect();
+
+  const clientY = isTouchEvent(e) ? e.touches[0]!.clientY : e.clientY;
+
+  return clientY >= top && clientY <= top + peekHeight;
+};

--- a/packages/wds/src/components/modal/hooks.ts
+++ b/packages/wds/src/components/modal/hooks.ts
@@ -3,9 +3,13 @@ import { useTheme } from '@wanteddev/wds-engine';
 
 import { getPreviousValue } from '../../utils/responsive-props';
 
-import { BOTTOM_SHEET_SHADOW, MODAL_NAME } from './constants';
+import {
+  BOTTOM_SHEET_PEEK_PADDING,
+  BOTTOM_SHEET_SHADOW,
+  MODAL_NAME,
+} from './constants';
 import { useModalContext } from './contexts';
-import { calcOpacityRatio, isTouchEvent } from './helpers';
+import { calcOpacityRatio, isMouseDownOnPeek, isTouchEvent } from './helpers';
 
 import type { RefObject } from 'react';
 import type { BreakPoint } from '@wanteddev/wds-engine';
@@ -13,6 +17,7 @@ import type { ModalContainerProps } from './types';
 
 export const useDraggable = ({
   variant: givenVariant,
+  peekHeight: givenPeekHeight,
   handle: givenHandle,
   xs,
   sm,
@@ -63,6 +68,15 @@ export const useDraggable = ({
     setIsBottomSheet(variant === 'bottom');
   }, [variant, setIsBottomSheet]);
 
+  const peekHeight = useRef(
+    givenPeekHeight !== undefined ? Math.max(givenPeekHeight, 20) : undefined,
+  );
+
+  useEffect(() => {
+    peekHeight.current =
+      givenPeekHeight !== undefined ? Math.max(givenPeekHeight, 20) : undefined;
+  }, [givenPeekHeight]);
+
   const calcTopNavigationHeight = () => {
     const topNavigation = ref.current?.querySelector(
       '[wds-component="top-navigation"]',
@@ -99,7 +113,10 @@ export const useDraggable = ({
       container.style.removeProperty('transition');
       container.style.setProperty(
         '--wds-modal-translate',
-        `calc(100% - ${topNavigationHeight.current}px)`,
+        `calc(100% - ${
+          peekHeight.current ??
+          topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING
+        }px)`,
       );
       dimmerRef.current?.style.removeProperty('transition');
       dimmerRef.current?.style.removeProperty('opacity');
@@ -121,9 +138,13 @@ export const useDraggable = ({
     // In iOS, target may be undefined when long-pressing, so use try-catch
     try {
       if (
-        (e.target as HTMLElement).closest('[wds-component="top-navigation"]') ||
         (e.target as HTMLElement).closest(
           '[data-role="modal-container-grabber"]',
+        ) ||
+        isMouseDownOnPeek(
+          e,
+          peekHeight.current ??
+            topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING,
         )
       ) {
         calcTopNavigationHeight();
@@ -151,7 +172,10 @@ export const useDraggable = ({
       const clientY = isTouchEvent(e) ? e.touches[0]!.clientY : e.clientY;
 
       const minPosition = window.innerHeight - container.clientHeight;
-      const maxPosition = window.innerHeight - topNavigationHeight.current;
+      const maxPosition =
+        window.innerHeight -
+        (peekHeight.current ??
+          topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING);
 
       const handleOpacityRatioStyle = (input: number) => {
         dimmerRef.current?.style.setProperty(
@@ -171,7 +195,9 @@ export const useDraggable = ({
       // Dragging down
       if (diffY > 0) {
         if (context.visibility === 'hidden') {
-          const nextPosition = topNavigationHeight.current - diffY;
+          const nextPosition =
+            (peekHeight.current ??
+              topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING) - diffY;
           handleOpacityRatioStyle(window.innerHeight - nextPosition);
           return container.style.setProperty(
             '--wds-modal-translate',
@@ -189,7 +215,10 @@ export const useDraggable = ({
 
       // Dragging up
       if (diffY < 0 && context.visibility === 'hidden') {
-        const nextPosition = Math.abs(diffY) + topNavigationHeight.current;
+        const nextPosition =
+          Math.abs(diffY) +
+          (peekHeight.current ??
+            topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING);
 
         if (minPosition >= window.innerHeight - nextPosition) {
           handleOpacityRatioStyle(minPosition);
@@ -228,7 +257,10 @@ export const useDraggable = ({
         if (context.visibility === 'hidden') {
           container.style.setProperty(
             '--wds-modal-translate',
-            `calc(100% - ${topNavigationHeight.current}px)`,
+            `calc(100% - ${
+              peekHeight.current ??
+              topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING
+            }px)`,
           );
           container.style.setProperty('box-shadow', BOTTOM_SHEET_SHADOW);
           dimmerRef.current?.style.setProperty('opacity', '0');
@@ -245,7 +277,10 @@ export const useDraggable = ({
         context.setVisibility('hidden');
         container.style.setProperty(
           '--wds-modal-translate',
-          `calc(100% - ${topNavigationHeight.current}px)`,
+          `calc(100% - ${
+            peekHeight.current ??
+            topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING
+          }px)`,
         );
         container.style.setProperty('box-shadow', BOTTOM_SHEET_SHADOW);
         dimmerRef.current?.style.setProperty('opacity', '0');

--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -38,6 +38,7 @@ import {
   useModalNavigationContext,
 } from './contexts';
 import {
+  BOTTOM_SHEET_PEEK_PADDING,
   MODAL_CLOSE_NAME,
   MODAL_CONTAINER_NAME,
   MODAL_DIMMER_NAME,
@@ -195,6 +196,7 @@ const ModalContainer = forwardRef(
       forceMount = false,
       sticky = true,
       wrapperProps,
+      peekHeight,
       dimmer = <ModalDimmer />,
       ...props
     }: PolymorphicPropsInternal<ModalContainerProps, T>,
@@ -224,6 +226,7 @@ const ModalContainer = forwardRef(
 
     const { isBottomSheetWithHandle, handleVisibilityHidden, ...dragProps } =
       useDraggable({
+        peekHeight,
         variant,
         handle,
         xs,
@@ -318,6 +321,14 @@ const ModalContainer = forwardRef(
                   e.preventDefault();
                 }
               }}
+              onFocusOutside={(e) => {
+                if (
+                  disableOutsideClickClose ||
+                  context.visibility === 'hidden'
+                ) {
+                  e.preventDefault();
+                }
+              }}
               onDismiss={() => {
                 if (!isBottomSheetWithHandle) {
                   onOpenChange(false);
@@ -366,12 +377,18 @@ const ModalContainer = forwardRef(
                     viewportProps={{
                       sx: {
                         height: 'initial',
-                        scrollPaddingTop: topNavigationHeight,
-                        scrollPaddingBottom: actionAreaHeight,
                         ['& [data-radix-scroll-area-content]']: {
                           display: 'flex',
                           flexDirection: 'column',
                         },
+                      },
+                      style: {
+                        scrollPaddingTop:
+                          topNavigationHeight +
+                          (isBottomSheetWithHandle
+                            ? BOTTOM_SHEET_PEEK_PADDING
+                            : 0),
+                        scrollPaddingBottom: actionAreaHeight,
                       },
                     }}
                     zIndex={11}
@@ -379,11 +396,11 @@ const ModalContainer = forwardRef(
                     <FlexBox
                       flexDirection="column"
                       flex="1"
+                      data-role="modal-container-wrapper"
                       sx={{
-                        ['[data-role="modal-container-grabber"] + [wds-component="top-navigation"]']:
-                          {
-                            paddingTop: 12,
-                          },
+                        ['&:has([data-role="modal-container-grabber"])']: {
+                          paddingTop: BOTTOM_SHEET_PEEK_PADDING,
+                        },
                       }}
                       {...dragProps}
                     >
@@ -451,14 +468,15 @@ const ModalDimmer = forwardRef(
           },
         )}
         onClick={composeEventHandlers(props.onClick, (e: MouseEvent) => {
-          e.preventDefault();
           if (disableOutsideClickClose) {
+            e.preventDefault();
             return;
           }
 
           if (!isBottomSheetWithHandle) {
             onOpenChange(false);
-          } else {
+          } else if (visibility === 'visible') {
+            e.preventDefault();
             handleVisibilityHidden();
           }
         })}

--- a/packages/wds/src/components/modal/types.ts
+++ b/packages/wds/src/components/modal/types.ts
@@ -30,9 +30,14 @@ export type ModalTriggerProps = SlotProps;
 type ModalContainerDefaultProps = WithSxProps<{
   variant?: 'popup' | 'bottom' | 'full';
   /**
-   * When `variant` is not `popup`, the modal can be pulled down and up by dragging.
+   * When `variant` is `bottom`, the modal can be pulled down and up by dragging.
    */
   handle?: boolean;
+  /**
+   * When `variant=bottom` and `handle=true`, sets the bottom sheet's peek height (px).
+   * If the peek height is not set, the bottom sheet will be peeked with navigation height.
+   */
+  peekHeight?: number;
   /**
    * When scrolling inside the modal, the gradient of `ModalActionArea` and the `borderBottom` style of `TopNavigation` are added.
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Bottom sheet now supports a configurable peek height for finer control of the visible grab area.
  - Layout adjusts automatically when a handle is present, improving spacing and readability.

- Improvements
  - Smoother, more predictable drag behavior and animations that respect the configured peek height.
  - Enhanced scroll padding for content, improving in-sheet navigation.

- Bug Fixes
  - Prevents unintended closing when focus moves outside or on outside clicks if outside-click close is disabled, improving consistency for modals and alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->