### PR TITLE
fix(wds): pagination dot color가 white일 때 숨김 처리된 dot이 보이는 버그 수정

### DIFF
--- a/packages/wds/src/components/pagination-dots/style.ts
+++ b/packages/wds/src/components/pagination-dots/style.ts
@@ -48,7 +48,8 @@ export const paginationDotsWrapperStyle =
         margin-left: var(--wds-pagination-dot-size, 10px);
 
         &::after {
-          border-width: 1px;
+          --wds-pagination-dot-border-color: ${theme.semantic.line.normal
+            .neutral};
         }
 
         &:first-of-type {
@@ -107,7 +108,14 @@ const paginationDotsWrapperColorStyle = (
             width: calc(100% + 2px);
             height: calc(100% + 2px);
             opacity: ${theme.opacity[52]};
-            border: 1px solid ${theme.semantic.line.normal.neutral};
+            transition:
+              border ease 0.2s,
+              opacity ease 0.2s;
+            border: 1px solid
+              var(
+                --wds-pagination-dot-border-color,
+                ${theme.semantic.line.normal.neutral}
+              );
           }
 
           &[aria-selected='true'] {
@@ -150,8 +158,8 @@ export const paginationDotsStyle = (scale: number, isFirst: boolean) => css`
 
   ${scale === 0 &&
   css`
-    &&::after {
-      border-width: 0px;
+    &::after {
+      --wds-pagination-dot-border-color: transparent;
     }
   `}
 


### PR DESCRIPTION
## Summary
- `PaginationDots`에서 `color="white"` 사용 시, `scale === 0`으로 숨김 처리되어야 하는 dot의 border가 그대로 노출되던 버그 수정
- border color를 CSS 변수(`--wds-pagination-dot-border-color`)로 제어하도록 변경하고, scale이 0일 때 `transparent`로 지정
- border/opacity transition을 추가해 scale 변화 시 자연스럽게 사라지도록 개선

## Test plan
- [ ] `PaginationDots` 스토리에서 `color="white"` 상태 확인 (숨김 dot이 보이지 않는지)
- [ ] 기본 color에서도 동일하게 동작하는지 확인
- [ ] scale 0 ↔ 0이 아닌 상태 전환 시 애니메이션이 부드럽게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 페이지네이션 점의 테두리 동작을 개선했습니다. 호버 및 포커스 상태에서 더 부드러운 시각적 전환을 제공합니다.
  * 페이지네이션 점의 색상 변형에 테두리 및 불투명도 애니메이션 효과를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->