### PR TITLE
feat(wds-mcp): refresh token 지원 및 Firestore 영속 저장

### DIFF
--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -84,19 +84,29 @@ const registeredClients = new TtlMap<string, OAuthClientInformationFull>();
 const pendingAuths = new TtlMap<string, PendingAuth>();
 const authCodes = new TtlMap<string, StoredAuthCode>();
 
+interface StoredRefreshToken {
+  clientId: string;
+  googleRefreshToken: string;
+}
+
 const refreshTokenStore = {
-  async set(mcpToken: string, googleToken: string) {
+  async set(mcpToken: string, value: StoredRefreshToken) {
     await refreshTokensCollection.doc(mcpToken).set({
-      googleRefreshToken: googleToken,
+      clientId: value.clientId,
+      googleRefreshToken: value.googleRefreshToken,
     });
   },
 
-  async get(mcpToken: string): Promise<string | undefined> {
+  async get(mcpToken: string, clientId: string): Promise<string | undefined> {
     const doc = await refreshTokensCollection.doc(mcpToken).get();
 
     if (!doc.exists) return undefined;
 
-    return (doc.data() as { googleRefreshToken: string }).googleRefreshToken;
+    const data = doc.data() as StoredRefreshToken;
+
+    if (data.clientId !== clientId) return undefined;
+
+    return data.googleRefreshToken;
   },
 
   async delete(mcpToken: string) {
@@ -253,7 +263,10 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
 
     if (googleTokens.refresh_token) {
       const mcpRefreshToken = crypto.randomUUID();
-      await refreshTokenStore.set(mcpRefreshToken, googleTokens.refresh_token);
+      await refreshTokenStore.set(mcpRefreshToken, {
+        clientId: client.client_id,
+        googleRefreshToken: googleTokens.refresh_token,
+      });
       tokens.refresh_token = mcpRefreshToken;
     }
 
@@ -261,10 +274,13 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
   },
 
   async exchangeRefreshToken(
-    _client: OAuthClientInformationFull,
+    client: OAuthClientInformationFull,
     refreshToken: string,
   ) {
-    const googleRefreshToken = await refreshTokenStore.get(refreshToken);
+    const googleRefreshToken = await refreshTokenStore.get(
+      refreshToken,
+      client.client_id,
+    );
 
     if (!googleRefreshToken) {
       throw new Error('Invalid or expired refresh token');
@@ -308,7 +324,10 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
 
     // Google may rotate refresh tokens
     if (googleTokens.refresh_token) {
-      await refreshTokenStore.set(refreshToken, googleTokens.refresh_token);
+      await refreshTokenStore.set(refreshToken, {
+        clientId: client.client_id,
+        googleRefreshToken: googleTokens.refresh_token,
+      });
     }
 
     // Exchange new Google ID token for Firebase ID token

--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -299,7 +299,13 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
       access_token: string;
       id_token: string;
       expires_in: number;
+      refresh_token?: string;
     };
+
+    // Google may rotate refresh tokens
+    if (googleTokens.refresh_token) {
+      await refreshTokenStore.set(refreshToken, googleTokens.refresh_token);
+    }
 
     // Exchange new Google ID token for Firebase ID token
     const firebaseResponse = await fetch(

--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 
 import { cert, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
 
 import type {
   AuthorizationParams,
@@ -32,6 +33,8 @@ const firebaseApp = initializeApp(
 );
 
 const firebaseAuth = getAuth(firebaseApp);
+const firestore = getFirestore(firebaseApp, 'montage-storage');
+const refreshTokensCollection = firestore.collection('refreshTokens');
 
 interface PendingAuth {
   clientId: string;
@@ -80,6 +83,26 @@ class TtlMap<K, V> {
 const registeredClients = new TtlMap<string, OAuthClientInformationFull>();
 const pendingAuths = new TtlMap<string, PendingAuth>();
 const authCodes = new TtlMap<string, StoredAuthCode>();
+
+const refreshTokenStore = {
+  async set(mcpToken: string, googleToken: string) {
+    await refreshTokensCollection.doc(mcpToken).set({
+      googleRefreshToken: googleToken,
+    });
+  },
+
+  async get(mcpToken: string): Promise<string | undefined> {
+    const doc = await refreshTokensCollection.doc(mcpToken).get();
+
+    if (!doc.exists) return undefined;
+
+    return (doc.data() as { googleRefreshToken: string }).googleRefreshToken;
+  },
+
+  async delete(mcpToken: string) {
+    await refreshTokensCollection.doc(mcpToken).delete();
+  },
+};
 
 export const getServerUrl = () =>
   process.env.MCP_SERVER_URL || 'http://localhost:3000';
@@ -179,6 +202,7 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
       access_token: string;
       id_token: string;
       expires_in: number;
+      refresh_token?: string;
     };
 
     // Exchange Google ID token for Firebase ID token via REST API
@@ -219,17 +243,107 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
 
     authCodes.delete(authorizationCode);
 
-    // Return the Firebase ID token — verifiable statelessly via firebaseAuth.verifyIdToken()
+    // Store Google refresh token for later token renewal
+    const tokens: OAuthTokens = {
+      access_token: firebaseTokens.idToken,
+      token_type: 'bearer',
+      expires_in: Number(firebaseTokens.expiresIn),
+      scope: 'openid email profile',
+    };
+
+    if (googleTokens.refresh_token) {
+      const mcpRefreshToken = crypto.randomUUID();
+      await refreshTokenStore.set(mcpRefreshToken, googleTokens.refresh_token);
+      tokens.refresh_token = mcpRefreshToken;
+    }
+
+    return tokens;
+  },
+
+  async exchangeRefreshToken(
+    _client: OAuthClientInformationFull,
+    refreshToken: string,
+  ) {
+    const googleRefreshToken = await refreshTokenStore.get(refreshToken);
+
+    if (!googleRefreshToken) {
+      throw new Error('Invalid or expired refresh token');
+    }
+
+    // Use Google refresh token to get new tokens
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        refresh_token: googleRefreshToken,
+        client_id: GOOGLE_CLIENT_ID,
+        client_secret: GOOGLE_CLIENT_SECRET,
+        grant_type: 'refresh_token',
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    }).catch((error) => {
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        throw new Error('Google token refresh timed out');
+      }
+      throw error;
+    });
+
+    if (!tokenResponse.ok) {
+      // Google refresh token may have been revoked
+      await refreshTokenStore.delete(refreshToken);
+      const error = await tokenResponse.text();
+      throw new Error(`Failed to refresh Google token: ${error}`);
+    }
+
+    const googleTokens = (await tokenResponse.json()) as {
+      access_token: string;
+      id_token: string;
+      expires_in: number;
+    };
+
+    // Exchange new Google ID token for Firebase ID token
+    const firebaseResponse = await fetch(
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${FIREBASE_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          postBody: `id_token=${googleTokens.id_token}&providerId=google.com`,
+          requestUri: getServerUrl(),
+          returnIdToken: true,
+          returnSecureToken: true,
+        }),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      },
+    ).catch((error) => {
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        throw new Error('Firebase sign-in timed out');
+      }
+      throw error;
+    });
+
+    if (!firebaseResponse.ok) {
+      const error = await firebaseResponse.text();
+      throw new Error(`Firebase sign-in failed: ${error}`);
+    }
+
+    const firebaseTokens = (await firebaseResponse.json()) as {
+      idToken: string;
+      expiresIn: string;
+      email?: string;
+    };
+
+    if (!firebaseTokens.email?.endsWith(`@${ALLOWED_DOMAIN}`)) {
+      throw new Error(`Access restricted to @${ALLOWED_DOMAIN} accounts`);
+    }
+
     return {
       access_token: firebaseTokens.idToken,
       token_type: 'bearer',
       expires_in: Number(firebaseTokens.expiresIn),
       scope: 'openid email profile',
+      refresh_token: refreshToken,
     } as OAuthTokens;
-  },
-
-  async exchangeRefreshToken() {
-    throw new Error('Refresh tokens not supported');
   },
 
   async verifyAccessToken(token: string): Promise<AuthInfo> {

--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -289,9 +289,13 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
     });
 
     if (!tokenResponse.ok) {
-      // Google refresh token may have been revoked
-      await refreshTokenStore.delete(refreshToken);
       const error = await tokenResponse.text();
+
+      // Only delete on permanent failures (token revoked/invalid)
+      if (tokenResponse.status === 400 || tokenResponse.status === 401) {
+        await refreshTokenStore.delete(refreshToken);
+      }
+
       throw new Error(`Failed to refresh Google token: ${error}`);
     }
 

--- a/packages/wds-mcp/src/http.ts
+++ b/packages/wds-mcp/src/http.ts
@@ -14,6 +14,7 @@ const PORT = parseInt(process.env.PORT ?? '3000', 10);
 
 const app = express();
 
+app.set('trust proxy', 2);
 app.use(express.json());
 
 const provider = createOAuthProvider();


### PR DESCRIPTION
## Summary
- Google OAuth refresh token을 활용하여 Firebase ID token 만료 시 자동 갱신 지원
- refresh token을 Firestore(`montage-storage`)에 영속 저장하여 서버 재시작 시에도 유지
- trust proxy 설정 추가

## Test plan
- [x] 로컬에서 OAuth 로그인 후 refresh token 발급 확인
- [ ] 토큰 만료 후 자동 갱신 동작 확인
- [ ] 서버 재시작 후 refresh token 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Google 리프레시 토큰을 안전하게 저장·관리하여 장기 인증 및 세션 자동 갱신을 지원합니다.
  * 리프레시 토큰을 이용한 액세스 토큰 갱신 흐름을 완전하게 구현했습니다(토큰 회전 반영 및 만료 시 삭제).

* **개선 사항**
  * 프록시 신뢰 설정을 조정해 역방향 프록시 환경에서 호스트/URL 해석과 관련 보안 처리가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->