### PR TITLE
fix(docs): 아이콘 문서 페이지 아이콘 색상 지정

### DIFF
--- a/docs/src/features/docs/components/foundations/icons/collections/style.ts
+++ b/docs/src/features/docs/components/foundations/icons/collections/style.ts
@@ -26,6 +26,7 @@ export const iconItemStyle = (theme: Theme) => css`
   justify-content: center;
   box-shadow: inset 0 0 0 1px ${theme.semantic.line.normal.alternative};
   transition: box-shadow 0.15s ease;
+  color: ${theme.semantic.label.normal};
 
   &[aria-expanded='true'] {
     box-shadow: inset 0 0 0 1px


### PR DESCRIPTION
## 변경 사항

아이콘 문서 페이지(`docs/src/features/docs/components/foundations/icons/collections`)에서 아이콘 색상이 지정되지 않던 이슈를 수정했습니다.

- `iconItemStyle`에 `color: ${theme.semantic.label.normal}`을 명시적으로 지정
- 아이콘이 상위 요소의 색상을 상속받지 않고 디자인 토큰 값을 사용하도록 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **스타일**
  * 아이콘 항목의 색상 스타일을 테마의 의미적 색상 시스템과 일치하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->