### PR TITLE
docs: alternative prop 주석 명확화

### DIFF
--- a/packages/wds/src/components/icon-button/types.ts
+++ b/packages/wds/src/components/icon-button/types.ts
@@ -21,7 +21,7 @@ export type IconButtonDefaultProps = WithSxProps<{
   /** The color of the icon button when the interaction is triggered. */
   interactionColor?: ThemeColorsToken;
   /**
-   * When using `background` button, if `alternative` is true, the dark theme is activated.
+   * When `variant` is `background`, if `alternative` is true, the icon button uses a dark-colored background.
    */
   alternative?: boolean;
   /** The content of the icon button. Use icon component as the children. */

--- a/packages/wds/src/components/page-counter/types.ts
+++ b/packages/wds/src/components/page-counter/types.ts
@@ -10,7 +10,7 @@ type PageCounterDefaultProps = WithSxProps<{
   totalPages: number;
   /** The current page number. */
   currentPage?: number;
-  /** Whether to use the alternative background style. */
+  /** If true, renders a fallback style that looks natural in environments where `blur` is not supported. */
   alternative?: boolean;
 }>;
 

--- a/packages/wds/src/components/play-badge/types.ts
+++ b/packages/wds/src/components/play-badge/types.ts
@@ -7,7 +7,7 @@ import type {
 export type PlayBadgeDefaultProps = WithSxProps<{
   /** The size of the play badge. */
   size?: 'medium' | 'large' | 'small';
-  /** Whether to use the alternative background style. */
+  /** If true, renders a fallback style that looks natural in environments where `blur` is not supported. */
   alternative?: boolean;
 }>;
 


### PR DESCRIPTION
## Summary
- `icon-button`의 `alternative` 주석을 `variant`가 `background`일 때 어두운 배경을 사용한다는 의미로 수정
- `page-counter`, `play-badge`의 `alternative` 주석을 `blur`가 적용되지 않는 환경에서 자연스럽게 표시되는 fallback 스타일임을 설명하도록 수정

## Test plan
- [ ] 주석 변경만 포함된 PR이므로 런타임 동작 변화 없음 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 아이콘 버튼, 페이지 카운터, 플레이 배지 컴포넌트의 대체 스타일 옵션에 대한 설명을 업데이트했습니다. 각 컴포넌트에서 대체 스타일이 활성화되는 구체적인 시나리오를 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->