### PR TITLE
fix(wds): floating top navigation in bottom modal, gradient is not working

### DIFF
--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -367,6 +367,7 @@ const ModalContainer = forwardRef(
                   ]}
                 >
                   <ScrollArea
+                    data-role="modal-container-scroll-area"
                     scrollbars="vertical"
                     viewportRef={context.innerContainerRef}
                     sx={{

--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -77,12 +77,38 @@ const modalContainerWrapperVariant = (
         justify-content: center;
         align-items: initial;
         padding: 0px;
+
+        [data-role='modal-dimmer'][data-status='close'] {
+          opacity: initial;
+          pointer-events: none;
+          transition: initial;
+        }
+
+        [data-role='modal-container-scroll-area']:has(
+            [wds-component='top-navigation'][data-variant='floating']
+          ) {
+          background: initial;
+          will-change: unset;
+        }
       `;
     case 'popup':
       return css`
         align-items: center;
         justify-content: center;
         padding: 20px;
+
+        [data-role='modal-dimmer'][data-status='close'] {
+          opacity: initial;
+          pointer-events: none;
+          transition: initial;
+        }
+
+        [data-role='modal-container-scroll-area']:has(
+            [wds-component='top-navigation'][data-variant='floating']
+          ) {
+          background: initial;
+          will-change: unset;
+        }
       `;
     case 'bottom':
       return css`
@@ -94,6 +120,13 @@ const modalContainerWrapperVariant = (
           opacity: 0;
           pointer-events: none;
           transition: opacity ease 200ms;
+        }
+
+        [data-role='modal-container-scroll-area']:has(
+            [wds-component='top-navigation'][data-variant='floating']
+          ) {
+          background: inherit;
+          will-change: backdrop-filter;
         }
       `;
   }

--- a/packages/wds/src/components/top-navigation/index.tsx
+++ b/packages/wds/src/components/top-navigation/index.tsx
@@ -53,6 +53,7 @@ const TopNavigation = forwardRef<
         ref={ref}
         flexDirection="column"
         {...props}
+        data-variant={variant}
         sx={[
           topNavigationStyle({
             background,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Fixed modal dimmer behavior when closing to prevent lingering opacity and blocked interactions.
  - Resolved visual conflicts between floating top navigation and modal scroll areas across full, popup, and bottom modal variants.

- Style
  - Refined modal overlay transitions and background behavior for smoother close animations.
  - Adjusted scroll area styling to better align with floating top navigation, improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->