### PR TITLE
fix(wds-mcp): oauth 클라이언트 등록 정보를 Firestore에 저장

### DIFF
--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -35,6 +35,7 @@ const firebaseApp = initializeApp(
 const firebaseAuth = getAuth(firebaseApp);
 const firestore = getFirestore(firebaseApp, 'montage-storage');
 const refreshTokensCollection = firestore.collection('refreshTokens');
+const clientsCollection = firestore.collection('clients');
 
 interface PendingAuth {
   clientId: string;
@@ -50,7 +51,6 @@ interface StoredAuthCode {
 }
 
 const TTL = {
-  CLIENT: 24 * 60 * 60 * 1000, // 24h
   PENDING_AUTH: 10 * 60 * 1000, // 10min
   AUTH_CODE: 5 * 60 * 1000, // 5min
 } as const;
@@ -80,7 +80,22 @@ class TtlMap<K, V> {
   }
 }
 
-const registeredClients = new TtlMap<string, OAuthClientInformationFull>();
+const clientRegistrationStore = {
+  async set(clientId: string, client: OAuthClientInformationFull) {
+    await clientsCollection
+      .doc(clientId)
+      .set(JSON.parse(JSON.stringify(client)));
+  },
+
+  async get(clientId: string): Promise<OAuthClientInformationFull | undefined> {
+    const doc = await clientsCollection.doc(clientId).get();
+
+    if (!doc.exists) return undefined;
+
+    return doc.data() as OAuthClientInformationFull;
+  },
+};
+
 const pendingAuths = new TtlMap<string, PendingAuth>();
 const authCodes = new TtlMap<string, StoredAuthCode>();
 
@@ -119,9 +134,10 @@ export const getServerUrl = () =>
 
 export const createOAuthProvider = (): OAuthServerProvider => ({
   clientsStore: {
-    getClient: async (clientId: string) => registeredClients.get(clientId),
+    getClient: async (clientId: string) =>
+      clientRegistrationStore.get(clientId),
     registerClient: async (client: OAuthClientInformationFull) => {
-      registeredClients.set(client.client_id, client, TTL.CLIENT);
+      await clientRegistrationStore.set(client.client_id, client);
       return client;
     },
   },


### PR DESCRIPTION
## Summary
- MCP OAuth `registeredClients`를 in-memory `TtlMap`에서 Firestore `clients` 컬렉션으로 변경
- ECS 컨테이너 재시작/스케일링 시에도 token refresh가 정상 동작하도록 개선
- 기존 `refreshTokenStore`와 동일한 패턴 적용

## Test plan
- [ ] MCP 서버 인증 후 정상 동작 확인
- [ ] 1시간 이상 경과 후 token refresh 성공 확인
- [ ] 컨테이너 재시작 후에도 재로그인 없이 연결 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * OAuth 클라이언트 등록 데이터 저장 방식을 개선하여 더 안정적인 인증 구성 관리를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->