### PR TITLE
feat(wds-codemod): add popover content migration codemod

### DIFF
--- a/packages/wds-codemod/src/transforms/v3/compact-tooltip-migration.ts
+++ b/packages/wds-codemod/src/transforms/v3/compact-tooltip-migration.ts
@@ -240,15 +240,13 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
               j.literal('bottom-center'),
             ),
           );
-        }
-
-        if (
-          position!.value?.type === 'StringLiteral' ||
-          position!.value?.type === 'Literal'
+        } else if (
+          position.value?.type === 'StringLiteral' ||
+          position.value?.type === 'Literal'
         ) {
           hasChanges = true;
-          position!.value.value = reversePosition(
-            position!.value.value!.toString(),
+          position.value.value = reversePosition(
+            position.value.value!.toString(),
           );
         }
       });
@@ -273,6 +271,18 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
 
         if (!attributes) return;
 
+        const variant = attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'variant',
+        ) as JSXAttribute | undefined;
+
+        if (!variant) {
+          hasChanges = true;
+          attributes.push(
+            j.jsxAttribute(j.jsxIdentifier('variant'), j.literal('custom')),
+          );
+        }
+
         const position = attributes.find(
           (attr) =>
             attr.type === 'JSXAttribute' && attr.name.name === 'position',
@@ -286,15 +296,13 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
               j.literal('bottom-center'),
             ),
           );
-        }
-
-        if (
-          position!.value?.type === 'StringLiteral' ||
-          position!.value?.type === 'Literal'
+        } else if (
+          position.value?.type === 'StringLiteral' ||
+          position.value?.type === 'Literal'
         ) {
           hasChanges = true;
-          position!.value.value = reversePosition(
-            position!.value.value!.toString(),
+          position.value.value = reversePosition(
+            position.value.value!.toString(),
           );
         }
       });
@@ -332,11 +340,9 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
               j.literal('bottom-center'),
             ),
           );
-        }
-
-        if (
-          position?.value?.type === 'StringLiteral' ||
-          position?.value?.type === 'Literal'
+        } else if (
+          position.value?.type === 'StringLiteral' ||
+          position.value?.type === 'Literal'
         ) {
           hasChanges = true;
           position.value.value = reversePosition(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Migration now auto-adds a default tooltip/popover position (bottom-center) when missing.
  - Automatically sets a custom variant on relevant popper/popover content when not specified.
  - Standardized position normalization for more consistent results.

- Bug Fixes
  - Safer attribute handling reduces migration errors and edge-case failures.
  - More reliable component/variant mapping to prevent broken imports or names.

- Refactor
  - Streamlined migration logic for clearer, more predictable transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->