### PR TITLE
feat(wds): bottom sheet handle 활성화 된 경우 기본적으로 바로 닫히도록 변경

### DIFF
--- a/docs/data/components/presentation/bottom-sheet/web.mdx
+++ b/docs/data/components/presentation/bottom-sheet/web.mdx
@@ -226,10 +226,6 @@ Bottom sheet의 상단에 핸들을 표시하여 드래그로 숨기고 열 수 
 - true
 - false (default)
 
-handle이 활성화된 경우 dimmer 영역 클릭 시 닫히지 않고 아래로 숨겨집니다.
-
-이 때 숨겨지는 영역의 높이는 ModalNavigation의 높이를 사용합니다.
-
 <Demo code={`import {
   FlexBox,
   Button,
@@ -282,7 +278,9 @@ export default Demo;`}
 
 ### Peek height
 
-`peekHeight` 옵션을 사용하면 숨겨지는 영역의 높이를 조정할 수 있습니다.
+`peekHeight` 옵션을 0보다 큰 값으로 설정하면 handle로 조작 혹은 dimmer 영역 클릭 시 닫히지 않고 아래로 숨겨집니다.
+
+이 때 숨겨지는 영역의 높이는 `peekHeight` 값을 사용합니다.
 
 <Demo code={`import {
   FlexBox,
@@ -335,7 +333,7 @@ export default Demo;`}
 
 아래로 숨겨지거나 다시 나타날 때 `onVisibilityChange` 콜백을 사용할 수 있습니다.
 
-해당 콜백을 사용하여 아래로 숨김 처리 되지 않고 바로 닫히게 구성할 수 있습니다.
+해당 콜백을 사용하여 특정 상황에서 아래로 숨김 처리 되지 않고 바로 닫히게 구성할 수 있습니다.
 
 <Demo code={`import { useState } from 'react';
 import {

--- a/packages/wds/src/components/modal/helpers.tsx
+++ b/packages/wds/src/components/modal/helpers.tsx
@@ -1,3 +1,5 @@
+import { BOTTOM_SHEET_SHADOW } from './constants';
+
 export const isTouchEvent = (
   value: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent,
 ): value is TouchEvent | React.TouchEvent => value.type.includes('touch');
@@ -22,4 +24,37 @@ export const isMouseDownOnPeek = (
   const clientY = isTouchEvent(e) ? e.touches[0]!.clientY : e.clientY;
 
   return clientY >= top && clientY <= top + peekHeight;
+};
+
+export const applyPeekState = (
+  container: HTMLDivElement,
+  dimmer: HTMLDivElement | null,
+  peek: number,
+) => {
+  container.style.setProperty(
+    '--wds-modal-translate',
+    `calc(100% - ${peek}px)`,
+  );
+  container.style.setProperty('box-shadow', BOTTOM_SHEET_SHADOW);
+  dimmer?.style.setProperty('opacity', '0');
+};
+
+export const applyVisibleState = (
+  container: HTMLDivElement,
+  dimmer: HTMLDivElement | null,
+) => {
+  container.style.setProperty('--wds-modal-translate', '0px');
+  container.style.removeProperty('box-shadow');
+  dimmer?.style.setProperty('opacity', '1');
+};
+
+export const resetDragStyles = (
+  container: HTMLDivElement,
+  dimmer: HTMLDivElement | null,
+) => {
+  container.style.removeProperty('transition');
+  container.style.removeProperty('--wds-modal-translate');
+  container.style.removeProperty('box-shadow');
+  dimmer?.style.removeProperty('transition');
+  dimmer?.style.removeProperty('opacity');
 };

--- a/packages/wds/src/components/modal/hooks.ts
+++ b/packages/wds/src/components/modal/hooks.ts
@@ -73,7 +73,7 @@ export const useDraggable = ({
     peekHeight.current = givenPeekHeight ?? 0;
   }, [givenPeekHeight]);
 
-  const hasPeek = peekHeight.current > 0;
+  const hasPeek = () => peekHeight.current > 0;
 
   const handleVisibilityHidden = () => {
     const container = context.containerRef.current;
@@ -82,7 +82,7 @@ export const useDraggable = ({
       return;
     }
 
-    if (hasPeek) {
+    if (hasPeek()) {
       context.setVisibility('hidden');
     } else {
       resetDragStyles(container, dimmerRef.current);
@@ -96,7 +96,7 @@ export const useDraggable = ({
       return;
     }
 
-    if (context.visibility === 'hidden' && context.open && hasPeek) {
+    if (context.visibility === 'hidden' && context.open && hasPeek()) {
       container.style.removeProperty('transition');
       container.style.setProperty(
         '--wds-modal-translate',
@@ -125,7 +125,7 @@ export const useDraggable = ({
         (e.target as HTMLElement).closest(
           '[data-role="modal-container-grabber"]',
         ) ||
-        (peekHeight.current > 0 &&
+        (hasPeek() &&
           (e.target as HTMLElement).closest(
             '[wds-component="top-navigation"]',
           )) ||
@@ -238,7 +238,7 @@ export const useDraggable = ({
       }
 
       if (window.innerHeight - clientY <= totalHeight / 1.25) {
-        if (peekHeight.current > 0) {
+        if (hasPeek()) {
           context.setVisibility('hidden');
           applyPeekState(container, dimmerRef.current, peekHeight.current);
         } else {

--- a/packages/wds/src/components/modal/hooks.ts
+++ b/packages/wds/src/components/modal/hooks.ts
@@ -3,13 +3,16 @@ import { useTheme } from '@wanteddev/wds-engine';
 
 import { getPreviousValue } from '../../utils/internal/responsive-props';
 
-import {
-  BOTTOM_SHEET_PEEK_PADDING,
-  BOTTOM_SHEET_SHADOW,
-  MODAL_NAME,
-} from './constants';
+import { BOTTOM_SHEET_SHADOW, MODAL_NAME } from './constants';
 import { useModalContext } from './contexts';
-import { calcOpacityRatio, isMouseDownOnPeek, isTouchEvent } from './helpers';
+import {
+  applyPeekState,
+  applyVisibleState,
+  calcOpacityRatio,
+  isMouseDownOnPeek,
+  isTouchEvent,
+  resetDragStyles,
+} from './helpers';
 
 import type { RefObject } from 'react';
 import type { BreakPoint } from '@wanteddev/wds-engine';
@@ -24,10 +27,8 @@ export const useDraggable = ({
   md,
   lg,
   xl,
-  target,
   dimmerRef,
 }: Omit<ModalContainerProps, 'target'> & {
-  target: HTMLDivElement | null;
   dimmerRef: RefObject<HTMLDivElement | null>;
 }) => {
   const theme = useTheme();
@@ -60,36 +61,19 @@ export const useDraggable = ({
 
   const isDragging = useRef(false);
 
-  const topNavigationHeight = useRef(0);
-
   const startedY = useRef(0);
 
   useEffect(() => {
     setIsBottomSheet(variant === 'bottom');
   }, [variant, setIsBottomSheet]);
 
-  const peekHeight = useRef(
-    givenPeekHeight !== undefined ? Math.max(givenPeekHeight, 20) : undefined,
-  );
+  const peekHeight = useRef(givenPeekHeight ?? 0);
 
   useEffect(() => {
-    peekHeight.current =
-      givenPeekHeight !== undefined ? Math.max(givenPeekHeight, 20) : undefined;
+    peekHeight.current = givenPeekHeight ?? 0;
   }, [givenPeekHeight]);
 
-  const calcTopNavigationHeight = () => {
-    const topNavigation = target?.querySelector(
-      '[wds-component="top-navigation"]',
-    );
-
-    const topNavigationToolbarHeight =
-      target?.querySelector('[data-role="top-navigation-toolbar"]')
-        ?.clientHeight ?? 0;
-
-    topNavigationHeight.current = topNavigation
-      ? topNavigation.clientHeight - topNavigationToolbarHeight
-      : 20;
-  };
+  const hasPeek = peekHeight.current > 0;
 
   const handleVisibilityHidden = () => {
     const container = context.containerRef.current;
@@ -98,7 +82,12 @@ export const useDraggable = ({
       return;
     }
 
-    context.setVisibility('hidden');
+    if (hasPeek) {
+      context.setVisibility('hidden');
+    } else {
+      resetDragStyles(container, dimmerRef.current);
+      context.onOpenChange(false);
+    }
   };
 
   useEffect(() => {
@@ -107,16 +96,11 @@ export const useDraggable = ({
       return;
     }
 
-    calcTopNavigationHeight();
-
-    if (context.visibility === 'hidden' && context.open) {
+    if (context.visibility === 'hidden' && context.open && hasPeek) {
       container.style.removeProperty('transition');
       container.style.setProperty(
         '--wds-modal-translate',
-        `calc(100% - ${
-          peekHeight.current ??
-          topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING
-        }px)`,
+        `calc(100% - ${peekHeight.current}px)`,
       );
       dimmerRef.current?.style.removeProperty('transition');
       dimmerRef.current?.style.removeProperty('opacity');
@@ -141,14 +125,12 @@ export const useDraggable = ({
         (e.target as HTMLElement).closest(
           '[data-role="modal-container-grabber"]',
         ) ||
-        isMouseDownOnPeek(
-          e,
-          peekHeight.current ??
-            topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING,
-        )
+        (peekHeight.current > 0 &&
+          (e.target as HTMLElement).closest(
+            '[wds-component="top-navigation"]',
+          )) ||
+        isMouseDownOnPeek(e, peekHeight.current)
       ) {
-        calcTopNavigationHeight();
-
         startedY.current = isTouchEvent(e) ? e.touches[0]!.clientY : e.clientY;
         isDragging.current = true;
         context.containerRef.current?.style.setProperty('transition', 'none');
@@ -172,10 +154,7 @@ export const useDraggable = ({
       const clientY = isTouchEvent(e) ? e.touches[0]!.clientY : e.clientY;
 
       const minPosition = window.innerHeight - container.clientHeight;
-      const maxPosition =
-        window.innerHeight -
-        (peekHeight.current ??
-          topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING);
+      const maxPosition = window.innerHeight - peekHeight.current;
 
       const handleOpacityRatioStyle = (input: number) => {
         dimmerRef.current?.style.setProperty(
@@ -195,9 +174,7 @@ export const useDraggable = ({
       // Dragging down
       if (diffY > 0) {
         if (context.visibility === 'hidden') {
-          const nextPosition =
-            (peekHeight.current ??
-              topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING) - diffY;
+          const nextPosition = peekHeight.current - diffY;
           handleOpacityRatioStyle(window.innerHeight - nextPosition);
           return container.style.setProperty(
             '--wds-modal-translate',
@@ -215,10 +192,7 @@ export const useDraggable = ({
 
       // Dragging up
       if (diffY < 0 && context.visibility === 'hidden') {
-        const nextPosition =
-          Math.abs(diffY) +
-          (peekHeight.current ??
-            topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING);
+        const nextPosition = Math.abs(diffY) + peekHeight.current;
 
         if (minPosition >= window.innerHeight - nextPosition) {
           handleOpacityRatioStyle(minPosition);
@@ -255,40 +229,25 @@ export const useDraggable = ({
       // Prevent action if moved less than or equal to 10px
       if (Math.abs(startedY.current - clientY) <= 10) {
         if (context.visibility === 'hidden') {
-          container.style.setProperty(
-            '--wds-modal-translate',
-            `calc(100% - ${
-              peekHeight.current ??
-              topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING
-            }px)`,
-          );
-          container.style.setProperty('box-shadow', BOTTOM_SHEET_SHADOW);
-          dimmerRef.current?.style.setProperty('opacity', '0');
+          applyPeekState(container, dimmerRef.current, peekHeight.current);
         } else {
-          container.style.setProperty('--wds-modal-translate', '0px');
-          container.style.removeProperty('box-shadow');
-          dimmerRef.current?.style.setProperty('opacity', '1');
+          applyVisibleState(container, dimmerRef.current);
         }
 
         return;
       }
 
       if (window.innerHeight - clientY <= totalHeight / 1.25) {
-        context.setVisibility('hidden');
-        container.style.setProperty(
-          '--wds-modal-translate',
-          `calc(100% - ${
-            peekHeight.current ??
-            topNavigationHeight.current + BOTTOM_SHEET_PEEK_PADDING
-          }px)`,
-        );
-        container.style.setProperty('box-shadow', BOTTOM_SHEET_SHADOW);
-        dimmerRef.current?.style.setProperty('opacity', '0');
+        if (peekHeight.current > 0) {
+          context.setVisibility('hidden');
+          applyPeekState(container, dimmerRef.current, peekHeight.current);
+        } else {
+          resetDragStyles(container, dimmerRef.current);
+          context.onOpenChange(false);
+        }
       } else {
         context.setVisibility('visible');
-        container.style.setProperty('--wds-modal-translate', '0px');
-        container.style.removeProperty('box-shadow');
-        dimmerRef.current?.style.setProperty('opacity', '1');
+        applyVisibleState(container, dimmerRef.current);
       }
     };
 

--- a/packages/wds/src/components/modal/index.tsx
+++ b/packages/wds/src/components/modal/index.tsx
@@ -248,7 +248,6 @@ const ModalContainer = forwardRef(
         md,
         lg,
         xl,
-        target: context.innerContainer,
         dimmerRef,
       });
 

--- a/packages/wds/src/components/modal/style.ts
+++ b/packages/wds/src/components/modal/style.ts
@@ -519,15 +519,24 @@ export const modalNavigationStyle = ({ variant }: ModalNavigationProps) => {
 export const modalGrabberStyle = (theme: Theme) => css`
   min-width: inherit;
   position: absolute;
-  padding: 7px 2px 0px 2px;
-  margin-bottom: 8px;
-  background-color: ${theme.semantic.background.elevated.normal};
+  padding: 7px 2px;
   width: 100%;
   top: 0;
   left: 0;
   transform: translate3d(0, 0, 0);
   z-index: 10;
   touch-action: pan-y;
+
+  &::before {
+    content: '';
+    background-color: ${theme.semantic.background.elevated.normal};
+    width: 100%;
+    height: calc(100% - 7px);
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: -1;
+  }
 
   &::after {
     content: '';

--- a/packages/wds/src/components/modal/types.ts
+++ b/packages/wds/src/components/modal/types.ts
@@ -35,7 +35,8 @@ type ModalContainerDefaultProps = WithSxProps<{
   handle?: boolean;
   /**
    * When `variant=bottom` and `handle=true`, sets the bottom sheet's peek height (px).
-   * If the peek height is not set, the bottom sheet will be peeked with navigation height.
+   * Defaults to 0, which means the bottom sheet will close completely when dragged down.
+   * If set to a value greater than 0, the bottom sheet will peek at the given height.
    */
   peekHeight?: number;
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 바텀 시트 문서를 갱신: peekHeight가 0보다 크면 시트가 해당 높이에서 멈추며 핸들 드래그나 디머 클릭으로 닫히지 않음을 명확히 했습니다.
  * Visibility 설명을 개선해 onVisibilityChange로 즉시 닫힘 또는 하강 비허용 시나리오를 구성할 수 있음을 명시했습니다.
* **Bug Fixes**
  * 피크가 없는 경우 드래그로 내릴 때 시트가 안정적으로 닫히도록 동작을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->