### PR TITLE
feat(wds): support disableFocusScope, disableAriaHiddenOthers and update popover design

### DIFF
--- a/packages/wds/src/components/alert/index.tsx
+++ b/packages/wds/src/components/alert/index.tsx
@@ -170,6 +170,8 @@ const AlertContainer = forwardRef(
       disableOutsideClickClose = false,
       disableEscapeKeyDownClose,
       disableRemoveScroll = false,
+      disableFocusScope = false,
+      disableAriaHiddenOthers = false,
       disablePortal,
       container,
       onDismiss,
@@ -197,10 +199,10 @@ const AlertContainer = forwardRef(
     useEffect(() => {
       const element = containerRef.current;
 
-      if (element && isPresent) {
+      if (element && isPresent && !disableAriaHiddenOthers) {
         return hideOthers(element);
       }
-    }, [isPresent]);
+    }, [isPresent, disableAriaHiddenOthers]);
 
     if (!isPresent) return null;
 
@@ -221,7 +223,7 @@ const AlertContainer = forwardRef(
           >
             {dimmer}
 
-            <FocusScope loop trapped>
+            <FocusScope loop trapped disableFocusScope={disableFocusScope}>
               <DismissableLayer
                 onPointerDownOutside={(e) => {
                   const originalEvent = e.detail.originalEvent;

--- a/packages/wds/src/components/alert/types.ts
+++ b/packages/wds/src/components/alert/types.ts
@@ -1,3 +1,4 @@
+import type { FocusScopeProps } from '../focus-scope';
 import type { ReactNode } from 'react';
 import type {
   DefaultComponentProps,
@@ -30,6 +31,8 @@ export type AlertContainerProps = Merge<
     disableOutsideClickClose?: boolean;
     disableEscapeKeyDownClose?: boolean;
     disableRemoveScroll?: boolean;
+    disableFocusScope?: FocusScopeProps['disableFocusScope'];
+    disableAriaHiddenOthers?: boolean;
     /**
      * When the esc key or dialog outside click is controlled.
      */

--- a/packages/wds/src/components/date-picker/index.tsx
+++ b/packages/wds/src/components/date-picker/index.tsx
@@ -82,6 +82,7 @@ const DatePicker = forwardRef<
       loop = true,
       trapped,
       trappedContent = true,
+      disableFocusScope,
       onMountAutoFocus,
       onUnmountAutoFocus,
       position = 'bottom-start',
@@ -218,6 +219,7 @@ const DatePicker = forwardRef<
               trappedContent={trappedContent}
               onMountAutoFocus={onMountAutoFocus}
               onUnmountAutoFocus={onUnmountAutoFocus}
+              disableFocusScope={disableFocusScope}
             >
               <DismissableLayer
                 asChild

--- a/packages/wds/src/components/focus-scope/index.tsx
+++ b/packages/wds/src/components/focus-scope/index.tsx
@@ -37,6 +37,51 @@ const FocusScope = forwardRef<
       loop = false,
       trapped = true,
       trappedContent = false,
+      disableFocusScope = false,
+      children,
+      onMountAutoFocus,
+      onUnmountAutoFocus,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    if (disableFocusScope) {
+      return (
+        <Slot ref={forwardedRef} {...props}>
+          {children}
+        </Slot>
+      );
+    }
+
+    return (
+      <FocusScopeWrapper
+        {...props}
+        ref={forwardedRef}
+        loop={loop}
+        trapped={trapped}
+        trappedContent={trappedContent}
+        onMountAutoFocus={onMountAutoFocus}
+        onUnmountAutoFocus={onUnmountAutoFocus}
+      >
+        {children}
+      </FocusScopeWrapper>
+    );
+  },
+);
+
+FocusScope.displayName = 'FocusScope';
+
+type FocusScopeAPI = { paused: boolean; pause(): void; resume(): void };
+
+const FocusScopeWrapper = forwardRef<
+  HTMLElement,
+  DefaultComponentPropsInternal<FocusScopeProps, 'div'>
+>(
+  (
+    {
+      loop = false,
+      trapped = true,
+      trappedContent = false,
       onMountAutoFocus: onMountAutoFocusProp,
       onUnmountAutoFocus: onUnmountAutoFocusProp,
       ...props
@@ -235,10 +280,6 @@ const FocusScope = forwardRef<
     );
   },
 );
-
-FocusScope.displayName = 'FocusScope';
-
-type FocusScopeAPI = { paused: boolean; pause(): void; resume(): void };
 
 const createFocusScopesStack = () => {
   let stack: Array<FocusScopeAPI> = [];

--- a/packages/wds/src/components/focus-scope/types.ts
+++ b/packages/wds/src/components/focus-scope/types.ts
@@ -11,6 +11,7 @@ export type FocusScopeProps = {
    * Whether the focus is within the internal content area outside the container.
    */
   trappedContent?: boolean;
+  disableFocusScope?: boolean;
   onMountAutoFocus?: (event: Event) => void;
   onUnmountAutoFocus?: (event: Event) => void;
 };

--- a/packages/wds/src/components/menu/types.ts
+++ b/packages/wds/src/components/menu/types.ts
@@ -35,6 +35,7 @@ export type MenuContentProps = Pick<
   | 'wrapperProps'
   | 'forceMount'
   | 'onInteractOutside'
+  | 'disableFocusScope'
   | 'onFocusOutside'
   | 'onPointerDownOutside'
   | 'onDismiss'

--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -193,6 +193,8 @@ const ModalContainer = forwardRef(
       disableEscapeKeyDownClose = false,
       disableRemoveScroll = false,
       disablePortal = false,
+      disableFocusScope = false,
+      disableAriaHiddenOthers = false,
       forceMount = false,
       sticky = true,
       wrapperProps,
@@ -254,7 +256,7 @@ const ModalContainer = forwardRef(
     useEffect(() => {
       const content = containerRef.current;
 
-      if (content && isPresent) {
+      if (content && isPresent && !disableAriaHiddenOthers) {
         const undo = hideOthers(content);
 
         if (isBottomSheetWithHandle && context.visibility === 'hidden') {
@@ -266,7 +268,12 @@ const ModalContainer = forwardRef(
         return undo;
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isBottomSheetWithHandle, context.visibility, isPresent]);
+    }, [
+      isBottomSheetWithHandle,
+      context.visibility,
+      isPresent,
+      disableAriaHiddenOthers,
+    ]);
 
     if (!isPresent) return null;
 
@@ -303,6 +310,7 @@ const ModalContainer = forwardRef(
           <FocusScope
             loop={open && context.visibility === 'visible'}
             trapped={open && context.visibility === 'visible'}
+            disableFocusScope={disableFocusScope}
           >
             <DismissableLayer
               asChild

--- a/packages/wds/src/components/modal/types.ts
+++ b/packages/wds/src/components/modal/types.ts
@@ -1,3 +1,4 @@
+import type { FocusScopeProps } from '../focus-scope';
 import type { SlotProps } from '@radix-ui/react-slot';
 import type {
   TopNavigationButtonProps,
@@ -54,6 +55,8 @@ type ModalContainerDefaultProps = WithSxProps<{
   disableOutsideClickClose?: boolean;
   disableEscapeKeyDownClose?: boolean;
   disableRemoveScroll?: boolean;
+  disableFocusScope?: FocusScopeProps['disableFocusScope'];
+  disableAriaHiddenOthers?: boolean;
   /**
    * React Portal does not support SSR, so it is used to support Server Side Rendering.
    *

--- a/packages/wds/src/components/pagination/index.tsx
+++ b/packages/wds/src/components/pagination/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useId, useMemo, useState } from 'react';
+import { forwardRef, useId, useMemo } from 'react';
 import {
   IconChevronLeftTightSmall,
   IconChevronRightTightSmall,
@@ -271,6 +271,10 @@ const PaginationSelect = forwardRef<
       optionRender,
       onChange,
       disabled,
+      open: givenOpen,
+      defaultOpen,
+      onOpenChange,
+      contentProps,
       ...props
     },
     ref,
@@ -279,7 +283,11 @@ const PaginationSelect = forwardRef<
       PAGINATION_SELECT_NAME,
     );
 
-    const [open, setOpen] = useState(false);
+    const [open = false, setOpen] = useControllableState({
+      prop: givenOpen,
+      defaultProp: defaultOpen,
+      onChange: onOpenChange,
+    });
 
     const [pageSize = defaultPageSize, setPageSize] =
       useControllableState<number>({
@@ -323,11 +331,15 @@ const PaginationSelect = forwardRef<
 
         <MenuContent
           offset={8}
-          position="top-start"
+          position="bottom-start"
           data-role="pagination-select-content"
-          sx={{
-            width: '140px',
-          }}
+          {...contentProps}
+          sx={[
+            {
+              width: '140px',
+            },
+            contentProps?.sx,
+          ]}
         >
           <MenuList role="listbox">
             {pageSizeOptions.map((option) => (

--- a/packages/wds/src/components/pagination/types.ts
+++ b/packages/wds/src/components/pagination/types.ts
@@ -1,6 +1,11 @@
+import type { MenuContent } from '../menu';
 import type { TextFieldProps } from '../text-field/types';
 import type { Merge, WithSxProps } from '@wanteddev/wds-engine';
-import type { MouseEventHandler, ReactNode } from 'react';
+import type {
+  ComponentPropsWithoutRef,
+  MouseEventHandler,
+  ReactNode,
+} from 'react';
 import type { FlexBoxProps } from '../flex-box/types';
 
 export type PaginationProps = Merge<PaginationDefaultProps, FlexBoxProps>;
@@ -56,6 +61,10 @@ export type PaginationSelectDefaultProps = WithSxProps<{
   disabled?: boolean;
   optionRender?: (pageSize: number) => ReactNode;
   onChange?: (pageSize?: number) => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  defaultOpen?: boolean;
+  contentProps?: ComponentPropsWithoutRef<typeof MenuContent>;
 }>;
 
 export type PaginationSelectProps = Merge<

--- a/packages/wds/src/components/popover/index.tsx
+++ b/packages/wds/src/components/popover/index.tsx
@@ -135,6 +135,7 @@ const PopoverContent = forwardRef(
       action,
       variant = 'normal',
       heading,
+      disableFocusScope,
       __scopePopover = 'Popover',
       ...props
     }: PolymorphicPropsInternal<ScopedProps<PopoverContentProps, 'Popover'>, T>,
@@ -167,6 +168,7 @@ const PopoverContent = forwardRef(
             loop={loop}
             trapped={trapped}
             trappedContent={trappedContent}
+            disableFocusScope={disableFocusScope}
             onMountAutoFocus={onMountAutoFocus}
             onUnmountAutoFocus={onUnmountAutoFocus}
           >
@@ -195,78 +197,126 @@ const PopoverContent = forwardRef(
                 as={as}
                 gap="4px"
                 {...props}
-                sx={[popoverStyle, props.sx]}
+                sx={[popoverStyle(variant), props.sx]}
               >
                 {variant === 'custom' ? (
                   children
                 ) : (
                   <>
                     <FlexBox
-                      flexDirection="column"
                       data-role="popover-content-wrapper"
                       sx={{ paddingInline: '4px' }}
-                      gap="10px"
                       flex="1"
+                      flexDirection={heading ? 'column' : 'row'}
+                      gap={heading ? '6px' : '4px'}
                     >
-                      <FlexBox
-                        flexDirection="column"
-                        data-role="popover-content-heading-wrapper"
-                        gap="2px"
-                      >
-                        {heading && (
-                          <Typography
-                            id={headingId}
-                            variant="headline2"
-                            weight="bold"
-                            color="semantic.label.normal"
-                            data-role="popover-content-heading"
-                          >
-                            {heading}
-                          </Typography>
-                        )}
-
-                        <Typography
-                          id={descriptionId}
-                          variant="body2-reading"
-                          weight="medium"
-                          color="semantic.label.neutral"
-                          data-role="popover-content-description"
-                        >
-                          {children}
-                        </Typography>
-                      </FlexBox>
-
-                      {action && (
-                        <TextButtonProvider assistive="semantic.label.alternative">
+                      {heading ? (
+                        <>
                           <FlexBox
-                            data-role="popover-content-action"
-                            flexShrink="0"
-                            alignItems="center"
-                            gap="16px"
-                            sx={{ height: '20px' }}
+                            data-role="popover-content-heading-wrapper"
+                            gap="4px"
                           >
-                            {action}
+                            <Typography
+                              id={headingId}
+                              variant="body2"
+                              weight="bold"
+                              color="semantic.label.normal"
+                              data-role="popover-content-heading"
+                              sx={{
+                                width: '100%',
+                              }}
+                            >
+                              {heading}
+                            </Typography>
+
+                            {closeButton && (
+                              <FlexBox
+                                data-role="popover-content-close-button"
+                                flexShrink="0"
+                                alignItems="center"
+                                justifyContent="center"
+                                sx={{ padding: '3px', height: 'fit-content' }}
+                              >
+                                <IconButton
+                                  size={16}
+                                  onClick={() => onOpenChange(false)}
+                                  aria-label="Close dialog"
+                                  sx={(theme) => ({
+                                    opacity: theme.opacity[61],
+                                  })}
+                                >
+                                  <IconClose />
+                                </IconButton>
+                              </FlexBox>
+                            )}
                           </FlexBox>
-                        </TextButtonProvider>
+
+                          <Typography
+                            id={descriptionId}
+                            variant="label2"
+                            weight="medium"
+                            color="semantic.label.neutral"
+                            data-role="popover-content-description"
+                          >
+                            {children}
+                          </Typography>
+                        </>
+                      ) : (
+                        <>
+                          <Typography
+                            id={descriptionId}
+                            variant="label2"
+                            weight="medium"
+                            color="semantic.label.neutral"
+                            data-role="popover-content-description"
+                            sx={{ padding: '2px 0px', width: '100%' }}
+                          >
+                            {children}
+                          </Typography>
+                          {closeButton && (
+                            <FlexBox
+                              data-role="popover-content-close-button"
+                              flexShrink="0"
+                              alignItems="center"
+                              justifyContent="center"
+                              sx={{ padding: '3px', height: 'fit-content' }}
+                            >
+                              <IconButton
+                                size={16}
+                                onClick={() => onOpenChange(false)}
+                                aria-label="Close dialog"
+                                sx={(theme) => ({ opacity: theme.opacity[61] })}
+                              >
+                                <IconClose />
+                              </IconButton>
+                            </FlexBox>
+                          )}
+                        </>
                       )}
                     </FlexBox>
 
-                    {closeButton && (
-                      <FlexBox
-                        data-role="popover-content-close-button"
-                        flexShrink="0"
-                        alignItems="center"
-                        justifyContent="center"
-                        sx={{ padding: '4px', height: 'fit-content' }}
-                      >
-                        <IconButton
-                          size={16}
-                          onClick={() => onOpenChange(false)}
-                          aria-label="Close dialog"
+                    {action && (
+                      <TextButtonProvider assistive="semantic.label.alternative">
+                        <FlexBox
+                          data-role="popover-content-action-wrapper"
+                          flexShrink="0"
+                          alignItems="flex-end"
+                          flex="1"
+                          flexDirection="column"
+                          sx={{ marginTop: '16px' }}
                         >
-                          <IconClose />
-                        </IconButton>
-                      </FlexBox>
+                          <FlexBox
+                            data-role="popover-content-action"
+                            alignItems="center"
+                            gap="16px"
+                            sx={{
+                              height: '20px',
+                            }}
+                          >
+                            {action}
+                          </FlexBox>
+                        </FlexBox>
+                      </TextButtonProvider>
                     )}
                   </>
                 )}

--- a/packages/wds/src/components/popover/style.ts
+++ b/packages/wds/src/components/popover/style.ts
@@ -2,17 +2,37 @@ import { css } from '@wanteddev/wds-engine';
 
 import { addOpacity } from '../../utils';
 
+import type { PopoverContentProps } from './types';
 import type { Theme } from '@wanteddev/wds-engine';
 
-export const popoverStyle = (theme: Theme) => css`
-  background-color: ${addOpacity(
-    theme.semantic.background.elevated.normal,
-    theme.opacity[88],
-  )};
-  border-radius: 16px;
-  padding: 16px;
-  outline-style: none;
-  box-shadow: ${theme.semantic.elevation.shadow.spread.small};
-  backdrop-filter: blur(32px);
-  min-width: 140px;
-`;
+export const popoverStyle =
+  (variant: PopoverContentProps['variant']) => (theme: Theme) => css`
+    background-color: ${addOpacity(
+      theme.semantic.background.elevated.normal,
+      theme.opacity[88],
+    )};
+    border-radius: 16px;
+    outline-style: none;
+    box-shadow: ${theme.semantic.elevation.shadow.spread.small};
+    backdrop-filter: blur(32px);
+    min-width: 140px;
+
+    ${popoverVariantStyle(variant)}
+  `;
+
+const popoverVariantStyle = (variant: PopoverContentProps['variant']) => {
+  switch (variant) {
+    case 'custom':
+      return css`
+        padding: 16px;
+      `;
+    case 'normal':
+    default:
+      return css`
+        padding: 12px 14px;
+        max-width: 360px;
+        flex-direction: column;
+        gap: 0px;
+      `;
+  }
+};

--- a/packages/wds/src/components/popover/types.ts
+++ b/packages/wds/src/components/popover/types.ts
@@ -49,6 +49,7 @@ export type PopoverContentProps = WithSxProps<
     | 'onUnmountAutoFocus'
     | 'trapped'
     | 'loop'
+    | 'disableFocusScope'
   > &
     Pick<
       DismissableLayerProps,

--- a/packages/wds/src/components/time-picker/index.tsx
+++ b/packages/wds/src/components/time-picker/index.tsx
@@ -83,6 +83,7 @@ const TimePicker = forwardRef<
       onMountAutoFocus,
       onUnmountAutoFocus,
       position = 'bottom-start',
+      disableFocusScope,
       offset,
       sx: contentSx,
       ...otherContentProps
@@ -223,6 +224,7 @@ const TimePicker = forwardRef<
               trappedContent={trappedContent}
               onMountAutoFocus={onMountAutoFocus}
               onUnmountAutoFocus={onUnmountAutoFocus}
+              disableFocusScope={disableFocusScope}
             >
               <DismissableLayer
                 asChild


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional controls to disable focus trapping and hiding of background content in alerts, modals, popovers, menus, and date/time pickers for greater accessibility flexibility.
  - PaginationSelect now supports controlled open state (open, defaultOpen, onOpenChange) and customizable content props.

- Enhancements
  - Popover layout refined: improved heading/description structure, integrated close button, optional action area, and variant-aware styling.
  - PaginationSelect menu now opens from bottom-start; content styling is more customizable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->