### PR TITLE
fix(wds): containerStyle xl breakpoint 스타일 수정

### DIFF
--- a/packages/wds/src/utils/layout.ts
+++ b/packages/wds/src/utils/layout.ts
@@ -15,19 +15,13 @@ export const containerStyle = (xl?: boolean) => (theme: Theme) => css`
 
   ${respondMore(theme.breakpoint.sm)} {
     width: 90%;
-    max-width: 1060px;
+
+    ${xl
+      ? css`
+          max-width: 1400px;
+        `
+      : css`
+          max-width: 1060px;
+        `}
   }
-
-  ${xl &&
-  css`
-    ${respondMore(theme.breakpoint.lg)} {
-      width: 90%;
-      max-width: 1400px;
-    }
-
-    ${respondMore(theme.breakpoint.xl)} {
-      width: 90%;
-      max-width: 1400px;
-    }
-  `}
 `;


### PR DESCRIPTION
## 변경 사항

`containerStyle`의 `xl` breakpoint 스타일 로직을 단순화했습니다.

- 기존: `sm` breakpoint에서 기본 `max-width: 1060px`를 설정하고, `xl` prop이 true일 때 `lg`/`xl` breakpoint에서 `max-width: 1400px`로 override
- 변경: `sm` breakpoint 내에서 `xl` prop에 따라 `max-width`를 삼항 조건으로 분기

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 반응형 레이아웃 크기 조정 로직을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->