### PR TITLE
feat(wds): add overlay prop in thumbnail

### DIFF
--- a/packages/wds/src/components/thumbnail/index.tsx
+++ b/packages/wds/src/components/thumbnail/index.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
 import { IconImage } from '@wanteddev/wds-icon';
+import { Box, type DefaultComponentPropsInternal } from '@wanteddev/wds-engine';
 
 import { FlexBox } from '../flex-box';
 import { Skeleton } from '../skeleton';
@@ -8,7 +9,6 @@ import { ImageBase } from '../image-base';
 import { thumbnailStyle } from './style';
 import { THUMBNAIL_NAME, THUMBNAIL_SKELETON_NAME } from './constants';
 
-import type { DefaultComponentPropsInternal } from '@wanteddev/wds-engine';
 import type { ForwardedRef } from 'react';
 import type { ThumbnailProps, ThumbnailSkeletonProps } from './types';
 
@@ -20,6 +20,7 @@ const Thumbnail = forwardRef<
     {
       ratio = '4:3',
       portrait = false,
+      overlay,
       radius,
       border,
       className,
@@ -55,6 +56,7 @@ const Thumbnail = forwardRef<
         wds-component="thumbnail"
         className={className}
         style={style}
+        data-status={imageLoadingStatus}
         sx={[
           thumbnailStyle({
             ratio,
@@ -83,6 +85,7 @@ const Thumbnail = forwardRef<
             setImageLoadingStatus('error');
           }}
         />
+        {overlay && <Box data-role="thumbnail-overlay">{overlay}</Box>}
         {children}
       </FlexBox>
     ) : (
@@ -91,6 +94,7 @@ const Thumbnail = forwardRef<
         wds-component="thumbnail"
         className={className}
         style={style}
+        data-status={imageLoadingStatus}
         alignItems="center"
         justifyContent="center"
         sx={[
@@ -115,6 +119,7 @@ const Thumbnail = forwardRef<
           aria-label={props.alt}
           sx={{ width: '33.34%', height: 'auto' }}
         />
+        {overlay && <Box data-role="thumbnail-overlay">{overlay}</Box>}
         {children}
       </FlexBox>
     );

--- a/packages/wds/src/components/thumbnail/style.ts
+++ b/packages/wds/src/components/thumbnail/style.ts
@@ -23,6 +23,8 @@ export const thumbnailStyle =
     xl,
   }: ThumbnailProps) =>
   (theme: Theme) => css`
+    position: relative;
+
     ${width !== undefined &&
     css`
       width: ${toCssValue(width)};
@@ -36,6 +38,13 @@ export const thumbnailStyle =
       width: 100%;
       height: 100%;
       object-fit: cover;
+    }
+
+    [data-role='thumbnail-overlay'] {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
     }
 
     ${createResponsiveStyle(

--- a/packages/wds/src/components/thumbnail/types.ts
+++ b/packages/wds/src/components/thumbnail/types.ts
@@ -22,6 +22,7 @@ type ThumbnailDefaultProps = WithSxProps<{
   border?: boolean;
   radius?: boolean;
   children?: ReactNode;
+  overlay?: ReactNode;
   width?: CSSProperties['width'];
 }>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Thumbnail now supports an optional overlay, displayed both over loaded images and during skeleton/placeholder states.
  - Overlay content is centered within the thumbnail for consistent presentation.
  - The thumbnail container exposes a data-status attribute reflecting image loading state, enabling easier styling and behavior based on load status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->