### PR TITLE
feat(wds): fallback view mobile button size to small

### DIFF
--- a/packages/wds/src/components/avatar-group/style.ts
+++ b/packages/wds/src/components/avatar-group/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { AvatarGroupProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/avatar/style.ts
+++ b/packages/wds/src/components/avatar/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { addOpacity } from '../../utils';
 
 import type { AvatarProps } from './types';

--- a/packages/wds/src/components/button/style.ts
+++ b/packages/wds/src/components/button/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { ButtonProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/card-list/style.ts
+++ b/packages/wds/src/components/card-list/style.ts
@@ -4,7 +4,7 @@ import {
   ellipsisTypographyStyle,
   typographyStyle,
 } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { CardListSkeletonProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/card/style.ts
+++ b/packages/wds/src/components/card/style.ts
@@ -1,11 +1,11 @@
 import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import {
-  createResponsiveStyle,
   ellipsisTypographyStyle,
   gradient,
   typographyStyle,
 } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 import { getWeightMap } from '../typography/style';
 

--- a/packages/wds/src/components/category/contexts.ts
+++ b/packages/wds/src/components/category/contexts.ts
@@ -2,6 +2,7 @@ import { createContext } from '@radix-ui/react-context';
 
 import { CATEGORY_LIST_NAME, CATEGORY_NAME } from './constants';
 
+import type { BreakPoint } from '@wanteddev/wds-engine';
 import type { CategoryListProps } from './types';
 import type { Dispatch, SetStateAction } from 'react';
 
@@ -23,11 +24,7 @@ export type CategoryListContextType = {
   handleResize: () => void;
   variant: CategoryListProps['variant'];
   size: CategoryListProps['size'];
-  xs: CategoryListProps['xs'];
-  sm: CategoryListProps['sm'];
-  md: CategoryListProps['md'];
-  lg: CategoryListProps['lg'];
-  xl: CategoryListProps['xl'];
+  responsive?: Pick<CategoryListProps, keyof BreakPoint>;
 };
 
 export const [CategoryListProvider, useCategoryListContext] =

--- a/packages/wds/src/components/category/helpers.ts
+++ b/packages/wds/src/components/category/helpers.ts
@@ -1,0 +1,31 @@
+import type { CategoryListContextType } from './contexts';
+import type { CategoryListItemProps } from './types';
+
+export const getCategoryListItemSize = (
+  context: Pick<CategoryListContextType, 'size' | 'responsive'>,
+  { xs, sm, md, lg, xl }: Partial<CategoryListItemProps>,
+) => {
+  return {
+    size: context.size,
+    xs: {
+      size: context.responsive?.xs?.size,
+      ...xs,
+    },
+    sm: {
+      size: context.responsive?.sm?.size,
+      ...sm,
+    },
+    md: {
+      size: context.responsive?.md?.size,
+      ...md,
+    },
+    lg: {
+      size: context.responsive?.lg?.size,
+      ...lg,
+    },
+    xl: {
+      size: context.responsive?.xl?.size,
+      ...xl,
+    },
+  };
+};

--- a/packages/wds/src/components/category/index.tsx
+++ b/packages/wds/src/components/category/index.tsx
@@ -42,6 +42,7 @@ import {
   CATEGORY_NAME,
   CATEGORY_PANEL_NAME,
 } from './constants';
+import { getCategoryListItemSize } from './helpers';
 
 import type {
   ElementRef,
@@ -166,11 +167,7 @@ const CategoryList = forwardRef<
         handleResize={handleResize}
         variant={variant}
         size={size}
-        xs={xs}
-        sm={sm}
-        md={md}
-        lg={lg}
-        xl={xl}
+        responsive={{ xs, sm, md, lg, xl }}
       >
         <RovingFocusGroup.Root asChild orientation="horizontal" loop dir="ltr">
           <FlexBox
@@ -252,34 +249,15 @@ const CategoryListItem = forwardRef<any, CategoryListItemProps>(
     const composedRefs = useComposedRefs(forwardedRef, ref as ForwardedRef<T>);
 
     const context = useCategoryContext(CATEGORY_LIST_ITEM_NAME);
-    const { handleResize, size, variant, ...categoryListContext } =
+    const { handleResize, variant, ...categoryListContext } =
       useCategoryListContext(CATEGORY_LIST_ITEM_NAME);
     const isDisabled = disabled;
 
-    const responsiveProps = useMemo(() => {
-      return {
-        xs: {
-          ...xs,
-          size: categoryListContext.xs?.size,
-        },
-        sm: {
-          ...sm,
-          size: categoryListContext.sm?.size,
-        },
-        md: {
-          ...md,
-          size: categoryListContext.md?.size,
-        },
-        lg: {
-          ...lg,
-          size: categoryListContext.lg?.size,
-        },
-        xl: {
-          ...xl,
-          size: categoryListContext.xl?.size,
-        },
-      };
-    }, [xs, sm, md, lg, xl, categoryListContext]);
+    const sizeProps = useMemo(
+      () =>
+        getCategoryListItemSize(categoryListContext, { xs, sm, md, lg, xl }),
+      [xs, sm, md, lg, xl, categoryListContext],
+    );
 
     const isActive = context.value === value;
     const isArrowKeyPressedRef = useRef(false);
@@ -362,7 +340,7 @@ const CategoryListItem = forwardRef<any, CategoryListItemProps>(
             originVariant ??
             (isActive && variant !== 'alternative' ? 'solid' : 'outlined')
           }
-          sx={[categoryListItemStyle({ ...responsiveProps, size }), props.sx]}
+          sx={[categoryListItemStyle(sizeProps), props.sx]}
           onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
             if (disabled) {
               return;

--- a/packages/wds/src/components/category/style.ts
+++ b/packages/wds/src/components/category/style.ts
@@ -1,11 +1,10 @@
 import { css } from '@wanteddev/wds-engine';
 
+import { getGradientMaskImage, typographyStyle } from '../../utils';
 import {
   createResponsiveStyle,
-  getGradientMaskImage,
   getPreviousValue,
-  typographyStyle,
-} from '../../utils';
+} from '../../utils/internal/responsive-props';
 
 import type { ResponsiveProps, Theme } from '@wanteddev/wds-engine';
 import type { CategoryListProps } from './types';

--- a/packages/wds/src/components/check-mark/style.ts
+++ b/packages/wds/src/components/check-mark/style.ts
@@ -3,7 +3,7 @@ import { css } from '@wanteddev/wds-engine';
 import {
   createResponsiveStyle,
   getPreviousValue,
-} from '../../utils/responsive-props';
+} from '../../utils/internal/responsive-props';
 import { typographyStyle } from '../../utils';
 
 import type { CheckMarkProps } from './types';

--- a/packages/wds/src/components/checkbox/style.ts
+++ b/packages/wds/src/components/checkbox/style.ts
@@ -4,7 +4,7 @@ import { typographyStyle } from '../../utils/typography';
 import {
   createResponsiveStyle,
   getPreviousValue,
-} from '../../utils/responsive-props';
+} from '../../utils/internal/responsive-props';
 
 import type { CheckboxProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/chip-action/style.ts
+++ b/packages/wds/src/components/chip-action/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { addOpacity } from '../../utils';
 
 import type { ChipActionProps } from './types';

--- a/packages/wds/src/components/chip-filter/style.ts
+++ b/packages/wds/src/components/chip-filter/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { addOpacity } from '../../utils';
 
 import type { ChipFilterProps } from './types';

--- a/packages/wds/src/components/content-badge/style.ts
+++ b/packages/wds/src/components/content-badge/style.ts
@@ -2,7 +2,7 @@ import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import { addOpacity } from '../../utils/color';
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { ContentBadgeProps } from './types';

--- a/packages/wds/src/components/divider/style.ts
+++ b/packages/wds/src/components/divider/style.ts
@@ -3,7 +3,7 @@ import { css, getColorByToken } from '@wanteddev/wds-engine';
 import {
   createResponsiveStyle,
   getPreviousValue,
-} from '../../utils/responsive-props';
+} from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { DividerProps } from './types';

--- a/packages/wds/src/components/fallback-view/contexts.ts
+++ b/packages/wds/src/components/fallback-view/contexts.ts
@@ -1,0 +1,14 @@
+import { createContext } from '@radix-ui/react-context';
+
+import { FALLBACK_VIEW_NAME } from './constants';
+
+import type { BreakPoint } from '@wanteddev/wds-engine';
+import type { FallbackViewProps } from './types';
+
+export type FallbackViewContextType = {
+  platform?: Exclude<FallbackViewProps['platform'], undefined>;
+  responsive?: Pick<FallbackViewProps, keyof BreakPoint>;
+};
+
+export const [FallbackViewProvider, useFallbackViewContext] =
+  createContext<FallbackViewContextType>(FALLBACK_VIEW_NAME);

--- a/packages/wds/src/components/fallback-view/helpers.ts
+++ b/packages/wds/src/components/fallback-view/helpers.ts
@@ -1,0 +1,43 @@
+import type { ButtonProps } from '../button';
+import type { FallbackViewContextType } from './contexts';
+import type { FallbackViewButtonProps } from './types';
+
+export const getFallbackViewButtonSize = (
+  context: FallbackViewContextType,
+  { xs, sm, md, lg, xl }: FallbackViewButtonProps,
+) => {
+  return {
+    size: getFallbackViewButtonSizePlatform(context.platform),
+    xs: {
+      size: getFallbackViewButtonSizePlatform(context.responsive?.xs?.platform),
+      ...xs,
+    },
+    sm: {
+      size: getFallbackViewButtonSizePlatform(context.responsive?.sm?.platform),
+      ...sm,
+    },
+    md: {
+      size: getFallbackViewButtonSizePlatform(context.responsive?.md?.platform),
+      ...md,
+    },
+    lg: {
+      size: getFallbackViewButtonSizePlatform(context.responsive?.lg?.platform),
+      ...lg,
+    },
+    xl: {
+      size: getFallbackViewButtonSizePlatform(context.responsive?.xl?.platform),
+      ...xl,
+    },
+  };
+};
+
+const getFallbackViewButtonSizePlatform = (
+  platform: FallbackViewContextType['platform'],
+): ButtonProps['size'] => {
+  switch (platform) {
+    case 'desktop':
+      return 'large';
+    case 'mobile':
+      return 'small';
+  }
+};

--- a/packages/wds/src/components/fallback-view/helpers.ts
+++ b/packages/wds/src/components/fallback-view/helpers.ts
@@ -4,10 +4,10 @@ import type { FallbackViewButtonProps } from './types';
 
 export const getFallbackViewButtonSize = (
   context: FallbackViewContextType,
-  { xs, sm, md, lg, xl }: FallbackViewButtonProps,
+  { size, xs, sm, md, lg, xl }: FallbackViewButtonProps,
 ) => {
   return {
-    size: getFallbackViewButtonSizePlatform(context.platform),
+    size: size ?? getFallbackViewButtonSizePlatform(context.platform),
     xs: {
       size: getFallbackViewButtonSizePlatform(context.responsive?.xs?.platform),
       ...xs,

--- a/packages/wds/src/components/fallback-view/index.tsx
+++ b/packages/wds/src/components/fallback-view/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 import {
   type DefaultComponentPropsInternal,
   type PolymorphicComponentInternal,
@@ -15,7 +15,13 @@ import {
   FALLBACK_VIEW_NAME,
   FALLBACK_VIEW_TEXT_NAME,
 } from './constants';
-import { fallbackViewStyle } from './style';
+import {
+  fallbackViewContentStyle,
+  fallbackViewImageStyle,
+  fallbackViewStyle,
+} from './style';
+import { FallbackViewProvider, useFallbackViewContext } from './contexts';
+import { getFallbackViewButtonSize } from './helpers';
 
 import type { ElementType, ForwardedRef } from 'react';
 import type {
@@ -45,28 +51,33 @@ const FallbackView = forwardRef(
     ref: ForwardedRef<T>,
   ) => {
     return (
-      <FlexBox
-        as={as || 'div'}
-        ref={ref}
-        flexDirection="column"
-        alignItems="center"
-        sx={[
-          fallbackViewStyle({
-            platform,
-            padding,
-            width,
-            xs,
-            sm,
-            md,
-            lg,
-            xl,
-          }),
-          sx,
-        ]}
-        {...props}
+      <FallbackViewProvider
+        platform={platform}
+        responsive={{ xs, sm, md, lg, xl }}
       >
-        {children}
-      </FlexBox>
+        <FlexBox
+          as={as || 'div'}
+          ref={ref}
+          flexDirection="column"
+          alignItems="center"
+          sx={[
+            fallbackViewStyle({
+              platform,
+              padding,
+              width,
+              xs,
+              sm,
+              md,
+              lg,
+              xl,
+            }),
+            sx,
+          ]}
+          {...props}
+        >
+          {children}
+        </FlexBox>
+      </FallbackViewProvider>
     );
   },
 ) as PolymorphicComponentInternal<FallbackViewProps, 'div'>;
@@ -78,6 +89,8 @@ const FallbackViewImage = forwardRef(
     props: DefaultComponentPropsInternal<FallbackViewImageProps, 'div'>,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
+    const context = useFallbackViewContext(FALLBACK_VIEW_IMAGE_NAME);
+
     return (
       <FlexBox
         ref={ref}
@@ -85,6 +98,7 @@ const FallbackViewImage = forwardRef(
         justifyContent="center"
         alignItems="center"
         {...props}
+        sx={[fallbackViewImageStyle(context), props.sx]}
       />
     );
   },
@@ -97,6 +111,8 @@ const FallbackViewContent = forwardRef(
     props: DefaultComponentPropsInternal<FallbackViewContentProps, 'div'>,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
+    const context = useFallbackViewContext(FALLBACK_VIEW_CONTENT_NAME);
+
     return (
       <FlexBox
         ref={ref}
@@ -105,6 +121,7 @@ const FallbackViewContent = forwardRef(
         alignItems="center"
         gap="24px"
         {...props}
+        sx={[fallbackViewContentStyle(context), props.sx]}
       />
     );
   },
@@ -122,7 +139,7 @@ const FallbackViewText = forwardRef(
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     return (
-      <FlexBox ref={ref} flexDirection="column" gap="12px" {...props}>
+      <FlexBox ref={ref} flexDirection="column" gap="10px" {...props}>
         {title && <span data-role="fallback-view-text-title">{title}</span>}
         <span data-role="fallback-view-text-description">{description}</span>
       </FlexBox>
@@ -137,6 +154,13 @@ const FallbackViewButton = forwardRef(
     { as, ...props }: PolymorphicPropsInternal<FallbackViewButtonProps, T>,
     ref: ForwardedRef<T>,
   ) => {
+    const context = useFallbackViewContext(FALLBACK_VIEW_BUTTON_NAME);
+
+    const sizeProps = useMemo(
+      () => getFallbackViewButtonSize(context, props),
+      [context, props],
+    );
+
     return (
       <Button
         as={(as || 'button') as ElementType}
@@ -145,6 +169,7 @@ const FallbackViewButton = forwardRef(
         variant="outlined"
         color="assistive"
         {...props}
+        {...sizeProps}
       />
     );
   },

--- a/packages/wds/src/components/fallback-view/style.ts
+++ b/packages/wds/src/components/fallback-view/style.ts
@@ -1,137 +1,24 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle, typographyStyle } from '../../utils';
+import { typographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
+import type { FallbackViewContextType } from './contexts';
 import type { Theme } from '@wanteddev/wds-engine';
 import type { FallbackViewProps } from './types';
-
-const fallbackViewPlatformStyle = ({
-  platform,
-}: Pick<FallbackViewProps, 'platform'>) => {
-  switch (platform) {
-    case 'mobile':
-      return css`
-        width: 335px;
-        max-width: 100%;
-
-        [wds-component='fallback-view-image'] {
-          width: 128px;
-          height: 128px;
-        }
-
-        [wds-component='fallback-view-image']
-          + [wds-component='fallback-view-content'] {
-          --wds-fallback-view-bottom-space: 20px;
-        }
-        [wds-component='fallback-view-content'] {
-          padding-top: 8px;
-          padding-bottom: calc(8px + var(--wds-fallback-view-bottom-space));
-        }
-
-        [data-role='fallback-view-text-title'] {
-          ${typographyStyle('headline1', 'bold')}
-        }
-        [data-role='fallback-view-text-description'] {
-          ${typographyStyle('body2-reading')}
-        }
-
-        [wds-component='fallback-view-button'] {
-          // button/style.ts size="medium"
-          border-radius: 10px;
-          padding: 9px 20px;
-          gap: 5px;
-
-          & > svg {
-            font-size: 18px;
-          }
-          & > span {
-            ${typographyStyle('body2', 'medium')}
-          }
-        }
-      `;
-
-    case 'desktop':
-      return css`
-        width: 400px;
-        max-width: 100%;
-
-        [wds-component='fallback-view-image'] {
-          width: 160px;
-          height: 160px;
-        }
-
-        [wds-component='fallback-view-image']
-          + [wds-component='fallback-view-content'] {
-          --wds-fallback-view-bottom-space: 20px;
-        }
-        [wds-component='fallback-view-content'] {
-          padding-top: 12px;
-          padding-bottom: calc(12px + var(--wds-fallback-view-bottom-space));
-        }
-
-        [data-role='fallback-view-text-title'] {
-          ${typographyStyle('heading2', 'bold')}
-        }
-        [data-role='fallback-view-text-description'] {
-          ${typographyStyle('body1-reading')}
-        }
-
-        [wds-component='fallback-view-button'] {
-          // button/style.ts size="large"
-          border-radius: 12px;
-          padding: 12px 28px;
-          gap: 6px;
-
-          & > svg {
-            font-size: 20px;
-          }
-          & > span {
-            ${typographyStyle('body1', 'medium')}
-          }
-        }
-      `;
-  }
-};
-
-const fallbackViewPaddingStyle = ({
-  padding,
-}: Pick<FallbackViewProps, 'padding'>) => {
-  switch (padding) {
-    case 'compact':
-      return css`
-        padding-top: 80px;
-        padding-bottom: 80px;
-      `;
-    case 'normal':
-      return css`
-        padding-top: 160px;
-        padding-bottom: 160px;
-      `;
-  }
-};
 
 export const fallbackViewStyle =
   ({ platform, padding, width, xs, sm, md, lg, xl }: FallbackViewProps) =>
   (theme: Theme) => css`
-    --wds-fallback-view-bottom-space: 0px;
-
+    width: ${toCssValue(width)};
     ${fallbackViewPlatformStyle({ platform })}
     ${fallbackViewPaddingStyle({ padding })}
-    width: ${toCssValue(width)};
+    --wds-fallback-view-bottom-space: 0px;
 
-    [wds-component='fallback-view-image'] {
-      max-width: 100%;
-      max-height: 100%;
-
-      img {
-        max-width: 100%;
-      }
-
-      svg {
-        width: 100%;
-        height: 100%;
-      }
+    &:has([wds-component='fallback-view-image'])
+      [wds-component='fallback-view-content'] {
+      --wds-fallback-view-bottom-space: 20px;
     }
 
     [data-role='fallback-view-text-title'] {
@@ -157,3 +44,129 @@ export const fallbackViewStyle =
       `,
     )}
   `;
+
+const fallbackViewPlatformStyle = ({
+  platform,
+}: Pick<FallbackViewProps, 'platform'>) => {
+  switch (platform) {
+    case 'mobile':
+      return css`
+        width: 335px;
+        max-width: 100%;
+
+        [data-role='fallback-view-text-title'] {
+          ${typographyStyle('headline1', 'bold')}
+        }
+        [data-role='fallback-view-text-description'] {
+          ${typographyStyle('body2-reading')}
+        }
+      `;
+
+    case 'desktop':
+      return css`
+        width: 400px;
+        max-width: 100%;
+
+        [data-role='fallback-view-text-title'] {
+          ${typographyStyle('heading2', 'bold')}
+        }
+        [data-role='fallback-view-text-description'] {
+          ${typographyStyle('body1-reading')}
+        }
+      `;
+  }
+};
+
+const fallbackViewPaddingStyle = ({
+  padding,
+}: Pick<FallbackViewProps, 'padding'>) => {
+  switch (padding) {
+    case 'compact':
+      return css`
+        padding-top: 80px;
+        padding-bottom: 80px;
+      `;
+    case 'normal':
+      return css`
+        padding-top: 160px;
+        padding-bottom: 160px;
+      `;
+  }
+};
+
+export const fallbackViewImageStyle =
+  ({ platform, responsive }: FallbackViewContextType) =>
+  (theme: Theme) => css`
+    max-width: 100%;
+    max-height: 100%;
+    ${fallbackViewImagePlatformStyle({ platform })}
+
+    img {
+      max-width: 100%;
+    }
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    ${createResponsiveStyle(
+      responsive || {},
+      theme,
+    )(
+      (params) => css`
+        ${fallbackViewImagePlatformStyle({ platform: params?.platform })}
+        ${params?.sx}
+      `,
+    )}
+  `;
+
+const fallbackViewImagePlatformStyle = ({
+  platform,
+}: FallbackViewContextType) => {
+  switch (platform) {
+    case 'mobile':
+      return css`
+        width: 128px;
+        height: 128px;
+      `;
+    case 'desktop':
+      return css`
+        width: 160px;
+        height: 160px;
+      `;
+  }
+};
+
+export const fallbackViewContentStyle =
+  ({ platform, responsive }: FallbackViewContextType) =>
+  (theme: Theme) => css`
+    ${fallbackViewContentPlatformStyle({ platform })}
+
+    ${createResponsiveStyle(
+      responsive || {},
+      theme,
+    )(
+      (params) => css`
+        ${fallbackViewContentPlatformStyle({ platform: params?.platform })}
+        ${params?.sx}
+      `,
+    )}
+  `;
+
+const fallbackViewContentPlatformStyle = ({
+  platform,
+}: FallbackViewContextType) => {
+  switch (platform) {
+    case 'mobile':
+      return css`
+        padding-top: 8px;
+        padding-bottom: calc(8px + var(--wds-fallback-view-bottom-space));
+      `;
+    case 'desktop':
+      return css`
+        padding-top: 12px;
+        padding-bottom: calc(12px + var(--wds-fallback-view-bottom-space));
+      `;
+  }
+};

--- a/packages/wds/src/components/flex-box/style.ts
+++ b/packages/wds/src/components/flex-box/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/grid-item/style.ts
+++ b/packages/wds/src/components/grid-item/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { GridItemProps } from './types';

--- a/packages/wds/src/components/grid/style.ts
+++ b/packages/wds/src/components/grid/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { GridProps } from './types';

--- a/packages/wds/src/components/icon-button/style.ts
+++ b/packages/wds/src/components/icon-button/style.ts
@@ -1,6 +1,7 @@
 import { css, getColorByToken } from '@wanteddev/wds-engine';
 
-import { addOpacity, createResponsiveStyle } from '../../utils';
+import { addOpacity } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { IconButtonProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/list/style.ts
+++ b/packages/wds/src/components/list/style.ts
@@ -1,11 +1,10 @@
 import { css } from '@wanteddev/wds-engine';
 
+import { ellipsisTypographyStyle, typographyStyle } from '../../utils';
 import {
   createResponsiveStyle,
-  ellipsisTypographyStyle,
   getPreviousValue,
-  typographyStyle,
-} from '../../utils';
+} from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/loading/style.ts
+++ b/packages/wds/src/components/loading/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { LoadingProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/modal/hooks.ts
+++ b/packages/wds/src/components/modal/hooks.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from '@wanteddev/wds-engine';
 
-import { getPreviousValue } from '../../utils/responsive-props';
+import { getPreviousValue } from '../../utils/internal/responsive-props';
 
 import {
   BOTTOM_SHEET_PEEK_PADDING,

--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -3,7 +3,7 @@ import { css, keyframes } from '@wanteddev/wds-engine';
 import {
   createResponsiveStyle,
   getPreviousValue,
-} from '../../utils/responsive-props';
+} from '../../utils/internal/responsive-props';
 import { ellipsisTypographyStyle, typographyStyle } from '../../utils';
 import { toCssValue } from '../../utils/internal/css';
 

--- a/packages/wds/src/components/page-counter/style.ts
+++ b/packages/wds/src/components/page-counter/style.ts
@@ -1,10 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import {
-  addOpacity,
-  createResponsiveStyle,
-  typographyStyle,
-} from '../../utils';
+import { addOpacity, typographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { PageCounterProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/pagination-dots/style.ts
+++ b/packages/wds/src/components/pagination-dots/style.ts
@@ -1,6 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { addOpacity, createResponsiveStyle } from '../../utils';
+import { addOpacity } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { PaginationDotsProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/play-badge/style.ts
+++ b/packages/wds/src/components/play-badge/style.ts
@@ -1,6 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { addOpacity, createResponsiveStyle } from '../../utils';
+import { addOpacity } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { PlayBadgeProps } from './types';

--- a/packages/wds/src/components/progress-step-indicator/style.ts
+++ b/packages/wds/src/components/progress-step-indicator/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { ProgressStepIndicatorProps } from './types';

--- a/packages/wds/src/components/push-badge/style.ts
+++ b/packages/wds/src/components/push-badge/style.ts
@@ -1,6 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle, typographyStyle } from '../../utils';
+import { typographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { PushBadgeProps } from './types';

--- a/packages/wds/src/components/radio-group/index.tsx
+++ b/packages/wds/src/components/radio-group/index.tsx
@@ -6,7 +6,7 @@ import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { Box } from '@wanteddev/wds-engine';
 
 import { Radio } from '../radio';
-import { createEmptyResponsiveStyle } from '../../utils';
+import { createEmptyResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import { RADIO_GROUP_NAME, RADIO_ITEM_NAME } from './constants';
 import { RadioGroupProvider, useRadioGroupContext } from './contexts';

--- a/packages/wds/src/components/radio/style.ts
+++ b/packages/wds/src/components/radio/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { typographyStyle } from '../../utils/typography';
 
 import type { RadioProps } from './types';

--- a/packages/wds/src/components/round-checkbox/style.ts
+++ b/packages/wds/src/components/round-checkbox/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { RoundCheckboxProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/search-field/style.ts
+++ b/packages/wds/src/components/search-field/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { SearchFieldProps } from './types';

--- a/packages/wds/src/components/section-header/style.ts
+++ b/packages/wds/src/components/section-header/style.ts
@@ -1,10 +1,10 @@
 import { css, getColorByToken } from '@wanteddev/wds-engine';
 
+import { typographyStyle } from '../../utils';
 import {
   createResponsiveStyle,
   getPreviousValue,
-  typographyStyle,
-} from '../../utils';
+} from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { SectionHeaderProps } from './types';

--- a/packages/wds/src/components/segmented-control/style.ts
+++ b/packages/wds/src/components/segmented-control/style.ts
@@ -2,10 +2,10 @@ import { css } from '@wanteddev/wds-engine';
 
 import {
   addOpacity,
-  createResponsiveStyle,
   ellipsisTypographyStyle,
   typographyStyle,
 } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { SegmentedControlProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/select/style.ts
+++ b/packages/wds/src/components/select/style.ts
@@ -1,10 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import {
-  addOpacity,
-  createResponsiveStyle,
-  ellipsisTypographyStyle,
-} from '../../utils';
+import { addOpacity, ellipsisTypographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/skeleton/style.ts
+++ b/packages/wds/src/components/skeleton/style.ts
@@ -1,7 +1,7 @@
 import { css, getColorByToken, keyframes } from '@wanteddev/wds-engine';
 import objectPath from 'object-path';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { SkeletonProps } from './types';

--- a/packages/wds/src/components/switch/style.ts
+++ b/packages/wds/src/components/switch/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { hoverInteractionStyle } from '../with-interaction/style';
 
 import type { SwitchProps } from './types';

--- a/packages/wds/src/components/tab/index.tsx
+++ b/packages/wds/src/components/tab/index.tsx
@@ -344,7 +344,7 @@ const TabListItem = forwardRef<any, TabListItemProps>(
 
     useEffect(() => {
       const scrollMove = () => {
-        if (context.value === value) {
+        if (context.value?.toString() === value.toString()) {
           scrollIntoView();
         }
       };

--- a/packages/wds/src/components/tab/style.ts
+++ b/packages/wds/src/components/tab/style.ts
@@ -1,11 +1,10 @@
 import { css } from '@wanteddev/wds-engine';
 
+import { getGradientMaskImage, typographyStyle } from '../../utils';
 import {
   createResponsiveStyle,
-  getGradientMaskImage,
   getPreviousValue,
-  typographyStyle,
-} from '../../utils';
+} from '../../utils/internal/responsive-props';
 
 import type { Theme } from '@wanteddev/wds-engine';
 import type { TabListProps } from './types';

--- a/packages/wds/src/components/text-area/style.ts
+++ b/packages/wds/src/components/text-area/style.ts
@@ -1,10 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import {
-  addOpacity,
-  createResponsiveStyle,
-  typographyStyle,
-} from '../../utils';
+import { addOpacity, typographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { TextAreaProps } from './types';

--- a/packages/wds/src/components/text-button/style.ts
+++ b/packages/wds/src/components/text-button/style.ts
@@ -1,7 +1,7 @@
 import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { Theme, ThemeColorsToken } from '@wanteddev/wds-engine';
 import type { TextButtonProps } from './types';

--- a/packages/wds/src/components/text-field/style.ts
+++ b/packages/wds/src/components/text-field/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { addOpacity } from '../../utils';
 import { toCssValue } from '../../utils/internal/css';
 

--- a/packages/wds/src/components/thumbnail/style.ts
+++ b/packages/wds/src/components/thumbnail/style.ts
@@ -1,6 +1,9 @@
 import { css } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle, getPreviousValue } from '../../utils';
+import {
+  createResponsiveStyle,
+  getPreviousValue,
+} from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/toggle-icon/style.ts
+++ b/packages/wds/src/components/toggle-icon/style.ts
@@ -1,6 +1,6 @@
 import { css, getColorByToken } from '@wanteddev/wds-engine';
 
-import { createResponsiveStyle } from '../../utils/responsive-props';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { toCssValue } from '../../utils/internal/css';
 
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/tooltip/style.ts
+++ b/packages/wds/src/components/tooltip/style.ts
@@ -1,10 +1,7 @@
 import { css, keyframes } from '@wanteddev/wds-engine';
 
-import {
-  addOpacity,
-  createResponsiveStyle,
-  typographyStyle,
-} from '../../utils';
+import { addOpacity, typographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { TooltipContentProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/top-navigation/style.ts
+++ b/packages/wds/src/components/top-navigation/style.ts
@@ -1,10 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 
-import {
-  createResponsiveStyle,
-  ellipsisTypographyStyle,
-  typographyStyle,
-} from '../../utils';
+import { ellipsisTypographyStyle, typographyStyle } from '../../utils';
+import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { TopNavigationProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';

--- a/packages/wds/src/components/typography/index.tsx
+++ b/packages/wds/src/components/typography/index.tsx
@@ -4,7 +4,7 @@ import { Box, css, getColorByToken } from '@wanteddev/wds-engine';
 import {
   createResponsiveStyle,
   getPreviousValue,
-} from '../../utils/responsive-props';
+} from '../../utils/internal/responsive-props';
 import {
   ellipsisTypographyStyle,
   typographyStyle,

--- a/packages/wds/src/utils/index.ts
+++ b/packages/wds/src/utils/index.ts
@@ -3,5 +3,4 @@ export * from './color';
 export * from './layout';
 export * from './media';
 export * from './typography';
-export * from './responsive-props';
 export * from './framed-style';

--- a/packages/wds/src/utils/internal/responsive-props.ts
+++ b/packages/wds/src/utils/internal/responsive-props.ts
@@ -1,7 +1,7 @@
 import { css } from '@wanteddev/wds-engine';
 import objectPath from 'object-path';
 
-import { respondMore } from './media';
+import { respondMore } from '../media';
 
 import type {
   BreakPoint,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - FallbackView now adapts button sizes by platform and breakpoints; image/content styling refined for better responsiveness.
- Enhancements
  - FallbackViewText spacing adjusted for improved readability.
  - Category list items apply responsive sizing more consistently.
- Bug Fixes
  - Tabs reliably scroll the active tab into view when values are non-string or undefined.
- Refactor
  - Consolidated responsive styling utilities under an internal module with no behavioral changes.
- Chores
  - Removed public re-export of responsive utilities from utils; adjust imports if consuming those directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->