### PR TITLE
feat(wds): add disableRemoveScroll prop in alert, modal

### DIFF
--- a/packages/wds/src/components/alert/index.tsx
+++ b/packages/wds/src/components/alert/index.tsx
@@ -169,6 +169,7 @@ const AlertContainer = forwardRef(
     {
       disableOutsideClickClose = false,
       disableEscapeKeyDownClose,
+      disableRemoveScroll = false,
       disablePortal,
       container,
       onDismiss,
@@ -250,7 +251,11 @@ const AlertContainer = forwardRef(
                 role="presentation"
                 asChild
               >
-                <RemoveScroll as={Slot} allowPinchZoom>
+                <RemoveScroll
+                  as={Slot}
+                  allowPinchZoom
+                  enabled={!disableRemoveScroll}
+                >
                   <Box
                     ref={composedRef}
                     role="alertdialog"

--- a/packages/wds/src/components/alert/types.ts
+++ b/packages/wds/src/components/alert/types.ts
@@ -29,6 +29,7 @@ export type AlertContainerProps = Merge<
     wrapperProps?: DefaultComponentProps<WithSxProps<{}>, 'div'>;
     disableOutsideClickClose?: boolean;
     disableEscapeKeyDownClose?: boolean;
+    disableRemoveScroll?: boolean;
     /**
      * When the esc key or dialog outside click is controlled.
      */

--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -191,6 +191,7 @@ const ModalContainer = forwardRef(
       container,
       disableOutsideClickClose = false,
       disableEscapeKeyDownClose = false,
+      disableRemoveScroll = false,
       disablePortal = false,
       forceMount = false,
       sticky = true,
@@ -338,7 +339,11 @@ const ModalContainer = forwardRef(
               ref={composedContainerRefs}
             >
               <RemoveScroll
-                enabled={open && context.visibility === 'visible'}
+                enabled={
+                  open &&
+                  context.visibility === 'visible' &&
+                  !disableRemoveScroll
+                }
                 as={Slot}
                 allowPinchZoom
               >

--- a/packages/wds/src/components/modal/types.ts
+++ b/packages/wds/src/components/modal/types.ts
@@ -53,6 +53,7 @@ type ModalContainerDefaultProps = WithSxProps<{
   container?: PortalProps['container'];
   disableOutsideClickClose?: boolean;
   disableEscapeKeyDownClose?: boolean;
+  disableRemoveScroll?: boolean;
   /**
    * React Portal does not support SSR, so it is used to support Server Side Rendering.
    *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable page scroll lock for Alerts.
  * Added an option to disable page scroll lock for Modals.
  * Defaults preserve current behavior (scroll remains locked when open) unless explicitly disabled.
  * Provides per-component control to keep the page scrollable while an Alert or Modal is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->