### PR TITLE
feat(wds): tab/category 스크롤바 숨김 및 top-navigation data-background 추가

### DIFF
--- a/packages/wds/src/components/category/style.ts
+++ b/packages/wds/src/components/category/style.ts
@@ -251,6 +251,14 @@ export const scrollWrapperStyle = css`
   [data-radix-scroll-area-viewport] {
     scroll-behavior: smooth;
   }
+
+  [data-role='scroll-area-vertical-bar'] {
+    display: none;
+  }
+
+  [data-role='scroll-area-horizontal-bar'] {
+    display: none;
+  }
 `;
 
 export const categoryListItemStyle =

--- a/packages/wds/src/components/scroll-area/index.tsx
+++ b/packages/wds/src/components/scroll-area/index.tsx
@@ -114,6 +114,7 @@ const ScrollBar = forwardRef<
     forceMount
     ref={ref}
     orientation={orientation}
+    data-role={`scroll-area-${orientation}-bar`}
     {...props}
     sx={[scrollBarStyle({ orientation, size }), props.sx]}
   >

--- a/packages/wds/src/components/tab/style.ts
+++ b/packages/wds/src/components/tab/style.ts
@@ -273,6 +273,14 @@ export const scrollWrapperStyle = css`
   [data-radix-scroll-area-viewport] {
     scroll-behavior: smooth;
   }
+
+  [data-role='scroll-area-vertical-bar'] {
+    display: none;
+  }
+
+  [data-role='scroll-area-horizontal-bar'] {
+    display: none;
+  }
 `;
 
 export const tabListWrapperStyle = (theme: Theme) => css`

--- a/packages/wds/src/components/top-navigation/index.tsx
+++ b/packages/wds/src/components/top-navigation/index.tsx
@@ -53,6 +53,7 @@ const TopNavigation = forwardRef<
         wds-component="top-navigation"
         ref={ref}
         flexDirection="column"
+        data-background={background}
         {...props}
         data-variant={variant}
         sx={[


### PR DESCRIPTION
## Summary
- `scroll-area`의 `ScrollBar`에 `data-role=\"scroll-area-{orientation}-bar\"` 속성 추가
- `tab`, `category` 컴포넌트에서 해당 data-role을 이용해 내부 스크롤바 숨김 처리
- `top-navigation`에 `background` 값을 `data-background` 속성으로 노출하여 외부에서 스타일 분기 가능하도록 개선

## Test plan
- [ ] tab, category 컴포넌트에서 스크롤바가 보이지 않는지 확인
- [ ] scroll-area 자체 사용 시 기존 스크롤바 동작이 그대로 유지되는지 확인
- [ ] top-navigation의 background 유무에 따라 data-background 속성이 올바르게 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 카테고리 및 탭 컴포넌트의 스크롤 바 표시 숨김 처리

* **기타**
  * 스크롤 영역 및 상단 네비게이션 컴포넌트의 DOM 메타데이터 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->