### PR TITLE
feat(wds): pagination leading, trailing content should render only extended variant

### DIFF
--- a/packages/wds/src/components/pagination/index.tsx
+++ b/packages/wds/src/components/pagination/index.tsx
@@ -130,12 +130,14 @@ const Pagination = forwardRef<
           {...props}
           sx={[paginationStyle({ variant }), sx]}
         >
-          <FlexBox
-            data-role="pagination-leading-content-wrapper"
-            sx={paginationContentStyle}
-          >
-            {Boolean(leadingContent) && leadingContent}
-          </FlexBox>
+          {variant === 'extended' && (
+            <FlexBox
+              data-role="pagination-leading-content-wrapper"
+              sx={paginationContentStyle}
+            >
+              {Boolean(leadingContent) && leadingContent}
+            </FlexBox>
+          )}
 
           <FlexBox
             ref={ref}
@@ -201,12 +203,14 @@ const Pagination = forwardRef<
             )}
           </FlexBox>
 
-          <FlexBox
-            data-role="pagination-trailing-content-wrapper"
-            sx={paginationContentStyle}
-          >
-            {Boolean(trailingContent) && trailingContent}
-          </FlexBox>
+          {variant === 'extended' && (
+            <FlexBox
+              data-role="pagination-trailing-content-wrapper"
+              sx={paginationContentStyle}
+            >
+              {Boolean(trailingContent) && trailingContent}
+            </FlexBox>
+          )}
         </FlexBox>
       </PaginationProvider>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Pagination rendering: leading/trailing sections now appear only in the extended variant, removing unnecessary wrappers in other variants.
  * Reduces DOM complexity for non-extended variants, potentially improving rendering performance and accessibility tree clarity.
  * No changes to behavior, public API, or error handling; functionality and visuals should remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->