### PR TITLE
fix(wds): 모바일에서 토스트가 닫히지 않는 문제 수정

### DIFF
--- a/packages/wds/src/components/snackbar/index.test.tsx
+++ b/packages/wds/src/components/snackbar/index.test.tsx
@@ -78,6 +78,8 @@ describe('when given snackbar component', () => {
   });
 
   it('should not close snackbar if mouse is over the toast container after open', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+
     expect(screen.getByTestId('snackbar')).toBeInTheDocument();
 
     act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
@@ -89,6 +91,20 @@ describe('when given snackbar component', () => {
     expect(screen.getByTestId('snackbar')).toBeInTheDocument();
 
     fireEvent.mouseLeave(screen.getByTestId('snackbar'));
+
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+
+    expect(screen.queryByTestId('snackbar')).not.toBeInTheDocument();
+  });
+
+  it('should close snackbar even if mouse is over the toast container on non-cursor device', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    expect(screen.getByTestId('snackbar')).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+
+    fireEvent.mouseEnter(screen.getByTestId('snackbar'));
 
     act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
 

--- a/packages/wds/src/components/toast/helpers.ts
+++ b/packages/wds/src/components/toast/helpers.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 
-export const isNotPointerDevice = () =>
-  window.matchMedia('(pointer: coarse)').matches;
+export const isCursorDevice = () =>
+  window.matchMedia('(pointer: fine)').matches;
 
 export const makeTransitionStyle = ({
   open,

--- a/packages/wds/src/components/toast/hooks.ts
+++ b/packages/wds/src/components/toast/hooks.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isCursorDevice } from './helpers';
+
 import type { CSSProperties } from 'react';
 import type { RegionToastItem } from '../../stores/region-store';
 
@@ -78,6 +80,7 @@ export const useToastAnimation = ({
 
   const handleMouseEnter = () => {
     if (
+      isCursorDevice() &&
       timeoutRef.current &&
       startTimeRef.current &&
       remainingTimeRef.current

--- a/packages/wds/src/components/toast/index.test.tsx
+++ b/packages/wds/src/components/toast/index.test.tsx
@@ -52,6 +52,8 @@ describe('when given toast component', () => {
   });
 
   it('should not close toast if mouse is over the toast container after open', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+
     expect(screen.getByTestId('toast-container')).toBeInTheDocument();
 
     act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
@@ -63,6 +65,20 @@ describe('when given toast component', () => {
     expect(screen.getByTestId('toast-container')).toBeInTheDocument();
 
     fireEvent.mouseLeave(screen.getByTestId('toast-container'));
+
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+
+    expect(screen.queryByTestId('toast-container')).not.toBeInTheDocument();
+  });
+
+  it('should close toast even if mouse is over the toast container on non-cursor device', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    expect(screen.getByTestId('toast-container')).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
+
+    fireEvent.mouseEnter(screen.getByTestId('toast-container'));
 
     act(() => vi.advanceTimersByTime(DEFAULT_DURATION / 2));
 


### PR DESCRIPTION
## Summary
- 모바일 특정 상황에서 토스트가 자동으로 닫히지 않는 버그 수정
- `pointer: coarse` 대신 `pointer: fine` 미디어 쿼리를 사용하여 커서 디바이스 판별 로직 개선
- `with-interaction` 컴포넌트의 `@media not (pointer: fine)` 정책과 일관성 유지

## Changes
- `isNotPointerDevice()` → `isCursorDevice()`로 함수명 및 로직 변경
- 기존: `(pointer: coarse)` 체크 → 터치 디바이스에서 hover 시 타이머 일시정지가 동작하여 토스트가 안 닫힘
- 변경: `(pointer: fine)` 체크 → 마우스/트랙패드에서만 hover 일시정지 동작, `pointer: none` 디바이스도 올바르게 처리

## Test plan
- [ ] 모바일(터치) 디바이스에서 토스트가 duration 후 정상적으로 닫히는지 확인
- [ ] 데스크탑(마우스)에서 토스트 hover 시 타이머 일시정지가 정상 동작하는지 확인
- [ ] 키보드 전용(pointer: none) 환경에서 토스트가 정상적으로 닫히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토스트/스낵바가 마우스(커서) 입력을 감지하는 환경에서만 마우스 오버로 재생/일시정지되도록 개선했습니다. 터치 중심 장치에서는 알림 타이머가 중단되지 않고 정상적으로 종료됩니다.
* **테스트**
  * 다양한 입력 환경(커서 유무)을 시뮬레이션하는 테스트를 추가·보강하여 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->