### PR TITLE
feat(wds-nextjs): support next 16

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalogs:
     '@next/bundle-analyzer': ^15.5.5
 
   peer-next:
-    next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta
+    next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   emotion:
     '@emotion/cache': ^11.11.0
@@ -47,7 +47,6 @@ onlyBuiltDependencies:
   - nx
   - sharp
   - unrs-resolver
-
 
 engineStrict: true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js peer dependency to support the stable 16.0.0 release, removing beta version qualifier for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->