### PR TITLE
feat(wds): add data attribute for resolved position in popper

### DIFF
--- a/packages/wds/src/components/popper/index.tsx
+++ b/packages/wds/src/components/popper/index.tsx
@@ -246,7 +246,7 @@ const PopperContent = forwardRef<
       if (content) setContentZIndex(window.getComputedStyle(content).zIndex);
     }, [content]);
 
-    const [side] = getSideAlignFromPlacement(placementResult);
+    const [side, align] = getSideAlignFromPlacement(placementResult);
 
     useEffect(() => {
       setContext?.(floatingContext);
@@ -258,6 +258,9 @@ const PopperContent = forwardRef<
           wds-ignore-dismissable-layer="true"
           ref={refs.setFloating}
           {...wrapperProps}
+          data-side={side}
+          data-align={align}
+          data-placement={placementResult}
           style={{
             ...wrapperProps.style,
             ...floatingStyles,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internal Improvements**
  * The popper wrapper now exposes side, align, and placement via data attributes on the rendered element, enabling more flexible styling, targeted selectors, and refined layout control for UI adjustments.
  * Placement behavior and public API are unchanged; this only surfaces extra metadata for styling and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->