### PR TITLE
fix(wds): fixed bottom sheet min width and emphasized navigation broken

### DIFF
--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -571,7 +571,13 @@ const ModalNavigation = forwardRef<
   DefaultComponentPropsInternal<ModalNavigationProps, 'div'>
 >(
   (
-    { leadingContent, trailingContent = <ModalClose />, variant, ...props },
+    {
+      leadingContent,
+      trailingContent = <ModalClose />,
+      variant,
+      children,
+      ...props
+    },
     ref,
   ) => {
     const { titleId } = useModalNavigationContext(MODAL_NAVIGATION_NAME);
@@ -585,6 +591,8 @@ const ModalNavigation = forwardRef<
         variant={variant === 'emphasized' ? undefined : variant}
         sx={[modalNavigationStyle({ variant }), props.sx]}
         ref={ref}
+        // eslint-disable-next-line react/no-children-prop
+        children={variant === 'emphasized' && !children ? <span /> : children}
       />
     );
   },

--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -439,7 +439,7 @@ const modalContainerVariant = (variant: ModalContainerProps['variant']) => {
         border-radius: 12px 12px 0px 0px;
         max-width: 480px;
         width: 100%;
-        min-width: none;
+        min-width: initial;
         overflow: hidden;
         transition:
           transform 200ms ease,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emphasized modal now renders correctly when no child content is provided, avoiding layout breakage.
  * Bottom-sheet modal minimum width adjusted for more consistent layout across browsers.

* **Refactor**
  * Internal component handling of child content clarified to ensure explicit, predictable rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->