### PR TITLE
chore: SKILL 개선 및 wds-mcp lint 수정

### DIFF
--- a/.claude-plugin/montage-web-guide/README.ko.md
+++ b/.claude-plugin/montage-web-guide/README.ko.md
@@ -31,6 +31,7 @@ Wanted Design System(WDS) MCP와 skill이 포함된 플러그인입니다.
 | `list_utility_functions` | 유틸리티 함수 목록 조회   |
 | `get_utility_function`   | 유틸리티 함수 상세 조회   |
 | `getting_started`        | WDS 초기 셋팅 가이드 조회 |
+| `health_check`           | MCP 서버 상태 확인        |
 
 ### Skill: montage-react
 

--- a/.claude-plugin/montage-web-guide/README.md
+++ b/.claude-plugin/montage-web-guide/README.md
@@ -31,6 +31,7 @@ The following tools are available through the `@wanteddev/wds-mcp` MCP server:
 | `list_utility_functions` | List utility functions               |
 | `get_utility_function`   | View detailed utility function specs |
 | `getting_started`        | View WDS initial setup guide         |
+| `health_check`           | Check MCP server health status       |
 
 ### Skill: montage-react
 

--- a/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
+++ b/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
@@ -1,128 +1,206 @@
 ---
 name: montage-react
-description: React/Next.js 프로젝트에서 Montage(WDS, Wanted Design System) 기반 UI 개발 가이드. 컴포넌트 구현, 페이지/화면 생성, 스타일링(sx, theme, 디자인 토큰), 아이콘, 유틸리티 함수 사용 시 트리거. @wanteddev/wds 패키지 사용 프로젝트에서 활성화
+description: Guide for building UI with Montage (Wanted Design System) in React/Next.js projects. Triggers on component implementation, page/screen creation, styling (sx, theme, design tokens), icons, and utility functions. Active in projects using @wanteddev/wds packages.
 ---
 
 # montage-react
 
-React 프로젝트에서 Wanted Design System(WDS, Montage)을 기반으로 컴포넌트를 개발할 때 자동으로 적용되는 skill입니다.
+Skill that is automatically applied when developing components based on Wanted Design System (Montage) in React projects.
 
 ## When to use
 
-다음 조건 중 하나라도 해당하면 이 skill을 적용합니다:
+Apply this skill when any of the following conditions are met:
 
-- `@wanteddev/wds`, `@wanteddev/wds-icon` 등 WDS 패키지를 사용하는 프로젝트에서 작업할 때
-- UI 컴포넌트를 생성, 수정, 또는 조회할 때 (예: "Button 만들어줘", "Modal 사용법 알려줘", "Table 컴포넌트 조회해줘")
-- 페이지나 화면을 구현할 때 (예: "로그인 페이지 만들어줘", "대시보드 화면 구현해줘")
-- 스타일링 작업을 할 때 (예: sx prop, theme 토큰, 색상, 타이포그래피)
-- 아이콘을 찾거나 사용할 때 (예: "아이콘 목록 보여줘", "검색 아이콘 뭐 있어?")
-- Figma 디자인을 코드로 구현할 때
-- WDS/Montage/디자인 시스템에 대해 질문할 때
+- Working in a project that uses Montage packages such as `@wanteddev/wds`, `@wanteddev/wds-icon`
+- Creating, modifying, or looking up UI components
+- Implementing pages or screens
+- Working on styling (sx prop, theme tokens, colors, typography)
+- Finding or using icons
+- Implementing Figma designs as code
+- Asking questions about Montage / design system
 
 ## Instructions
 
-### 0. MCP 서버 연결 확인 (필수, 최우선)
+### 0. Verify MCP Server Connection (Required, Highest Priority)
 
-MCP 도구를 사용하기 전에 **반드시** `montage-mcp-server` MCP 서버의 연결 상태를 확인합니다.
+Before using any MCP tools, **always** verify the `montage-mcp-server` connection first.
 
-`mcp__montage-mcp-server__list_components`를 호출하여 연결 상태를 확인합니다.
+Call `mcp__montage-mcp-server__health_check` to check the connection status.
 
-- **도구를 찾을 수 없는 경우** (MCP 서버 미연결): 사용자에게 MCP 서버가 연결되어 있지 않다고 안내합니다. `/mcp` 명령어를 실행하여 `montage-mcp-server`를 연결하도록 안내합니다.
-- **인증 오류가 발생하는 경우**: 사용자에게 로그인이 필요하다고 안내합니다. `/mcp` 명령어를 실행하면 인증 절차를 진행할 수 있다고 안내합니다.
-- **기타 오류가 발생하는 경우**: 사용자에게 MCP 서버에 접근할 수 없다고 안내하고, 나중에 다시 시도하도록 제안합니다.
+- **Tool not found** (MCP server not connected): Inform the user and suggest running `/mcp` to connect `montage-mcp-server`.
+- **Authentication error**: Inform the user that login is required. Running `/mcp` will initiate the auth flow.
+- **Other errors**: Inform the user that the MCP server is unreachable and suggest retrying later.
 
-연결 확인에 실패하면 이후 단계를 진행하지 않고, 사용자의 응답을 기다립니다.
+If the connection check fails, do not proceed. Wait for the user's response.
 
-### 1. 코딩 가이드라인 확인 (필수)
+### 1. Gather Initial Information (Parallel Calls)
 
-처음부터 React.js, Next.js 셋팅을 할 때에는 도구를 활용합니다.
+Gather required information **in parallel** at the start. Avoid unnecessary sequential calls.
 
-```
-mcp__montage-mcp-server__getting_started
-```
+When setting up React.js or Next.js from scratch, use:
 
-컴포넌트 작성 전 **반드시** WDS 코딩 가이드라인을 먼저 확인합니다.
+- `mcp__montage-mcp-server__getting_started`
 
-```
-mcp__montage-mcp-server__wds_coding_guidelines
-```
+**Always call in parallel**:
 
-### 2. 컴포넌트 개발 워크플로우
+- `mcp__montage-mcp-server__wds_coding_guidelines` — coding guidelines
+- `mcp__montage-mcp-server__list_components` — available component list
 
-#### 2.1 기존 컴포넌트 확인
+**Add in parallel when needed**:
 
-새 컴포넌트를 만들기 전, WDS에서 제공하는 컴포넌트가 있는지 **반드시** 확인합니다.
+- `mcp__montage-mcp-server__list_tokens` — when custom styling is required
+- `mcp__montage-mcp-server__get_color_usage` — when color application is needed
+- `mcp__montage-mcp-server__list_icons` — when icons are needed
 
-```
-mcp__montage-mcp-server__list_components
-```
+### 2. Component Usage Principles
 
-적합한 컴포넌트가 있다면 사용 방법을 추론하지 말고 **최대한 상세 스펙을 조회**합니다.
+#### 2.1 Always Look Up Specs Before Use
 
-```
-mcp__montage-mcp-server__get_component({ componentName: "컴포넌트명" })
-```
-
-#### 2.2 컴포넌트 사용 원칙
-
-1. **WDS 컴포넌트 우선 사용**: 직접 구현하기 전에 WDS 컴포넌트를 최대한 활용합니다.
-2. **확장 시 WDS 기반**: 커스텀이 필요한 경우에도 WDS 컴포넌트를 기반으로 확장합니다.
-3. **일관성 유지**: WDS의 패턴과 API 설계를 따릅니다.
-
-### 3. 디자인 토큰 적용
-
-#### 3.1 토큰 목록 조회
-
-스타일링 시 하드코딩된 값 대신 WDS 디자인 토큰을 사용합니다.
-토큰에는 색상, 미디어 사이즈, 쉐도우 값 등이 사용됩니다. spacing 값은 사용하지 마세요.
+When using Montage components, **never guess** — always look up the detailed specs.
 
 ```
-mcp__montage-mcp-server__list_tokens
+mcp__montage-mcp-server__get_component({ componentName: "ComponentName" })
 ```
 
-#### 3.2 색상 사용법
+**Important**: Looking up the **parent component** instead of a sub-component gives you the full composition pattern (Anatomy) and all APIs at once.
 
-색상 적용 시 올바른 사용법을 확인합니다.
+- For Modal: `get_component("Modal")` — includes ModalContainer, ModalNavigation, etc.
+- For Card: `get_component("Card")` — includes CardThumbnail, CardContent, etc.
+- For Tab: `get_component("Tab")` — includes TabList, TabListItem, TabPanel, etc.
 
+When unsure which Typography variant to use, call `get_component("Typography")` to check the size table for each variant.
+
+#### 2.2 Prefer Montage Components
+
+1. **Check Montage before implementing**: Before creating a new component, check if an identical or similar one exists in Montage
+2. **Extend based on Montage**: Even when customization is needed, extend from Montage components
+3. **Props first, sx second**: Use props provided by the component (size, color, variant, etc.) first; only use sx when props are insufficient
+
+### 3. Page/Screen Implementation Guide
+
+Follow these patterns for vibe design or page implementation requests.
+
+#### 3.1 Page Layout Structure
+
+Basic page skeleton:
+
+```tsx
+import { Box, FlexBox, containerStyle } from '@wanteddev/wds';
+
+<FlexBox flexDirection="column" sx={{ minHeight: '100vh' }}>
+  <Box as="header" sx={containerStyle(true)}>
+    ...
+  </Box>
+  <Box as="main" sx={containerStyle(true)}>
+    ...
+  </Box>
+  <Box as="footer" sx={containerStyle(true)}>
+    ...
+  </Box>
+</FlexBox>;
 ```
-mcp__montage-mcp-server__get_color_usage
+
+> For `containerStyle` details, use `get_utility_function("containerStyle")`.
+
+#### 3.2 Layout Component Selection Guide
+
+| Purpose                             | Component                  |
+| ----------------------------------- | -------------------------- |
+| One-directional layout (row/column) | `FlexBox`                  |
+| 12-column grid layout               | `Grid` + `GridItem`        |
+| Page container                      | `containerStyle()` utility |
+| General wrapper/styling             | `Box`                      |
+
+#### 3.3 Spacing Guide
+
+When implementing a Figma design directly, **ignore this guide and use the exact spacing values defined in Figma**.
+
+Otherwise (vibe design or freeform composition), do not use spacing tokens. Use px values directly instead.
+
+- Default gap between components: `gap="12px"` or `gap="16px"`
+- Gap between sections: `gap="24px"` ~ `gap="32px"`
+- Page-level section gap: `gap="40px"` ~ `gap="48px"`
+- Use FlexBox's `gap` prop or specify `padding`, `margin` in px via sx
+
+#### 3.4 Responsive Implementation Strategy
+
+Three methods are available. Pick based on what's changing:
+
+- **Only component props change** → responsive props (`sm={{ size: "large" }}`)
+- **Custom CSS changes** → `respondTo` / `respondDown` utilities
+- **Rendering itself changes** → `useMediaQuery` hook
+
+Use mobile-first sizing, then override with `sm`, `md`, `lg`, `xl`. Typically only `sm` breakpoint is used.
+
+#### 3.5 UI Implementation Notes
+
+- `TextButton`, `IconButton` (variant background, normal), `ListCell`, `RadioGroupItem`, `Checkbox`, `AvatarButton`, `ToggleIcon` have interaction areas larger than their visual bounds — give slightly more spacing room.
+- When using `ScrollArea` with border-radius, add `[data-role='scroll-area-bar-wrapper'] { padding-block: ${radius}; }` to avoid unnatural scrollbar.
+- Don't render too much UI in a single file. Split into smaller components appropriately.
+
+### 4. Styling Rules
+
+#### 4.1 When to Separate style.ts
+
+- **Inline (1-3 lines)**: Write directly in `sx` prop
+- **Separate style.ts (4+ lines)**: Extract to a separate file
+
+> When using a theme function in the sx prop, the theme is injected automatically. No need to pass it manually like `wrapperStyle(theme)`.
+
+#### 4.2 Conditional Styles
+
+```tsx
+// style.ts
+export const buttonStyle = (isActive: boolean) => (theme: Theme) => css`
+  color: ${isActive
+    ? theme.semantic.primary.normal
+    : theme.semantic.label.alternative};
+`;
+
+// index.tsx
+<Box sx={buttonStyle(isActive)} />;
 ```
 
-#### 3.3 토큰 사용 원칙
+### 5. Icons
 
-- 색상: `#RRGGBB` 대신 WDS 색상 토큰 사용
-- 타이포그래피: WDS typography 토큰 사용
-- 그림자, 테두리 등: WDS에서 정의된 토큰 사용
+When icons are needed, check the Montage icon library first via `mcp__montage-mcp-server__list_icons`. Always prefer Montage icons over creating new ones.
 
-### 4. 아이콘 사용
+### 6. Utility Functions
 
-아이콘이 필요한 경우 WDS 아이콘 라이브러리를 사용합니다.
+Use utility functions provided by Montage. Look up available utilities via `mcp__montage-mcp-server__list_utility_functions`, and get detailed usage with `mcp__montage-mcp-server__get_utility_function`.
 
-```
-mcp__montage-mcp-server__list_icons
-```
+### 7. Design Token Usage
 
-### 5. 유틸리티 함수 활용
+Use Montage design tokens instead of hardcoded values. Look up available tokens via `mcp__montage-mcp-server__list_tokens`.
 
-WDS에서 제공하는 유틸리티 함수를 활용합니다.
+- **Never use CSS variable (`var(--semantic-...)`) directly.** Always access colors through the `theme` callback (e.g., `sx={theme => ({ color: theme.semantic.label.normal })}`). CSS variable names are internal implementation details and may change without notice.
+- Colors: use semantic color tokens instead of `#RRGGBB` (fall back to atomic colors if not possible). Use `get_color_usage` to look up which token to use for a given purpose.
+- Typography: use the Typography component or `typographyStyle` utility. Use `get_component("Typography")` to look up the variant/size table.
+- Shadows: use `theme.semantic.elevation.shadow.normal.*`
+- Opacity: **must** use `addOpacity` utility + `theme.opacity[N]`. Theme color values are CSS variables (e.g. `var(--semantic-primary-normal)`), so appending hex alpha strings directly will **NOT** work. Available opacity keys: `0, 5, 8, 12, 16, 22, 28, 35, 43, 52, 61, 74, 88, 97, 100`.
 
-```
-mcp__montage-mcp-server__list_utility_functions
-```
+  ```tsx
+  // WRONG - never do this. The result is broken CSS like "var(--semantic-primary-normal)0A"
+  backgroundColor: theme.semantic.primary.normal + '0A';
+  border: `1px solid ${theme.semantic.primary.normal}33`;
 
-필요한 유틸리티의 상세 사용법 확인:
+  // CORRECT - use addOpacity utility
+  import { addOpacity } from '@wanteddev/wds';
 
-```
-mcp__montage-mcp-server__get_utility_function({ name: "함수명" })
-```
+  backgroundColor: addOpacity(theme.semantic.primary.normal, theme.opacity[5]);
+  border: `1px solid ${addOpacity(theme.semantic.primary.normal, theme.opacity[22])}`;
+  ```
+
+- Do not use spacing tokens. Use px values directly.
 
 ## Checklist
 
-컴포넌트 작성 완료 후 다음을 확인합니다:
+Verify the following after completing a component/page:
 
-- [ ] WDS 코딩 가이드라인을 따랐는가?
-- [ ] WDS 컴포넌트를 최대한 활용했는가?
-- [ ] 하드코딩된 스타일 값 대신 디자인 토큰을 사용했는가?
-- [ ] 컴포넌트 옵션으로 제공되어 있는 값을 커스텀 스타일로 사용하지는 않았는가?
-- [ ] WDS 아이콘을 사용했는가? (필요한 경우)
-- [ ] WDS 유틸리티 함수를 활용했는가? (해당되는 경우)
+- [ ] Maximized use of Montage components? (checked Montage before custom implementation)
+- [ ] Looked up exact specs via `get_component` before using components? (no guessing)
+- [ ] Did not replace component props with custom styles?
+- [ ] Used semantic design tokens instead of hardcoded colors?
+- [ ] Used FlexBox/Grid/containerStyle appropriately for layout?
+- [ ] Used Montage icons? (when applicable)
+- [ ] Used appropriate responsive method when needed?

--- a/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
+++ b/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
@@ -64,11 +64,11 @@ mcp__montage-mcp-server__get_component({ componentName: "ComponentName" })
 
 **Important**: Looking up the **parent component** instead of a sub-component gives you the full composition pattern (Anatomy) and all APIs at once.
 
-- For Modal: `get_component("Modal")` — includes ModalContainer, ModalNavigation, etc.
-- For Card: `get_component("Card")` — includes CardThumbnail, CardContent, etc.
-- For Tab: `get_component("Tab")` — includes TabList, TabListItem, TabPanel, etc.
+- For Modal: `get_component({ componentName: "Modal" })` — includes ModalContainer, ModalNavigation, etc.
+- For Card: `get_component({ componentName: "Card" })` — includes CardThumbnail, CardContent, etc.
+- For Tab: `get_component({ componentName: "Tab" })` — includes TabList, TabListItem, TabPanel, etc.
 
-When unsure which Typography variant to use, call `get_component("Typography")` to check the size table for each variant.
+When unsure which Typography variant to use, call `get_component({ componentName: "Typography" })` to check the size table for each variant.
 
 #### 2.2 Prefer Montage Components
 
@@ -175,21 +175,57 @@ Use Montage design tokens instead of hardcoded values. Look up available tokens 
 
 - **Never use CSS variable (`var(--semantic-...)`) directly.** Always access colors through the `theme` callback (e.g., `sx={theme => ({ color: theme.semantic.label.normal })}`). CSS variable names are internal implementation details and may change without notice.
 - Colors: use semantic color tokens instead of `#RRGGBB` (fall back to atomic colors if not possible). Use `get_color_usage` to look up which token to use for a given purpose.
-- Typography: use the Typography component or `typographyStyle` utility. Use `get_component("Typography")` to look up the variant/size table.
+- Typography: use the Typography component or `typographyStyle` utility. Use `get_component({ componentName: "Typography" })` to look up the variant/size table.
 - Shadows: use `theme.semantic.elevation.shadow.normal.*`
 - Opacity: **must** use `addOpacity` utility + `theme.opacity[N]`. Theme color values are CSS variables (e.g. `var(--semantic-primary-normal)`), so appending hex alpha strings directly will **NOT** work. Available opacity keys: `0, 5, 8, 12, 16, 22, 28, 35, 43, 52, 61, 74, 88, 97, 100`.
 
-  ```tsx
-  // WRONG - never do this. The result is broken CSS like "var(--semantic-primary-normal)0A"
-  backgroundColor: theme.semantic.primary.normal + '0A';
-  border: `1px solid ${theme.semantic.primary.normal}33`;
-
-  // CORRECT - use addOpacity utility
+  ```ts
+  // use addOpacity utility
   import { addOpacity } from '@wanteddev/wds';
 
-  backgroundColor: addOpacity(theme.semantic.primary.normal, theme.opacity[5]);
-  border: `1px solid ${addOpacity(theme.semantic.primary.normal, theme.opacity[22])}`;
+  import type { Theme } from '@wanteddev/wds';
+
+  const wrapperStyle = (theme: Theme) => css`
+    background-color: addOpacity(
+      theme.semantic.primary.normal,
+      theme.opacity[5]
+    );
+    border: 1px solid
+      ${addOpacity(theme.semantic.primary.normal, theme.opacity[22])};
+  `;
   ```
+
+  **When implementing a Figma design:**
+  - If Figma specifies an opacity value that does not match any `theme.opacity[N]` key, use the raw number directly (e.g., `opacity: 0.07`) instead of a token.
+  - If the Figma design renders the opacity as a **colored overlay layer** (not fading the element itself), implement it via `::before` / `::after` pseudo-element so child content stays fully opaque. When the parent has `border-radius`, the pseudo-element **must** also set `borderRadius: 'inherit'`, otherwise the overlay will overflow the rounded corners.
+
+    ```ts
+    // style.ts
+    import { css } from '@wanteddev/wds';
+
+    import type { Theme } from '@wanteddev/wds';
+
+    export const overlayStyle = (theme: Theme) => css`
+      position: relative;
+      border-radius: 12px;
+
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background-color: ${theme.semantic.fill.normal};
+        opacity: ${theme.opacity[8]};
+      }
+    `;
+    ```
+
+    ```tsx
+    // index.tsx
+    import { overlayStyle } from './style';
+
+    <Box sx={overlayStyle} />;
+    ```
 
 - Do not use spacing tokens. Use px values directly.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "typescript.tsdk": "./node_modules/typescript/lib",
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
   "eslint.workingDirectories": [
     { "pattern": ".github/actions/*/" },
     { "pattern": "docs/" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,6 +139,15 @@ export default defineConfig(
   },
 
   {
+    files: ['packages/wds-mcp/**/*.ts'],
+    rules: {
+      'import/no-unresolved': [
+        'error',
+        { ignore: ['@modelcontextprotocol/sdk/.*'] },
+      ],
+    },
+  },
+  {
     files: ['**/*.test.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/wds-mcp/README.ko.md
+++ b/packages/wds-mcp/README.ko.md
@@ -19,6 +19,7 @@ AI 코딩 어시스턴트에게 WDS 컴포넌트 문서, 디자인 토큰, 아�
 | `list_utility_functions` | 사용 가능한 유틸리티 함수 목록 조회                    |
 | `get_utility_function`   | 특정 유틸리티 함수의 문서 조회                         |
 | `getting_started`        | 설치 및 초기 설정 가이드 조회                          |
+| `health_check`           | MCP 서버의 상태 확인                                   |
 
 ## 설정
 

--- a/packages/wds-mcp/README.md
+++ b/packages/wds-mcp/README.md
@@ -19,6 +19,7 @@ It provides AI coding assistants with access to WDS component documentation, des
 | `list_utility_functions` | List all available utility functions                         |
 | `get_utility_function`   | Get documentation for a specific utility function            |
 | `getting_started`        | Get installation and initial configuration guide             |
+| `health_check`           | Check the health status of the MCP server                    |
 
 ## Setup
 

--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -7,12 +7,12 @@ import { getFirestore } from 'firebase-admin/firestore';
 import type {
   AuthorizationParams,
   OAuthServerProvider,
-} from '@modelcontextprotocol/sdk/server/auth/provider';
-import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
+} from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type {
   OAuthClientInformationFull,
   OAuthTokens,
-} from '@modelcontextprotocol/sdk/shared/auth';
+} from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { Request, Response } from 'express';
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? '';

--- a/packages/wds-mcp/src/http.ts
+++ b/packages/wds-mcp/src/http.ts
@@ -1,6 +1,6 @@
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp';
-import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router';
-import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import express from 'express';
 
 import { getServer } from './server';

--- a/packages/wds-mcp/src/server.ts
+++ b/packages/wds-mcp/src/server.ts
@@ -536,6 +536,33 @@ or with the Typography component like:
     },
   );
 
+  server.registerTool(
+    'health_check',
+    {
+      description:
+        'Check the health status of the Montage MCP server. Returns server name, version, and status.',
+    },
+    () => {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                status: 'ok',
+                name: 'Montage, Wanted Design System',
+                version,
+                timestamp: new Date().toISOString(),
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
   return server;
 };
 


### PR DESCRIPTION
## Summary
- `montage-react` SKILL 가이드 개선
  - Spacing 가이드에 Figma 디자인 그대로 구현 시 예외 케이스 추가
  - Opacity 섹션에 `theme.opacity[N]` 미스매치 케이스 및 컬러 오버레이 패턴(`::before`/`::after` + `borderRadius: inherit`) 가이드 추가
- `wds-mcp`: `@modelcontextprotocol/sdk` import 경로 및 관련 lint 설정 정리
- ESLint 설정 일부 업데이트

## Test plan
- [ ] SKILL.md 문서 내용 확인
- [ ] `pnpm lint` 통과 확인
- [ ] `pnpm -F @wanteddev/wds-mcp build` 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * Montage React 스킬 가이드를 영어로 전면 교체하고 연결 흐름, 컴포넌트 사용 원칙, 레이아웃/반응형/간격 지침, 디자인 토큰 사용법, 아이콘·유틸 가이드를 개선했습니다.
  * 체크리스트와 검증 항목을 영어로 업데이트했습니다.

* **새 기능**
  * MCP 서버 상태를 확인하는 새로운 헬스체크 도구(health_check)를 추가했습니다.

* **기타**
  * 편집기 설정 키를 갱신했고 린트/모듈 해석 관련 설정을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->