### PR TITLE
fix(wds): snackbar extraContent gap to 8px

### DIFF
--- a/packages/wds/src/components/snackbar/index.tsx
+++ b/packages/wds/src/components/snackbar/index.tsx
@@ -176,7 +176,7 @@ const SnackbarContent = forwardRef<
   DefaultComponentPropsInternal<SnackbarContentProps, 'div'>
 >(({ extraContent, children, ...props }, ref) => {
   return (
-    <FlexBox gap="12px" alignItems="center" ref={ref} {...props}>
+    <FlexBox gap="8px" alignItems="center" ref={ref} {...props}>
       {extraContent}
       <FlexBox
         flexDirection="column"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted horizontal spacing in the snackbar content layout for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->