### PR TITLE
fix(wds,wds-codemod): migration position in menu, select, autocomplete

### DIFF
--- a/packages/wds-codemod/src/transforms/v3/compact-tooltip-migration.ts
+++ b/packages/wds-codemod/src/transforms/v3/compact-tooltip-migration.ts
@@ -1,10 +1,17 @@
 import {
+  deepConvertPropertyValue,
   findImportDeclaration,
   getImportedName,
   getLocalName,
 } from '../../helpers';
 
-import type { API, FileInfo, JSXAttribute, Options } from 'jscodeshift';
+import type {
+  API,
+  FileInfo,
+  JSXAttribute,
+  JSXExpressionContainer,
+  Options,
+} from 'jscodeshift';
 
 const reversePosition = (position: string) => {
   if (position.includes('bottom')) {
@@ -249,6 +256,161 @@ const transformer = (file: FileInfo, api: API, options: Options) => {
             position.value.value!.toString(),
           );
         }
+      });
+  }
+
+  const autocompleteListImport = findImportDeclaration(
+    'AutocompleteList',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (autocompleteListImport) {
+    root
+      .find(j.JSXElement, {
+        openingElement: {
+          name: { name: getLocalName(autocompleteListImport) },
+        },
+      })
+      .forEach((node) => {
+        const attributes = node.value.openingElement.attributes;
+
+        if (!attributes) return;
+
+        const position = attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'position',
+        ) as JSXAttribute | undefined;
+
+        if (!position) {
+          return;
+        }
+
+        if (
+          position.value?.type === 'StringLiteral' ||
+          position.value?.type === 'Literal'
+        ) {
+          hasChanges = true;
+          position.value.value = reversePosition(
+            position.value.value!.toString(),
+          );
+        }
+      });
+  }
+
+  const menuContentImport = findImportDeclaration(
+    'MenuContent',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (menuContentImport) {
+    root
+      .find(j.JSXElement, {
+        openingElement: {
+          name: { name: getLocalName(menuContentImport) },
+        },
+      })
+      .forEach((node) => {
+        const attributes = node.value.openingElement.attributes;
+
+        if (!attributes) return;
+
+        const position = attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'position',
+        ) as JSXAttribute | undefined;
+
+        if (!position) {
+          return;
+        }
+
+        if (
+          position.value?.type === 'StringLiteral' ||
+          position.value?.type === 'Literal'
+        ) {
+          hasChanges = true;
+          position.value.value = reversePosition(
+            position.value.value!.toString(),
+          );
+        }
+      });
+  }
+
+  const timePickerImport = findImportDeclaration(
+    'TimePicker',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (timePickerImport) {
+    root
+      .find(j.JSXElement, {
+        openingElement: {
+          name: { name: getLocalName(timePickerImport) },
+        },
+      })
+      .forEach((node) => {
+        const attributes = node.value.openingElement.attributes;
+
+        if (!attributes) return;
+
+        const contentProps = attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'contentProps',
+        ) as JSXAttribute | undefined;
+
+        if (!contentProps) {
+          return;
+        }
+
+        hasChanges = true;
+
+        deepConvertPropertyValue(
+          contentProps.value as JSXExpressionContainer,
+          'position',
+          reversePosition,
+        );
+      });
+  }
+
+  const datePickerImport = findImportDeclaration(
+    'DatePicker',
+    '@wanteddev/wds',
+    j,
+    root,
+  );
+
+  if (datePickerImport) {
+    root
+      .find(j.JSXElement, {
+        openingElement: {
+          name: { name: getLocalName(datePickerImport) },
+        },
+      })
+      .forEach((node) => {
+        const attributes = node.value.openingElement.attributes;
+
+        if (!attributes) return;
+
+        const contentProps = attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'contentProps',
+        ) as JSXAttribute | undefined;
+
+        if (!contentProps) {
+          return;
+        }
+
+        deepConvertPropertyValue(
+          contentProps.value as JSXExpressionContainer,
+          'position',
+          reversePosition,
+        );
+        hasChanges = true;
       });
   }
 

--- a/packages/wds/src/components/autocomplete/index.tsx
+++ b/packages/wds/src/components/autocomplete/index.tsx
@@ -515,6 +515,7 @@ const AutocompleteList = forwardRef(
           role="presentation"
           ref={ref}
           offset={8}
+          position="bottom-center"
           {...props}
           data-status={open ? 'open' : 'close'}
           sx={[{ width }, autocompleteListStyle, props.sx]}

--- a/packages/wds/src/components/date-picker/index.tsx
+++ b/packages/wds/src/components/date-picker/index.tsx
@@ -84,7 +84,7 @@ const DatePicker = forwardRef<
       trappedContent = true,
       onMountAutoFocus,
       onUnmountAutoFocus,
-      position = 'top-start',
+      position = 'bottom-start',
       offset = 8,
       sx: contentSx,
       ...otherContentProps

--- a/packages/wds/src/components/menu/index.tsx
+++ b/packages/wds/src/components/menu/index.tsx
@@ -128,7 +128,7 @@ MenuTrigger.displayName = MENU_TRIGGER_NAME;
 const MenuContent = forwardRef(
   <T extends ElementType = 'div'>(
     {
-      position = 'top-center',
+      position = 'bottom-center',
       offset,
       container,
       disablePortal,

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -282,6 +282,7 @@ const Select = forwardRef<
 
           <MenuContent
             offset={8}
+            position="bottom-center"
             {...contentProps}
             sx={[
               { width: contentWidth ?? '320px', minWidth: '140px' },

--- a/packages/wds/src/components/time-picker/index.tsx
+++ b/packages/wds/src/components/time-picker/index.tsx
@@ -82,7 +82,7 @@ const TimePicker = forwardRef<
       trappedContent = true,
       onMountAutoFocus,
       onUnmountAutoFocus,
-      position = 'top-start',
+      position = 'bottom-start',
       offset,
       sx: contentSx,
       ...otherContentProps


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated default placement to open below by default across components: DatePicker, TimePicker, Menu, Select, and AutocompleteList (e.g., bottom-start or bottom-center), improving consistency and visibility of dropdowns/popovers.

- Chores
  - Added a codemod to automatically migrate position-related props for multiple components (including TooltipContent), updating attributes and nested content props to the new positioning scheme for easier upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->