### PR TITLE
fix(wds-mcp): 컴포넌트 그룹핑 로직 및 JSON 빌드 오류 수정

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "wanteddev"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Wanted Lab Design System for Web",
   "plugins": [
     {

--- a/.claude-plugin/montage-web-guide/.claude-plugin/plugin.json
+++ b/.claude-plugin/montage-web-guide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "montage-web-guide",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wanted Design System Plugin",
   "author": {
     "name": "Sh031224"

--- a/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
+++ b/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: montage-react
-description: React 프로젝트에서 Montage(WDS) 기반 컴포넌트 개발 가이드. React UI 컴포넌트, 스타일링, 아이콘 작업 시 사용
+description: React/Next.js 프로젝트에서 Montage(WDS, Wanted Design System) 기반 UI 개발 가이드. 컴포넌트 구현, 페이지/화면 생성, 스타일링(sx, theme, 디자인 토큰), 아이콘, 유틸리티 함수 사용 시 트리거. @wanteddev/wds 패키지 사용 프로젝트에서 활성화
 ---
 
 # montage-react
@@ -9,22 +9,37 @@ React 프로젝트에서 Wanted Design System(WDS, Montage)을 기반으로 컴�
 
 ## When to use
 
-다음 조건에 해당하면 이 skill을 자동으로 적용합니다:
+다음 조건 중 하나라도 해당하면 이 skill을 적용합니다:
 
-- React 프로젝트에서 작업할 때 (package.json에 react 의존성이 있는 경우)
-- UI 컴포넌트를 생성하거나 수정할 때
-- 스타일링 작업을 할 때
-- 아이콘을 사용할 때
+- `@wanteddev/wds`, `@wanteddev/wds-icon` 등 WDS 패키지를 사용하는 프로젝트에서 작업할 때
+- UI 컴포넌트를 생성, 수정, 또는 조회할 때 (예: "Button 만들어줘", "Modal 사용법 알려줘", "Table 컴포넌트 조회해줘")
+- 페이지나 화면을 구현할 때 (예: "로그인 페이지 만들어줘", "대시보드 화면 구현해줘")
+- 스타일링 작업을 할 때 (예: sx prop, theme 토큰, 색상, 타이포그래피)
+- 아이콘을 찾거나 사용할 때 (예: "아이콘 목록 보여줘", "검색 아이콘 뭐 있어?")
+- Figma 디자인을 코드로 구현할 때
+- WDS/Montage/디자인 시스템에 대해 질문할 때
 
 ## Instructions
+
+### 0. MCP 서버 연결 확인 (필수, 최우선)
+
+MCP 도구를 사용하기 전에 **반드시** `montage-mcp-server` MCP 서버의 연결 상태를 확인합니다.
+
+`mcp__montage-mcp-server__list_components`를 호출하여 연결 상태를 확인합니다.
+
+- **도구를 찾을 수 없는 경우** (MCP 서버 미연결): 사용자에게 MCP 서버가 연결되어 있지 않다고 안내합니다. `/mcp` 명령어를 실행하여 `montage-mcp-server`를 연결하도록 안내합니다.
+- **인증 오류가 발생하는 경우**: 사용자에게 로그인이 필요하다고 안내합니다. `/mcp` 명령어를 실행하면 인증 절차를 진행할 수 있다고 안내합니다.
+- **기타 오류가 발생하는 경우**: 사용자에게 MCP 서버에 접근할 수 없다고 안내하고, 나중에 다시 시도하도록 제안합니다.
+
+연결 확인에 실패하면 이후 단계를 진행하지 않고, 사용자의 응답을 기다립니다.
+
+### 1. 코딩 가이드라인 확인 (필수)
 
 처음부터 React.js, Next.js 셋팅을 할 때에는 도구를 활용합니다.
 
 ```
 mcp__montage-mcp-server__getting_started
 ```
-
-### 1. 코딩 가이드라인 확인 (필수)
 
 컴포넌트 작성 전 **반드시** WDS 코딩 가이드라인을 먼저 확인합니다.
 

--- a/packages/wds-mcp/src/helpers/index.ts
+++ b/packages/wds-mcp/src/helpers/index.ts
@@ -47,13 +47,21 @@ export const getGuideUrls = async (version: string) => {
 };
 
 export const listComponents = () => {
-  const componentDir = (filePath: string) =>
-    filePath.split('/components/')[1]?.split('/')[0] ?? '';
+  function getComponentDir(filePath: string | undefined): string | undefined {
+    if (!filePath) return undefined;
+    return filePath.split('/components/')[1]?.split('/')[0];
+  }
 
   const groups = new Map<string, Array<string>>();
 
   for (const component of componentApi) {
-    const dir = componentDir(component.filePath);
+    const dir = getComponentDir(component.filePath);
+
+    if (!dir) {
+      groups.set(component.name, [component.name]);
+      continue;
+    }
+
     const existing = groups.get(dir);
     if (existing) {
       existing.push(component.name);
@@ -62,10 +70,17 @@ export const listComponents = () => {
     }
   }
 
-  return Array.from(groups.values()).map((names) => ({
-    name: names[0]!,
-    subComponents: names.slice(1),
-  }));
+  return Array.from(groups.entries()).map(([dir, names]) => {
+    const dirPascalCase = dir
+      .split('-')
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join('');
+    const primaryIdx = names.findIndex((n) => n === dirPascalCase);
+    const primary = primaryIdx !== -1 ? names[primaryIdx]! : names[0]!;
+    const subComponents = names.filter((n) => n !== primary);
+
+    return { name: primary, subComponents };
+  });
 };
 
 export const listIcons = () => iconNames;

--- a/packages/wds-mcp/src/helpers/index.ts
+++ b/packages/wds-mcp/src/helpers/index.ts
@@ -3,12 +3,11 @@ import { load } from 'cheerio';
 import { camelCase, kebabCase } from 'change-case';
 import semver from 'semver';
 
-import api from '../../../../docs/generated/api.json';
+import componentApi from '../../../../docs/generated/api.json';
 import icons from '../../../../docs/generated/icons.json';
 import readme from '../../../wds/README.md';
 import { DOCS_BASE_URL } from '../constants';
 
-const componentApi = api;
 const iconNames = icons.map(({ name }) => name);
 
 export const getDocsBaseUrl = (version: string) => {
@@ -48,55 +47,25 @@ export const getGuideUrls = async (version: string) => {
 };
 
 export const listComponents = () => {
-  const components = componentApi.map((component) => component.name).sort();
+  const componentDir = (filePath: string) =>
+    filePath.split('/components/')[1]?.split('/')[0] ?? '';
 
-  const parsedComponents: Array<{
-    name: string;
-    subComponents: Array<string>;
-  }> = [];
+  const groups = new Map<string, Array<string>>();
 
-  for (const name of components) {
-    if (['ListCell', 'FormField'].includes(name)) {
-      parsedComponents.push({
-        name,
-        subComponents: [],
-      });
-      continue;
+  for (const component of componentApi) {
+    const dir = componentDir(component.filePath);
+    const existing = groups.get(dir);
+    if (existing) {
+      existing.push(component.name);
+    } else {
+      groups.set(dir, [component.name]);
     }
-
-    const parentComponentIdx = parsedComponents.findIndex(
-      (component) =>
-        name.startsWith(component.name) ||
-        ([
-          'FormControl',
-          'FormLabel',
-          'FormMessage',
-          'FormErrorMessage',
-        ].includes(name) &&
-          component.name === 'FormField'),
-    );
-
-    if (parentComponentIdx === -1) {
-      parsedComponents.push({
-        name,
-        subComponents: [],
-      });
-      continue;
-    }
-
-    const parentComponent = parsedComponents[parentComponentIdx]!;
-
-    if (
-      parentComponent.subComponents.includes(name) ||
-      parentComponent.name === name
-    ) {
-      continue;
-    }
-
-    parentComponent.subComponents.push(name);
   }
 
-  return parsedComponents;
+  return Array.from(groups.values()).map((names) => ({
+    name: names[0]!,
+    subComponents: names.slice(1),
+  }));
 };
 
 export const listIcons = () => iconNames;

--- a/packages/wds-mcp/tsdown.config.ts
+++ b/packages/wds-mcp/tsdown.config.ts
@@ -15,8 +15,21 @@ const rawTextPlugin = () => ({
   },
 });
 
+const jsonPlugin = () => ({
+  name: 'json-default-export',
+  load(id: string) {
+    if (id.endsWith('.json') && !id.endsWith('package.json')) {
+      const content = fs.readFileSync(id, 'utf-8');
+      return {
+        code: `export default (${content});`,
+        moduleType: 'js',
+      };
+    }
+  },
+});
+
 export default defineConfiguration({
   entry: ['src/**/*.ts', 'src/**/*.tsx'],
   format: ['esm'],
-  plugins: [rawTextPlugin()],
+  plugins: [rawTextPlugin(), jsonPlugin()],
 });


### PR DESCRIPTION
## Summary
- `listComponents`의 `startsWith` 기반 그룹핑을 `filePath` 디렉토리 기반으로 변경하여 Table이 Tab의 subComponent로 잘못 분류되는 문제 해결 (AvatarGroup, CardList, SelectMultiple 등 동일 이슈 포함)
- tsdown 빌드 시 JSON default import의 `.map()` 호출이 `void 0`으로 컴파일되는 문제를 `jsonPlugin` 추가로 수정

## Test plan
- [ ] `pnpm -F wds-mcp build` 빌드 성공 확인
- [ ] MCP 서버 실행 후 `Table`, `Avatar`, `AvatarGroup`, `Chip`, `ListCell` 등 컴포넌트 조회 정상 동작 확인
- [ ] `list_components` 호출 시 컴포넌트 그룹핑이 filePath 기준으로 올바르게 분류되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 컴포넌트 목록 조회 로직을 파일 경로 기반 그룹화로 재구성하여 일관성 및 유지보수성 향상

* **Chores**
  * 빌드 구성에 JSON 임포트 지원 추가
  * 플러그인/매니페스트 버전 소폭 업데이트

* **Documentation**
  * 가이드/스킬 문서 업데이트: React/Next.js 및 WDS 시나리오 확장, 서버 연결 검증 절차 및 워크플로우 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->