### PR TITLE
feat(wds-mcp,ci): versioned docs 배포 지원

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,12 +23,22 @@ on:
         options:
           - "www"
           - "dev"
+      version_path:
+        description: "Versioned docs path (e.g., 3.4.x)"
+        required: false
+        default: ""
+        type: string
   workflow_call:
     inputs:
       server_type:
         description: Server type
         required: false
         default: "dev"
+        type: string
+      version_path:
+        description: "Versioned docs path (e.g., 3.4.x). When set, deploys to /{version_path}/ instead of root."
+        required: false
+        default: ""
         type: string
 
 env:
@@ -83,6 +93,7 @@ jobs:
           echo "AWS_REGION=$AWS_REGION" >> $GITHUB_OUTPUT
           echo "SERVER_TYPE=$SERVER_TYPE" >> $GITHUB_OUTPUT
           echo "CLOUDFRONT_DISTRIBUTION_ID=$CLOUDFRONT_DISTRIBUTION_ID" >> $GITHUB_OUTPUT
+          echo "VERSION_PATH=${{ inputs.version_path }}" >> $GITHUB_OUTPUT
     outputs:
       is_preview: ${{ steps.env-vars.outputs.IS_PREVIEW }}
       node_version: ${{ steps.env-vars.outputs.NODE_VERSION }}
@@ -91,6 +102,7 @@ jobs:
       bucket: ${{ steps.env-vars.outputs.BUCKET }}
       cloudfront_distribution_id: ${{ steps.env-vars.outputs.CLOUDFRONT_DISTRIBUTION_ID }}
       server_type: ${{ steps.env-vars.outputs.SERVER_TYPE }}
+      version_path: ${{ steps.env-vars.outputs.VERSION_PATH }}
 
   set-pnpm:
     needs: [set-env]
@@ -117,6 +129,8 @@ jobs:
 
         if [ "${{ needs.set-env.outputs.is_preview }}" = "true" ]; then
           NEXT_PUBLIC_SERVER_TYPE=${{ needs.set-env.outputs.server_type }} PREVIEW_HASH=${{ needs.set-env.outputs.short_commit_hash }} pnpm -F docs build
+        elif [ -n "${{ needs.set-env.outputs.version_path }}" ]; then
+          NEXT_PUBLIC_SERVER_TYPE=${{ needs.set-env.outputs.server_type }} VERSION_PATH=${{ needs.set-env.outputs.version_path }} pnpm -F docs build
         else
           NEXT_PUBLIC_SERVER_TYPE=${{ needs.set-env.outputs.server_type }} pnpm -F docs build
         fi
@@ -137,6 +151,9 @@ jobs:
         if [ "${{ needs.set-env.outputs.is_preview }}" = "true" ]; then
           S3_PATH="s3://${{ needs.set-env.outputs.bucket }}/${{ needs.set-env.outputs.short_commit_hash }}"
           CLOUDFRONT_PATH="/${{ needs.set-env.outputs.short_commit_hash }}/*"
+        elif [ -n "${{ needs.set-env.outputs.version_path }}" ]; then
+          S3_PATH="s3://${{ needs.set-env.outputs.bucket }}/${{ needs.set-env.outputs.version_path }}"
+          CLOUDFRONT_PATH="/${{ needs.set-env.outputs.version_path }}/*"
         else
           S3_PATH="s3://${{ needs.set-env.outputs.bucket }}"
           CLOUDFRONT_PATH="/*"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       increment:
-        description: "SemVer Increment (prepatch = bump alpha)"
+        description: 'SemVer Increment (prepatch = bump alpha)'
         required: true
-        default: "prepatch"
+        default: 'prepatch'
         type: choice
         options:
           - prerelease
@@ -19,8 +19,8 @@ on:
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
   GH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-  SLACK_CHANNEL: "#wds-deploy"
-  SERVICE: "WDS"
+  SLACK_CHANNEL: '#wds-deploy'
+  SERVICE: 'WDS'
 
 jobs:
   deploy:
@@ -45,6 +45,16 @@ jobs:
       - run: echo ""
       - name: Publish
         run: pnpm run lerna-deploy ${{ inputs.increment }} --force-publish --dist-tag ${{ contains(inputs.increment, 'pre') && 'alpha' || 'latest' }} --yes ${{ contains(inputs.increment, 'pre') && '--conventional-prerelease' || '--conventional-commits' }} --registry https://npm.pkg.github.com/ --yes --conventional-commits --create-release=github
+
+      - name: Get published version
+        id: version
+        run: |
+          git pull
+          VERSION=$(node -e "console.log(require('./lerna.json').version)")
+          VERSION_PATH=$(echo $VERSION | sed 's/\.[0-9]*$/.x/')
+          echo "version_path=$VERSION_PATH" >> $GITHUB_OUTPUT
+    outputs:
+      version_path: ${{ steps.version.outputs.version_path }}
 
   deploy-success:
     runs-on: ubuntu-latest
@@ -117,6 +127,7 @@ jobs:
     uses: ./.github/workflows/docs-deploy.yml
     secrets: inherit
     needs: [deploy]
-    if: ${{ needs.deploy.result == 'success' && !contains(inputs.increment, 'pre') }}
+    if: ${{ needs.deploy.result == 'success' && !contains(inputs.increment, 'pre') && (inputs.increment == 'minor' || inputs.increment == 'major') }}
     with:
       server_type: www
+      version_path: ${{ needs.deploy.outputs.version_path || '' }}

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -6,10 +6,12 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 });
 
 const previewHash = process.env.PREVIEW_HASH;
+const versionPath = process.env.VERSION_PATH; // e.g., "3.4.x"
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isDev = process.env.NEXT_PUBLIC_SERVER_TYPE?.toLowerCase() === 'dev';
 const isPreview = Boolean(previewHash);
+const isVersioned = Boolean(versionPath);
 
 const commitHash = exec('git rev-parse --short HEAD').stdout.trim();
 const host = isDev
@@ -18,15 +20,25 @@ const host = isDev
 
 const buildId = previewHash ?? commitHash;
 
-const assetPrefix = isPreview ? `${host}/${buildId}` : host;
-
-const basePath = isDev && isPreview ? `/${buildId}` : undefined;
+const paths = isPreview
+  ? {
+      basePath: isDev ? `/${buildId}` : undefined,
+      assetPrefix: `${host}/${buildId}`,
+      publicBasePath: host,
+    }
+  : isVersioned
+    ? {
+        basePath: `/${versionPath}`,
+        assetPrefix: `${host}/${versionPath}`,
+        publicBasePath: `${host}/${versionPath}`,
+      }
+    : { basePath: undefined, assetPrefix: host, publicBasePath: host };
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
   output: 'export',
-  basePath,
+  basePath: paths.basePath,
   generateBuildId: () => {
     return buildId;
   },
@@ -38,12 +50,12 @@ const nextConfig = {
     },
   },
   trailingSlash: false,
-  assetPrefix: isProduction ? assetPrefix : undefined,
+  assetPrefix: isProduction ? paths.assetPrefix : undefined,
   transpilePackages: ['next-mdx-remote'],
   env: {
     APP_BUILD_ID: buildId,
-    NEXT_PUBLIC_BASE_PATH: host,
-    NEXT_PUBLIC_ASSET_PREFIX: assetPrefix,
+    NEXT_PUBLIC_BASE_PATH: paths.publicBasePath,
+    NEXT_PUBLIC_ASSET_PREFIX: paths.assetPrefix,
   },
   images: {
     unoptimized: true,

--- a/packages/wds-mcp/package.json
+++ b/packages/wds-mcp/package.json
@@ -7,6 +7,7 @@
     "@wanteddev/wds-theme": "workspace:*",
     "change-case": "^5.4.3",
     "cheerio": "^1.0.0",
+    "semver": "^7.7.4",
     "turndown": "^7.2.2",
     "typescript": "^5.9.3",
     "zod": "^4.0.10"
@@ -36,6 +37,7 @@
     "wds-mcp": "bin/wds-mcp"
   },
   "devDependencies": {
+    "@types/semver": "^7.7.1",
     "@types/turndown": "^5.0.6"
   }
 }

--- a/packages/wds-mcp/src/constants/index.ts
+++ b/packages/wds-mcp/src/constants/index.ts
@@ -1,4 +1,5 @@
 export const DOCS_BASE_URL = 'https://montage.wanted.co.kr';
 
-export const DOCS_COLOR_USAGE_URL = `${DOCS_BASE_URL}/docs/foundations/base-material/colors/semantic`;
+export const DOCS_COLOR_USAGE_URL =
+  '/docs/foundations/base-material/colors/semantic';
 export const DOCS_SELECTOR = '[data-algolia-page-scope="true"]';

--- a/packages/wds-mcp/src/constants/index.ts
+++ b/packages/wds-mcp/src/constants/index.ts
@@ -1,5 +1,5 @@
 export const DOCS_BASE_URL = 'https://montage.wanted.co.kr';
 
 export const DOCS_COLOR_USAGE_URL =
-  '/docs/foundations/base-material/colors/semantic';
+  'docs/foundations/base-material/colors/semantic';
 export const DOCS_SELECTOR = '[data-algolia-page-scope="true"]';

--- a/packages/wds-mcp/src/helpers/index.ts
+++ b/packages/wds-mcp/src/helpers/index.ts
@@ -11,7 +11,11 @@ import { DOCS_BASE_URL } from '../constants';
 const componentApi = api;
 
 export const getDocsBaseUrl = (version: string) => {
-  const parsedVersion = semver.parse(version)!;
+  const parsedVersion = semver.parse(version);
+
+  if (!parsedVersion) {
+    return DOCS_BASE_URL;
+  }
 
   if (parsedVersion.compare('3.2.0') < 0) {
     return `${DOCS_BASE_URL}/3.2.x`;

--- a/packages/wds-mcp/src/helpers/index.ts
+++ b/packages/wds-mcp/src/helpers/index.ts
@@ -2,6 +2,7 @@ import * as icons from '@wanteddev/wds-icon';
 import { theme } from '@wanteddev/wds-theme';
 import { load } from 'cheerio';
 import { camelCase, kebabCase } from 'change-case';
+import semver from 'semver';
 
 import api from '../../../../docs/generated/api.json';
 import readme from '../../../wds/README.md';
@@ -9,8 +10,18 @@ import { DOCS_BASE_URL } from '../constants';
 
 const componentApi = api;
 
-export const getGuideUrls = async () => {
-  const sitemap = await fetch(`${DOCS_BASE_URL}/sitemap.xml`);
+export const getDocsBaseUrl = (version: string) => {
+  const parsedVersion = semver.parse(version)!;
+
+  if (parsedVersion.compare('3.2.0') < 0) {
+    return `${DOCS_BASE_URL}/3.2.x`;
+  }
+
+  return `${DOCS_BASE_URL}/${parsedVersion.major}.${parsedVersion.minor}.x`;
+};
+
+export const getGuideUrls = async (version: string) => {
+  const sitemap = await fetch(`${getDocsBaseUrl(version)}/sitemap.xml`);
   const sitemapXml = await sitemap.text();
 
   const $sitemap = load(sitemapXml);
@@ -95,8 +106,8 @@ export const listTokens = () => {
   });
 };
 
-export const listUtilityFunctions = async () => {
-  const guideUrls = await getGuideUrls();
+export const listUtilityFunctions = async (version: string) => {
+  const guideUrls = await getGuideUrls(version);
 
   const utilityUrls = guideUrls.filter(
     (url) =>
@@ -119,7 +130,10 @@ export const listUtilityFunctions = async () => {
   ];
 };
 
-export const getComponentUrl = async (componentName: string) => {
+export const getComponentUrl = async (
+  componentName: string,
+  version: string,
+) => {
   const componentSlug = kebabCase(componentName);
   const componentPathMap: Record<string, string> = {
     list: 'list-cell',
@@ -129,7 +143,7 @@ export const getComponentUrl = async (componentName: string) => {
   };
   const customComponentPath = componentPathMap[componentSlug];
 
-  const guideUrls = await getGuideUrls();
+  const guideUrls = await getGuideUrls(version);
 
   return (
     guideUrls.find((url) =>
@@ -145,7 +159,10 @@ export const getComponentUrl = async (componentName: string) => {
   );
 };
 
-export const getUtilityFunctionUrl = async (functionName: string) => {
+export const getUtilityFunctionUrl = async (
+  functionName: string,
+  version: string,
+) => {
   const utilityFunctionPathMap: Record<string, string> = {
     respondTo: 'media',
     respondDown: 'media',
@@ -155,7 +172,7 @@ export const getUtilityFunctionUrl = async (functionName: string) => {
   };
   const customUtilityFunctionPath = utilityFunctionPathMap[functionName];
 
-  const guideUrls = await getGuideUrls();
+  const guideUrls = await getGuideUrls(version);
 
   return guideUrls.find((url) =>
     url.endsWith(kebabCase(customUtilityFunctionPath ?? functionName)),

--- a/packages/wds-mcp/src/server.ts
+++ b/packages/wds-mcp/src/server.ts
@@ -7,6 +7,7 @@ import { version } from '../package.json';
 
 import {
   getComponentUrl,
+  getDocsBaseUrl,
   getGettingStarted,
   getUtilityFunctionUrl,
   listComponents,
@@ -229,7 +230,7 @@ server.registerTool(
       };
     }
 
-    const fetchUrl = await getComponentUrl(match.name);
+    const fetchUrl = await getComponentUrl(match.name, version);
 
     if (!fetchUrl) {
       return {
@@ -375,7 +376,9 @@ server.registerTool(
   'get_color_usage',
   { description: 'Get the guidelines for how to apply color' },
   async () => {
-    const response = await fetch(DOCS_COLOR_USAGE_URL);
+    const response = await fetch(
+      `${getDocsBaseUrl(version)}/${DOCS_COLOR_USAGE_URL}`,
+    );
 
     if (!response.ok) {
       throw new Error(`Failed to fetch - ${response.statusText}`);
@@ -427,7 +430,7 @@ server.registerTool(
     description: 'List all of the utility functions available from WDS',
   },
   async () => {
-    const utilityFunctions = await listUtilityFunctions();
+    const utilityFunctions = await listUtilityFunctions(version);
 
     return {
       content: [
@@ -451,7 +454,7 @@ server.registerTool(
     }),
   },
   async ({ functionName }) => {
-    const fetchUrl = await getUtilityFunctionUrl(functionName);
+    const fetchUrl = await getUtilityFunctionUrl(functionName, version);
 
     if (!fetchUrl) {
       return {

--- a/packages/wds/README.md
+++ b/packages/wds/README.md
@@ -4,6 +4,14 @@ Powered by [Emotion](https://github.com/emotion-js/emotion).
 
 ## Install
 
+Before installing, add the following to your `.npmrc` file:
+
+```sh
+@wanteddev:registry=https://npm.pkg.github.com/
+```
+
+Then install the packages:
+
 ```sh
 pnpm i @wanteddev/wds @wanteddev/wds-icon
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,7 +448,7 @@ importers:
         version: 7.3.3
       jscodeshift:
         specifier: 17.1.1
-        version: 17.1.1(@babel/preset-env@7.25.7(@babel/core@7.25.8))
+        version: 17.1.1(@babel/preset-env@7.25.7(@babel/core@7.28.5))
       meow:
         specifier: 7.0.1
         version: 7.0.1
@@ -543,6 +543,9 @@ importers:
       cheerio:
         specifier: ^1.0.0
         version: 1.1.2
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
       turndown:
         specifier: ^7.2.2
         version: 7.2.2
@@ -553,6 +556,9 @@ importers:
         specifier: ^4.0.10
         version: 4.2.1
     devDependencies:
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6
@@ -3806,6 +3812,9 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
   '@types/shelljs@0.8.15':
     resolution: {integrity: sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==}
 
@@ -5881,25 +5890,28 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -8599,13 +8611,13 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -9013,6 +9025,7 @@ packages:
   tar@6.1.11:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -9640,6 +9653,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -10201,32 +10215,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/helper-create-regexp-features-plugin@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-annotate-as-pure': 7.25.9
-      regexpu-core: 6.1.1
-      semver: 6.3.1
-    optional: true
-
   '@babel/helper-create-regexp-features-plugin@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.25.9
       regexpu-core: 6.1.1
       semver: 6.3.1
-    optional: true
-
-  '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3
-      lodash.debounce: 4.0.8
-      resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.28.5)':
@@ -10290,16 +10284,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -10322,16 +10306,6 @@ snapshots:
   '@babel/helper-plugin-utils@7.25.9': {}
 
   '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-remap-async-to-generator@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-wrap-function': 7.25.7
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/helper-remap-async-to-generator@7.25.7(@babel/core@7.28.5)':
     dependencies:
@@ -10436,15 +10410,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -10454,21 +10419,9 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10478,31 +10431,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-transform-optional-chaining': 7.25.7(@babel/core@7.25.8)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
       '@babel/plugin-transform-optional-chaining': 7.25.7(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -10516,20 +10450,9 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-    optional: true
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-    optional: true
-
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
@@ -10542,43 +10465,19 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10593,21 +10492,9 @@ snapshots:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-assertions@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-import-assertions@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-syntax-import-attributes@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10616,22 +10503,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
@@ -10642,12 +10517,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
@@ -10664,33 +10533,15 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
@@ -10707,22 +10558,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
@@ -10734,23 +10573,10 @@ snapshots:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-arrow-functions@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10760,17 +10586,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
-  '@babel/plugin-transform-async-generator-functions@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.8)
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-async-generator-functions@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -10778,16 +10593,6 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.28.5)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
       '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-async-to-generator@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.25.7(@babel/core@7.25.8)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -10802,21 +10607,9 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-block-scoped-functions@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-block-scoped-functions@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-block-scoping@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10843,35 +10636,12 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-class-static-block@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.8)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-class-static-block@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-classes@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.25.8)
-      '@babel/traverse': 7.28.5
-      globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -10889,13 +10659,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-computed-properties@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.27.2
-    optional: true
-
   '@babel/plugin-transform-computed-properties@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -10903,22 +10666,9 @@ snapshots:
       '@babel/template': 7.27.2
     optional: true
 
-  '@babel/plugin-transform-destructuring@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-destructuring@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-dotall-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10929,22 +10679,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
-  '@babel/plugin-transform-duplicate-keys@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-duplicate-keys@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -10955,27 +10692,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
-  '@babel/plugin-transform-dynamic-import@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.8)
-    optional: true
-
   '@babel/plugin-transform-dynamic-import@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
-    optional: true
-
-  '@babel/plugin-transform-exponentiation-operator@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.25.7
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   '@babel/plugin-transform-exponentiation-operator@7.25.7(@babel/core@7.28.5)':
@@ -10985,13 +10706,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@babel/plugin-transform-export-namespace-from@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.8)
     optional: true
 
   '@babel/plugin-transform-export-namespace-from@7.25.7(@babel/core@7.28.5)':
@@ -11007,30 +10721,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.25.8)
 
-  '@babel/plugin-transform-for-of@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-for-of@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-function-name@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -11045,13 +10740,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-json-strings@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.8)
-    optional: true
-
   '@babel/plugin-transform-json-strings@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -11059,23 +10747,10 @@ snapshots:
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
     optional: true
 
-  '@babel/plugin-transform-literals@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-literals@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-logical-assignment-operators@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.8)
     optional: true
 
   '@babel/plugin-transform-logical-assignment-operators@7.25.7(@babel/core@7.28.5)':
@@ -11085,25 +10760,10 @@ snapshots:
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
     optional: true
 
-  '@babel/plugin-transform-member-expression-literals@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-member-expression-literals@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-modules-amd@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   '@babel/plugin-transform-modules-amd@7.25.7(@babel/core@7.28.5)':
@@ -11132,17 +10792,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-modules-systemjs@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-modules-systemjs@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -11150,15 +10799,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@babel/plugin-transform-modules-umd@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -11172,23 +10812,10 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-new-target@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -11211,27 +10838,11 @@ snapshots:
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
     optional: true
 
-  '@babel/plugin-transform-numeric-separator@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.8)
-    optional: true
-
   '@babel/plugin-transform-numeric-separator@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
-    optional: true
-
-  '@babel/plugin-transform-object-rest-spread@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-transform-parameters': 7.25.7(@babel/core@7.25.8)
     optional: true
 
   '@babel/plugin-transform-object-rest-spread@7.25.7(@babel/core@7.28.5)':
@@ -11243,15 +10854,6 @@ snapshots:
       '@babel/plugin-transform-parameters': 7.25.7(@babel/core@7.28.5)
     optional: true
 
-  '@babel/plugin-transform-object-super@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.25.8)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-object-super@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -11259,13 +10861,6 @@ snapshots:
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@babel/plugin-transform-optional-catch-binding@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.8)
     optional: true
 
   '@babel/plugin-transform-optional-catch-binding@7.25.7(@babel/core@7.28.5)':
@@ -11294,12 +10889,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-parameters@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-parameters@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -11323,17 +10912,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-private-property-in-object@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.8)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-private-property-in-object@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -11345,23 +10923,10 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-property-literals@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-property-literals@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-regenerator@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      regenerator-transform: 0.15.2
     optional: true
 
   '@babel/plugin-transform-regenerator@7.25.7(@babel/core@7.28.5)':
@@ -11371,21 +10936,9 @@ snapshots:
       regenerator-transform: 0.15.2
     optional: true
 
-  '@babel/plugin-transform-reserved-words@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-reserved-words@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-shorthand-properties@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -11393,15 +10946,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-spread@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   '@babel/plugin-transform-spread@7.25.7(@babel/core@7.28.5)':
@@ -11413,33 +10957,15 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-sticky-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-sticky-regex@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
-  '@babel/plugin-transform-template-literals@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-template-literals@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-typeof-symbol@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -11460,22 +10986,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-unicode-escapes@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-unicode-property-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -11486,24 +10999,10 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
-  '@babel/plugin-transform-unicode-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-transform-unicode-regex@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/plugin-transform-unicode-sets-regex@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.25.8)
       '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
@@ -11512,96 +11011,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.25.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
-  '@babel/preset-env@7.25.7(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/core': 7.25.8
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.8)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-import-assertions': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-syntax-import-attributes': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.8)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.25.8)
-      '@babel/plugin-transform-arrow-functions': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-async-generator-functions': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-async-to-generator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-block-scoping': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-class-properties': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-class-static-block': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-classes': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-computed-properties': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-destructuring': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-dotall-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-duplicate-keys': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-dynamic-import': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-export-namespace-from': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-for-of': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-function-name': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-json-strings': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-literals': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-logical-assignment-operators': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-member-expression-literals': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-modules-amd': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.25.8)
-      '@babel/plugin-transform-modules-systemjs': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-modules-umd': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-new-target': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-numeric-separator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-object-rest-spread': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-object-super': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-optional-catch-binding': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-optional-chaining': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-parameters': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-private-methods': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-private-property-in-object': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-property-literals': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-regenerator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-reserved-words': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-shorthand-properties': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-spread': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-sticky-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-template-literals': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-typeof-symbol': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-unicode-escapes': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-unicode-property-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-unicode-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-unicode-sets-regex': 7.25.7(@babel/core@7.25.8)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.25.8)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.25.8)
-      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.25.8)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.25.8)
-      core-js-compat: 3.38.1
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   '@babel/preset-env@7.25.7(@babel/core@7.28.5)':
@@ -11700,14 +11109,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-validator-option': 7.25.9
       '@babel/plugin-transform-flow-strip-types': 7.25.9(@babel/core@7.25.8)
-
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.8)':
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
-      esutils: 2.0.3
-    optional: true
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
     dependencies:
@@ -13340,7 +12741,7 @@ snapshots:
       metro: 0.82.5
       metro-config: 0.82.5
       metro-core: 0.82.5
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -13970,6 +13371,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
 
   '@types/shelljs@0.8.15':
     dependencies:
@@ -14635,16 +14038,6 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
-  babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.25.8):
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/core': 7.25.8
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.8)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.28.5):
     dependencies:
       '@babel/compat-data': 7.28.5
@@ -14655,28 +14048,11 @@ snapshots:
       - supports-color
     optional: true
 
-  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.25.8):
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.8)
-      core-js-compat: 3.38.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.28.5):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.28.5)
       core-js-compat: 3.38.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.25.8):
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.8)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17462,31 +16838,6 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jscodeshift@17.1.1(@babel/preset-env@7.25.7(@babel/core@7.25.8)):
-    dependencies:
-      '@babel/core': 7.25.8
-      '@babel/parser': 7.27.0
-      '@babel/plugin-transform-class-properties': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.25.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-optional-chaining': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-transform-private-methods': 7.25.7(@babel/core@7.25.8)
-      '@babel/preset-flow': 7.25.9(@babel/core@7.25.8)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.25.8)
-      '@babel/register': 7.25.9(@babel/core@7.25.8)
-      flow-parser: 0.235.1
-      graceful-fs: 4.2.11
-      micromatch: 4.0.8
-      neo-async: 2.6.2
-      picocolors: 1.1.0
-      recast: 0.23.9
-      tmp: 0.2.3
-      write-file-atomic: 5.0.1
-    optionalDependencies:
-      '@babel/preset-env': 7.25.7(@babel/core@7.25.8)
-    transitivePeerDependencies:
-      - supports-color
-
   jscodeshift@17.1.1(@babel/preset-env@7.25.7(@babel/core@7.28.5)):
     dependencies:
       '@babel/core': 7.25.8
@@ -17678,7 +17029,7 @@ snapshots:
       read-package-json: 6.0.4
       resolve-from: 5.0.0
       rimraf: 4.4.1
-      semver: 7.6.0
+      semver: 7.7.3
       signal-exit: 3.0.7
       slash: 3.0.0
       ssri: 9.0.1
@@ -19637,7 +18988,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.26.0
-      semver: 7.7.3
+      semver: 7.7.4
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 6.2.3
@@ -20200,11 +19551,9 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.6.0:
-    dependencies:
-      lru-cache: 6.0.0
-
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
 
   send@0.19.0:
     dependencies:


### PR DESCRIPTION
## Summary
- minor/major 버전 배포 시 `montage.wanted.co.kr/{major}.{minor}.x/` 경로로 문서 배포
- wds-mcp에서 현재 패키지 버전에 맞는 versioned docs URL을 사용하도록 수정

## Changes
- **version.yml**: 배포 후 버전을 추출하여 `version_path` output 생성, minor/major일 때 docs-deploy에 전달
- **docs-deploy.yml**: `version_path` input 추가, 빌드 및 S3 업로드 시 versioned 경로 분기 처리
- **next.config.js**: `VERSION_PATH` 환경변수에 따른 `basePath`, `assetPrefix`, `NEXT_PUBLIC_BASE_PATH` 설정
- **wds-mcp**: semver 기반으로 현재 버전의 docs URL을 동적으로 결정

## Test plan
- [ ] `VERSION_PATH=3.2.x NEXT_PUBLIC_SERVER_TYPE=www pnpm -F docs build` 로컬 빌드 확인
- [ ] 빌드 결과 HTML 내 asset 경로에 `/3.2.x/`가 포함되는지 확인
- [ ] minor 배포 시 S3에 versioned 경로로 업로드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 문서 배포에 버전별 경로 지원 추가 — 특정 버전으로 빌드·배포 가능.
  * 런타임 환경 기반 버전 경로 적용으로 프리뷰와 버전화된 배포 경로가 구분되어 동작.
  * 문서 링크와 검색이 배포된 버전 컨텍스트를 반영하도록 개선.

* **Chores**
  * 패키지 설치 전 개인 npm 레지스트리 설정 안내(README) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->