### PR TITLE
fix(wds): fallback-view title 색상이 상속되지 않도록 수정

### DIFF
--- a/packages/wds/src/components/fallback-view/style.ts
+++ b/packages/wds/src/components/fallback-view/style.ts
@@ -23,6 +23,7 @@ export const fallbackViewStyle =
 
     [data-role='fallback-view-text-title'] {
       text-align: center;
+      color: ${theme.semantic.label.normal};
     }
     [data-role='fallback-view-text-description'] {
       text-align: center;


### PR DESCRIPTION
## 변경 사항

`FallbackView`의 title 색상이 상위 요소로부터 상속되던 이슈를 수정했습니다.

- `[data-role='fallback-view-text-title']`에 `color: ${theme.semantic.label.normal}`을 명시적으로 지정
- 의도한 디자인 토큰(`label.normal`)이 항상 적용되도록 보장

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 폴백 뷰의 텍스트 제목 색상이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->