### PR TITLE
fix(wds): next.js 16부터 as={Link} 사용시 타입 오류 나는 현상

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/inquirer": "^9.0.7",
+    "@types/node": "^22.17.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/shelljs": "^0.8.15",

--- a/packages/eslint-plugin-wds/package.json
+++ b/packages/eslint-plugin-wds/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "build": "tsdown",
+    "build": "tsc --noEmit && tsdown",
     "watch": "tsdown --watch"
   },
   "repository": {

--- a/packages/wds-codemod/package.json
+++ b/packages/wds-codemod/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "watch": "tsdown --watch",
-    "build": "tsdown"
+    "build": "tsc --noEmit && tsdown"
   },
   "repository": {
     "url": "https://github.com/wanteddev/wds",

--- a/packages/wds-engine/package.json
+++ b/packages/wds-engine/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsc --noEmit && tsdown",
     "watch": "tsdown --watch",
     "lint": "eslint",
     "lint:fix": "eslint --fix"

--- a/packages/wds-engine/src/types/index.ts
+++ b/packages/wds-engine/src/types/index.ts
@@ -55,6 +55,14 @@ export type DistributiveOmit<T, K extends keyof any> = T extends any
 export type Merge<T, K> = T & DistributiveOmit<K, keyof T>;
 
 /**
+ * Merges custom props with element props, excluding the element's `as` prop
+ * to prevent conflicts with the polymorphic `as` prop
+ * (e.g., Next.js Link's `as?: Url`).
+ */
+type MergeElementProps<P, C extends ElementType> = P &
+  DistributiveOmit<ComponentPropsWithoutRef<C>, keyof P | 'as'>;
+
+/**
  * Adds the `sx` prop to a given props type for custom Emotion styling.
  *
  * @example
@@ -88,9 +96,9 @@ export { CSSInterpolation };
  * @example
  * type Props = OverrideProps<{ custom: string }, 'a'>;
  */
-export type OverrideProps<P, C extends ElementType> = Merge<
+export type OverrideProps<P, C extends ElementType> = MergeElementProps<
   P,
-  ComponentPropsWithoutRef<C>
+  C
 > & {
   ref?: Ref<ComponentRef<C>>;
   sx?: SxProp;
@@ -105,9 +113,9 @@ export type OverrideProps<P, C extends ElementType> = Merge<
  * @example
  * type Props = OverridePropsInternal<{ custom: string }, 'a'>;
  */
-export type OverridePropsInternal<P, C extends ElementType> = Merge<
+export type OverridePropsInternal<P, C extends ElementType> = MergeElementProps<
   P,
-  ComponentPropsWithoutRef<C>
+  C
 > & {
   ref?: Ref<ComponentRef<C>>;
 };
@@ -163,10 +171,10 @@ export interface PolymorphicComponent<P, E extends ElementType = 'div'> {
  * @template P Custom props
  * @template E React element type (default: 'div')
  */
-export type DefaultComponentProps<P, E extends ElementType = 'div'> = Merge<
+export type DefaultComponentProps<
   P,
-  ComponentPropsWithoutRef<E>
-> & {
+  E extends ElementType = 'div',
+> = MergeElementProps<P, E> & {
   sx?: SxProp;
   ref?: Ref<ComponentRef<E>>;
 };
@@ -190,7 +198,7 @@ export type DefaultComponentProps<P, E extends ElementType = 'div'> = Merge<
 export type DefaultComponentPropsInternal<
   P,
   E extends ElementType = 'div',
-> = Merge<P, ComponentPropsWithoutRef<E>> & {
+> = MergeElementProps<P, E> & {
   ref?: Ref<ComponentRef<E>>;
 };
 

--- a/packages/wds-icon/package.json
+++ b/packages/wds-icon/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/wds-icon"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsc --noEmit && tsdown",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "watch": "tsup --watch"

--- a/packages/wds-lottie/package.json
+++ b/packages/wds-lottie/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "watch": "tsdown --watch",
-    "build": "tsdown",
+    "build": "tsc --noEmit && tsdown",
     "lint": "eslint",
     "lint:fix": "eslint --fix"
   },

--- a/packages/wds-mcp/package.json
+++ b/packages/wds-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wanteddev/wds-mcp",
-  "version": "3.2.0",
+  "version": "0.0.7",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.24.3",
     "@wanteddev/wds-icon": "workspace:*",

--- a/packages/wds-nextjs/package.json
+++ b/packages/wds-nextjs/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "watch": "tsdown --watch",
-    "build": "tsdown"
+    "build": "tsc --noEmit && tsdown"
   },
   "repository": {
     "url": "https://github.com/wanteddev/wds",

--- a/packages/wds-theme/package.json
+++ b/packages/wds-theme/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "build": "tsdown",
+    "build": "tsc --noEmit && tsdown",
     "watch": "tsdown --watch"
   },
   "repository": {

--- a/packages/wds/package.json
+++ b/packages/wds/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "build": "tsdown && node scripts/build.mjs",
+    "build": "tsc --noEmit && tsdown && node scripts/build.mjs",
     "watch": "tsdown --watch && node scripts/build.mjs"
   },
   "repository": {
@@ -37,7 +37,6 @@
     "directory": "packages/wds"
   },
   "devDependencies": {
-    "@types/node": "^22.13.14",
     "@types/object-path": "^0.11.4",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/packages/wds/src/components/autocomplete/types.ts
+++ b/packages/wds/src/components/autocomplete/types.ts
@@ -38,16 +38,18 @@ export type AutocompleteFieldProps = SlotProps;
 
 export type AutocompleteTriggerProps = PropsWithChildren;
 
-export type AutocompleteListProps = Merge<
-  {
-    /**
-     * When `asSelect=true`, the first focus is not specified.
-     */
-    disableTrappedContent?: boolean;
-    /** Keeps the autocomplete list mounted in the DOM even when open is false. */
-    forceMount?: boolean;
-  },
-  PopperContentProps
+export type AutocompleteListProps = WithSxProps<
+  Merge<
+    {
+      /**
+       * When `asSelect=true`, the first focus is not specified.
+       */
+      disableTrappedContent?: boolean;
+      /** Keeps the autocomplete list mounted in the DOM even when open is false. */
+      forceMount?: boolean;
+    },
+    PopperContentProps
+  >
 >;
 
 export type AutocompleteGroupProps = Merge<

--- a/packages/wds/src/components/toast/types.ts
+++ b/packages/wds/src/components/toast/types.ts
@@ -4,25 +4,27 @@ import type { TypographyProps } from '../typography/types';
 import type { FlexBoxProps } from '../flex-box/types';
 import type { RegionToastItem } from '../../stores/region-store';
 import type { ReactNode } from 'react';
+import type { WithSxProps } from '@wanteddev/wds-engine';
 
 export type ToastProps = Pick<
   RegionToastItem,
   'duration' | 'variant' | 'icon' | 'onAnimationEnd'
-> & {
-  /** Whether the toast is open by default. */
-  defaultOpen?: boolean;
-  /** Whether the toast is open. */
-  open?: boolean;
-  /** Callback function when the open state changes. */
-  onOpenChange?: (open: boolean) => void;
-  /** The container of the toast. */
-  container?: PortalOrFragmentProps['container'];
-  /** Whether to disable the portal. */
-  disablePortal?: PortalOrFragmentProps['disablePortal'];
-  /** Whether to disable the animation. */
-  disableAnimation?: boolean;
-  children?: ReactNode;
-};
+> &
+  WithSxProps<{
+    /** Whether the toast is open by default. */
+    defaultOpen?: boolean;
+    /** Whether the toast is open. */
+    open?: boolean;
+    /** Callback function when the open state changes. */
+    onOpenChange?: (open: boolean) => void;
+    /** The container of the toast. */
+    container?: PortalOrFragmentProps['container'];
+    /** Whether to disable the portal. */
+    disablePortal?: PortalOrFragmentProps['disablePortal'];
+    /** Whether to disable the animation. */
+    disableAnimation?: boolean;
+    children?: ReactNode;
+  }>;
 
 export type ToastContainerProps = FlexBoxProps;
 export type ToastIconProps = SlotProps;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@types/inquirer':
         specifier: ^9.0.7
         version: 9.0.7
+      '@types/node':
+        specifier: ^22.17.0
+        version: 22.17.0
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -413,9 +416,6 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.5.0(react@19.2.3))
     devDependencies:
-      '@types/node':
-        specifier: ^22.13.14
-        version: 22.17.0
       '@types/object-path':
         specifier: ^0.11.4
         version: 0.11.4

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "strictNullChecks": true,
     "target": "ES2022",
     "types": [
+      "node",
       "vitest/globals",
       "@testing-library/jest-dom",
       "vitest-axe/extend-expect"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  - 모든 패키지의 빌드 스크립트에 TypeScript 타입 검사 단계 추가
  - Node.js 타입 정의 지원 추가
  - TypeScript 컴파일러 설정 강화

* **Refactor**
  - 컴포넌트 prop 타입 정의 시스템 개선
  - 자동 완성 및 알림 컴포넌트 prop 타입 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->