### PR TITLE
feat(wds): chip action in select render prop, change default color to alternative

### DIFF
--- a/packages/wds/src/components/chip-action/contexts.ts
+++ b/packages/wds/src/components/chip-action/contexts.ts
@@ -1,0 +1,14 @@
+import createLooseContext from '../../hooks/internal/use-loose-context';
+
+import type { ThemeColorsToken } from '@wanteddev/wds-engine';
+import type { ChipActionProps } from './types';
+
+type ChipActionContextValue = {
+  [key in NonNullable<ChipActionProps['variant']>]?: ThemeColorsToken;
+};
+
+/**
+ * Used to easily override the default color value of the chip action.
+ */
+export const [ChipActionProvider, useChipActionContext] =
+  createLooseContext<ChipActionContextValue>('AnyComponent');

--- a/packages/wds/src/components/chip-action/index.tsx
+++ b/packages/wds/src/components/chip-action/index.tsx
@@ -4,6 +4,7 @@ import { Box } from '@wanteddev/wds-engine';
 import { WithInteraction } from '../with-interaction';
 
 import { actionStyle } from './style';
+import { useChipActionContext } from './contexts';
 
 import type {
   PolymorphicComponentInternal,
@@ -34,6 +35,7 @@ const ChipAction = forwardRef(
     }: PolymorphicPropsInternal<ChipActionProps, T>,
     ref: ForwardedRef<T>,
   ) => {
+    const context = useChipActionContext();
     const id = useId();
 
     const active = givenActive ?? props['aria-pressed'];
@@ -49,6 +51,10 @@ const ChipAction = forwardRef(
 
       return 'semantic.inverse.label';
     }, [active, variant]);
+
+    const overrideColor = useMemo(() => {
+      return context?.[variant];
+    }, [context, variant]);
 
     return (
       <WithInteraction
@@ -67,7 +73,17 @@ const ChipAction = forwardRef(
           aria-pressed={active}
           {...props}
           sx={[
-            actionStyle({ active, variant, size, xs, sm, md, lg, xl }),
+            actionStyle({
+              overrideColor,
+              active,
+              variant,
+              size,
+              xs,
+              sm,
+              md,
+              lg,
+              xl,
+            }),
             props.sx,
           ]}
         >

--- a/packages/wds/src/components/chip-action/style.ts
+++ b/packages/wds/src/components/chip-action/style.ts
@@ -1,14 +1,18 @@
-import { css } from '@wanteddev/wds-engine';
+import { css, getColorByToken } from '@wanteddev/wds-engine';
 
 import { typographyStyle } from '../../utils/typography';
 import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 import { addOpacity } from '../../utils';
 
 import type { ChipActionProps } from './types';
-import type { Theme } from '@wanteddev/wds-engine';
+import type { Theme, ThemeColorsToken } from '@wanteddev/wds-engine';
+
+type ActionStyleProps = ChipActionProps & {
+  overrideColor?: ThemeColorsToken;
+};
 
 export const actionStyle =
-  ({ xs, sm, md, lg, xl, ...props }: ChipActionProps) =>
+  ({ xs, sm, md, lg, xl, overrideColor, ...props }: ActionStyleProps) =>
   (theme: Theme) => css`
     display: inline-flex;
     align-items: center;
@@ -31,7 +35,7 @@ export const actionStyle =
       cursor: initial;
     }
 
-    ${actionVariantStyle(props, theme)}
+    ${actionVariantStyle({ ...props, overrideColor }, theme)}
     ${actionSizeStyle(props)}
 
   ${createResponsiveStyle(
@@ -108,13 +112,15 @@ const actionSizeStyle = ({ size }: ChipActionProps = {}) => {
 };
 
 const actionVariantStyle = (
-  { variant, active }: ChipActionProps = {},
+  { variant, active, overrideColor }: ActionStyleProps = {},
   theme: Theme,
 ) => {
   switch (variant) {
     case 'solid':
       return css`
-        color: ${theme.semantic.label.normal};
+        color: ${overrideColor
+          ? getColorByToken(theme, overrideColor)
+          : theme.semantic.label.normal};
         background-color: ${theme.semantic.fill.alternative};
         box-shadow: none;
 
@@ -133,7 +139,9 @@ const actionVariantStyle = (
       `;
     case 'outlined':
       return css`
-        color: ${theme.semantic.label.normal};
+        color: ${overrideColor
+          ? getColorByToken(theme, overrideColor)
+          : theme.semantic.label.normal};
         background-color: transparent;
         box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.neutral};
 

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -31,13 +31,13 @@ import {
 import useResizeObserver from '../../hooks/internal/use-resize-observer';
 import { VirtualValueInput } from '../virtual-input';
 import { SelectProvider } from '../select/context';
+import { ChipActionProvider } from '../chip-action/contexts';
 
 import { customSelectMultipleRenderWrapperStyle } from './style';
 
 import type { DefaultComponentPropsInternal } from '@wanteddev/wds-engine';
 import type { UIEventHandler } from 'react';
 import type { SelectMultipleProps } from './types';
-import { ChipActionProvider } from '../chip-action/contexts';
 
 const SelectMultiple = forwardRef<
   HTMLDivElement,

--- a/packages/wds/src/components/select-multiple/index.tsx
+++ b/packages/wds/src/components/select-multiple/index.tsx
@@ -37,6 +37,7 @@ import { customSelectMultipleRenderWrapperStyle } from './style';
 import type { DefaultComponentPropsInternal } from '@wanteddev/wds-engine';
 import type { UIEventHandler } from 'react';
 import type { SelectMultipleProps } from './types';
+import { ChipActionProvider } from '../chip-action/contexts';
 
 const SelectMultiple = forwardRef<
   HTMLDivElement,
@@ -308,16 +309,18 @@ const SelectMultiple = forwardRef<
                     isScrollableRight,
                   })}
                 >
-                  <FlexBox
-                    ref={setRenderWrapperNode}
-                    gap="4px"
-                    flexWrap={overflow ? 'wrap' : 'nowrap'}
-                    onScrollCapture={handleOnScroll}
-                  >
-                    {shouldShowAllSelectedLabel
-                      ? allSelectedLabel
-                      : render(label, value)}
-                  </FlexBox>
+                  <ChipActionProvider solid="semantic.label.alternative">
+                    <FlexBox
+                      ref={setRenderWrapperNode}
+                      gap="4px"
+                      flexWrap={overflow ? 'wrap' : 'nowrap'}
+                      onScrollCapture={handleOnScroll}
+                    >
+                      {shouldShowAllSelectedLabel
+                        ? allSelectedLabel
+                        : render(label, value)}
+                    </FlexBox>
+                  </ChipActionProvider>
                 </FlexBox>
               )}
 

--- a/packages/wds/src/components/select/index.tsx
+++ b/packages/wds/src/components/select/index.tsx
@@ -32,6 +32,7 @@ import { Typography } from '../typography';
 import { invalidIconWrapperStyle } from '../text-field/style';
 import { VirtualValueInput } from '../virtual-input';
 import { ListCellContent } from '../list';
+import { ChipActionProvider } from '../chip-action/contexts';
 
 import { selectIconStyle, selectStyle, selectTextStyle } from './style';
 import { convertChildrenToData } from './helpers';
@@ -122,8 +123,7 @@ const Select = forwardRef<
       () =>
         typeof value === 'string'
           ? value.length === 0
-          : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            !Boolean(value) && value !== 0,
+          : !Boolean(value) && value !== 0,
       [value],
     );
 
@@ -253,14 +253,16 @@ const Select = forwardRef<
               )}
 
               {typeof render === 'function' && !shouldShowPlaceholder && (
-                <FlexBox
-                  flex="1"
-                  gap="4px"
-                  flexWrap="wrap"
-                  data-role="select-render-wrapper"
-                >
-                  {render(label, value)}
-                </FlexBox>
+                <ChipActionProvider solid="semantic.label.alternative">
+                  <FlexBox
+                    flex="1"
+                    gap="4px"
+                    flexWrap="wrap"
+                    data-role="select-render-wrapper"
+                  >
+                    {render(label, value)}
+                  </FlexBox>
+                </ChipActionProvider>
               )}
 
               {invalid && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chip actions now support customizable color overrides for more flexible theming and consistent styling across variants.
  * Select and SelectMultiple components now apply chip color overrides when using custom renderers, ensuring rendered chips match theme customizations.
  * Value-display behavior simplified to improve placeholder handling when rendering custom content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->