### PR TITLE
chore: set up Claude Code environment and dev tooling

### DIFF
--- a/.claude/references/architecture.md
+++ b/.claude/references/architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+## Project Overview
+
+Montage (formerly WDS) is Wanted Lab's design system for web. It's a Lerna + Nx monorepo containing 9 packages, all published under `@wanteddev/*` to GitHub Package Registry.
+
+## Package Dependency Graph
+
+```text
+wds-theme (design tokens, no React dependency)
+    ↓
+wds-engine (Box, ThemeProvider, polymorphic types — depends on wds-theme + Emotion)
+    ↓
+wds, wds-icon, wds-lottie (UI components — depend on wds-engine)
+    ↓
+wds-nextjs (Next.js integration — depends on wds-engine)
+```
+
+Tooling packages (`wds-codemod`, `wds-mcp`, `eslint-plugin-wds`) are standalone.
+
+## Where to make changes (and where not to)
+
+Day-to-day work — adding components, updating styles, reflecting design changes from Figma — happens in **`wds`** (and occasionally `wds-icon` / `wds-lottie`). The foundation packages should be treated as nearly read-only:
+
+| Package      | Modify?                                        | Why                                                                                                                                                                                                     |
+| ------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wds`        | **Yes** — primary work surface                 | Component implementations, styles, types live here.                                                                                                                                                     |
+| `wds-icon`   | Via `sync-icons` skill, not by hand            | Icon set is generated from Figma. Manual edits get overwritten on the next sync.                                                                                                                        |
+| `wds-lottie` | Yes (rare)                                     | Only when adding/updating Lottie assets.                                                                                                                                                                |
+| `wds-theme`  | **Almost never** — token additions only        | Adding a new semantic token is OK when one is genuinely missing. Renaming/removing tokens, or changing the token shape, is a breaking change for every consumer of `wds`. Coordinate before touching.   |
+| `wds-engine` | **Almost never** — `Box`/types/`sx` are stable | Box, ThemeProvider, polymorphic types, the `sx` prop runtime, `useSxProps`. These are the primitives every component depends on; bugs here ripple through the entire library. Defer to the maintainers. |
+| `wds-nextjs` | **Almost never** — Next.js integration only    | RSC boundaries, `'use client'` injection. Touch only when a Next.js compatibility issue is the actual root cause.                                                                                       |
+
+**Rule of thumb**: if a task can be solved by editing files under `packages/wds/src/components/<name>/`, do it there. If it seems to require touching `wds-engine` / `wds-theme` / `wds-nextjs`, stop and confirm with the user — usually the right fix is in `wds` (compose `Box`/tokens/types differently), not in the foundation. Foundation changes are breaking-change territory and belong on a `feature/<major>.<minor>.<patch>` branch with explicit intent.
+
+The token exception worth knowing: if a designer asks for a color/spacing/typography value that doesn't exist as a `theme.semantic.*` token, the right move is to **add** the token in `wds-theme` (small, additive, non-breaking) rather than inline a hex/px literal in the component. This is the one routine reason to touch `wds-theme`.
+
+## Component Type System
+
+`wds-engine` exposes two parallel type families. Both have a public variant (with `sx`) and an `Internal` variant (without `sx`, used inside implementations because `Box` consumes `sx` separately).
+
+### Choosing the right pattern
+
+- **Default — use `DefaultComponent*`** for components that always render a fixed element. This is the right choice for the vast majority of components.
+- **Use `PolymorphicComponent*` only when the component genuinely needs an `as` prop** to swap its root element/component. The polymorphic generics add type complexity (and the event-handler caveat below), so don't reach for them by default.
+
+### Public vs Internal
+
+- **Public API** (consumed by users): `DefaultComponentProps<P, E>` / `PolymorphicProps<P, C>` and the matching component interfaces — include `sx`.
+- **Internal API** (used inside the implementation): `DefaultComponentPropsInternal<P, E>` / `PolymorphicPropsInternal<P, C>` — exclude `sx`, which is composed manually onto `Box`.
+
+### Default (non-polymorphic) pattern
+
+```tsx
+const ContentBadge = forwardRef<
+  HTMLSpanElement,
+  DefaultComponentPropsInternal<ContentBadgeProps, 'span'>
+>(({ variant = 'solid', ...props }, ref) => {
+  return (
+    <Box
+      as="span"
+      ref={ref}
+      {...props}
+      sx={[contentBadgeStyle({ variant }), props.sx]}
+    />
+  );
+});
+```
+
+### Polymorphic (`as`-prop) pattern
+
+```tsx
+const MyComponent = forwardRef(
+  <T extends ElementType = 'div'>(
+    { as, ...props }: PolymorphicPropsInternal<MyComponentProps, T>,
+    ref: ForwardedRef<T>,
+  ) => {
+    return (
+      <Box
+        as={(as || 'div') as T}
+        ref={ref}
+        sx={[myStyle, props.sx]}
+        {...props}
+      />
+    );
+  },
+) as PolymorphicComponentInternal<MyComponentProps, 'div'>;
+```
+
+**Critical TypeScript caveat (polymorphic only)**: When using `PolymorphicPropsInternal`, event handlers (`onClick`, `onKeyDown`, etc.) accessed via `...props` spread may cause TypeScript errors because `Omit` types don't resolve properly. Fix by destructuring event handlers explicitly: `{ onClick, onKeyDown, ...rest }`. This is one more reason to prefer `DefaultComponent*` when `as` isn't needed.
+
+## Component File Structure
+
+Each component follows this layout:
+
+```text
+component-name/
+├── index.tsx       # Implementation (uses Box from wds-engine)
+├── types.ts        # Props defined with WithSxProps<{...}> + ResponsiveProps
+├── style.ts        # Style functions using theme tokens
+├── constants.ts    # Optional constants
+└── index.test.tsx  # Unit tests
+```
+
+## Theme System
+
+Three-layer architecture:
+
+1. **wds-theme**: Raw atomic tokens + semantic tokens (light/dark) + design tokens (spacing, opacity, breakpoint, zIndex)
+2. **wds-engine**: Emotion-based runtime (ThemeProvider, Box with `sx` prop, `useSxProps` hook)
+3. **wds**: Components compose styles using theme tokens via style functions
+
+## Responsive Props
+
+Components support per-breakpoint prop overrides:
+
+```tsx
+type ButtonProps = Merge<
+  ButtonDefaultProps,
+  ResponsiveProps<Pick<ButtonDefaultProps, 'fullWidth' | 'size'>>
+>;
+// Usage: <Button xs={{ size: 'small' }} md={{ size: 'large' }} />
+```
+
+## Build System
+
+- **tsdown** bundles each package to CJS + ESM with DTS generation
+- Post-build hook injects `'use client'` directive for RSC-compatible files
+- External: `react`, `react-dom`, `next`

--- a/.claude/references/coding-style.md
+++ b/.claude/references/coding-style.md
@@ -1,0 +1,328 @@
+# Coding Style
+
+> Branch naming, commit conventions, PR rules, visual regression workflow, and CI checks live in [workflow.md](./workflow.md). This document covers code itself.
+
+## Code Conventions
+
+- **Arrow functions only** for React components (`react/function-component-definition`)
+- **Type imports**: Use `import type { ... }` consistently (`@typescript-eslint/consistent-type-imports`)
+- **Array types**: Use `Array<T>` generic syntax, not `T[]` (`@typescript-eslint/array-type`)
+- **Import ordering**: Groups separated by newlines — builtin, external, internal, parent, sibling, index, object, type. Type-only imports come last as their own group.
+- **Naming**: PascalCase for interfaces/types, camelCase for variables/functions
+
+## Component Folder Structure
+
+Every component lives in its own kebab-case directory under `packages/wds/src/components/<component-name>/`. Files are added only when needed — start minimal.
+
+```text
+component-name/
+├── index.tsx       # Required. Component implementation.
+├── types.ts        # Required. Public Props types.
+├── style.ts        # Required. Style functions (Emotion css helper).
+├── constants.ts    # Optional. Component name strings, magic numbers.
+├── contexts.ts     # Optional. Compound-component context (Radix createContext).
+├── hooks.ts        # Optional. Component-local hooks.
+├── helpers.ts      # Optional. Pure helper functions (date math, formatting, etc).
+└── index.test.tsx  # Optional. Vitest + Testing Library unit tests.
+```
+
+The component is then re-exported from `packages/wds/src/components/index.ts` with `export * from './component-name';` — that one line is the entire registration step.
+
+### When to add each optional file
+
+- **`constants.ts`**: as soon as you have a compound component (Accordion, AccordionSummary, ...). Name strings are shared between `displayName` and the Radix context name to keep error messages consistent. Also a good home for non-styling magic numbers.
+- **`contexts.ts`**: whenever a parent component needs to share state with descendants. Use `@radix-ui/react-context`'s `createContext` (returns `[Provider, useContext]` tuple) — never `React.createContext` directly, because the Radix version gives clearer "must be used within X" errors and accepts a name for the message.
+- **`hooks.ts`**: when a hook is component-internal and not reused elsewhere. If it becomes reusable, lift it to `packages/wds/src/hooks/`.
+- **`helpers.ts`**: pure functions (no React, no hooks). Keeps `index.tsx` readable.
+
+## types.ts — Props Type Patterns
+
+### Non-responsive component
+
+```ts
+import type { WithSxProps } from '@wanteddev/wds-engine';
+import type { ReactNode } from 'react';
+
+export type ContentBadgeDefaultProps = WithSxProps<{
+  /** The size of the content badge. */
+  size?: 'xsmall' | 'small' | 'medium';
+  /** The variant of the content badge. */
+  variant?: 'solid' | 'outlined';
+  /** The content of the content badge. */
+  children?: ReactNode;
+}>;
+```
+
+Key rules:
+
+- **Always wrap with `WithSxProps<{...}>`** — this adds the public `sx` prop. The `Internal` types used inside `index.tsx` strip it back off.
+- **JSDoc every public prop.** These comments surface in IDE tooltips and the docs site. Keep them short and start with a capital letter.
+- **Use string-literal unions** for variants (`'solid' | 'outlined'`) instead of enums.
+
+### Responsive component
+
+When a component supports per-breakpoint overrides, split the type into three:
+
+```ts
+export type ButtonDefaultProps = WithSxProps<{
+  size?: 'small' | 'medium' | 'large';
+  fullWidth?: boolean;
+  // ...
+}>;
+
+export type ButtonResponsiveProps = ResponsiveProps<
+  Pick<ButtonDefaultProps, 'fullWidth' | 'size'>
+>;
+
+export type ButtonProps = Merge<ButtonDefaultProps, ButtonResponsiveProps>;
+```
+
+`Pick` only the props that actually make sense to override per-breakpoint (size, layout-affecting flags). Don't blanket-apply `ResponsiveProps` to every prop — `disabled`, callbacks, and content props should stay flat.
+
+### Compound component types
+
+Each subcomponent gets its own exported Props type. Reuse base component props via `Merge` when extending:
+
+```ts
+export type AccordionSummaryProps = Merge<
+  { leadingContent?: ReactNode; trailingContent?: ReactNode },
+  Omit<ListCellProps, 'selected' | 'divider'>
+>;
+```
+
+Use `Omit` to hide props that don't apply in the new context.
+
+## index.tsx — Component Implementation Patterns
+
+See [architecture.md](./architecture.md#component-type-system) for `DefaultComponent*` vs `PolymorphicComponent*` selection. The TL;DR: default to `DefaultComponent*`; reach for `PolymorphicComponent*` only when `as` is genuinely needed.
+
+### Default (fixed-element) pattern
+
+```tsx
+import { forwardRef } from 'react';
+import { Box } from '@wanteddev/wds-engine';
+
+import { contentBadgeStyle } from './style';
+
+import type { DefaultComponentPropsInternal } from '@wanteddev/wds-engine';
+import type { ContentBadgeProps } from './types';
+
+const ContentBadge = forwardRef<
+  HTMLSpanElement,
+  DefaultComponentPropsInternal<ContentBadgeProps, 'span'>
+>(
+  (
+    {
+      variant = 'solid',
+      size = 'xsmall',
+      children,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <Box
+        as="span"
+        ref={ref}
+        {...props}
+        sx={[
+          contentBadgeStyle({ variant, size, xs, sm, md, lg, xl }),
+          props.sx,
+        ]}
+      >
+        {children}
+      </Box>
+    );
+  },
+);
+
+ContentBadge.displayName = 'ContentBadge';
+
+export { ContentBadge };
+export type { ContentBadgeProps };
+```
+
+### Polymorphic (`as`-prop) pattern
+
+```tsx
+const Button = forwardRef(
+  <T extends ElementType = 'button'>(
+    {
+      as,
+      variant = 'solid',
+      children,
+      ...props
+    }: PolymorphicPropsInternal<ButtonProps, T>,
+    ref: ForwardedRef<T>,
+  ) => {
+    return (
+      <Box
+        as={(as || 'button') as T}
+        ref={ref}
+        {...props}
+        sx={[buttonStyle({ variant }), props.sx]}
+      >
+        {children}
+      </Box>
+    );
+  },
+) as PolymorphicComponentInternal<ButtonProps, 'button'>;
+
+Button.displayName = 'Button';
+```
+
+Note the trailing `as PolymorphicComponentInternal<...>` cast — it's required so the generic call signature survives `forwardRef`'s type erasure.
+
+### Conventions that apply to both
+
+- **Always `forwardRef`.** Even seemingly leaf components get refs from consumers (focus management, animations, third-party integrations).
+- **Render through `Box`** from `wds-engine` — never a raw `div`/`span`/etc. `Box` handles the `sx` prop, theme access, and the polymorphic `as` plumbing.
+- **Spread `{...props}` _before_ `sx`** so the merged-with-defaults `sx` wins over any incoming `sx` from `props`. Do the same for any prop you intentionally override (`onClick` composed via `composeEventHandlers`, etc).
+- **Compose event handlers, don't replace them.** When you need to add behavior to `onClick` / `onKeyDown`, use `composeEventHandlers(internalHandler, props.onClick)` from `@radix-ui/primitive` so the consumer's handler still runs.
+- **Provide controllable state via `useControllableState`** (`@radix-ui/react-use-controllable-state`) — it gives you the `value`/`defaultValue`/`onChange` triple for free, matching native form-element semantics.
+- **Set `displayName` from a `constants.ts` constant** when the component is part of a compound — the same string is reused as the context name, so a single source of truth keeps debug output consistent.
+- **Re-export the Props type** at the bottom: `export type { ButtonProps };`. Tooling (docs site, codemods) relies on this.
+
+### Import ordering inside `index.tsx`
+
+Three groups, blank line between each:
+
+```tsx
+// 1) Value imports — external (react first), then internal (parent → sibling)
+import { forwardRef, useId } from 'react';
+import { Box } from '@wanteddev/wds-engine';
+import { composeEventHandlers } from '@radix-ui/primitive';
+
+import { WithInteraction } from '../with-interaction';
+import { Loading } from '../loading';
+
+import { buttonStyle } from './style';
+
+// 2) Type-only imports — same ordering, but as a separate group
+import type {
+  PolymorphicComponentInternal,
+  PolymorphicPropsInternal,
+} from '@wanteddev/wds-engine';
+import type { ElementType, ForwardedRef, SyntheticEvent } from 'react';
+import type { ButtonProps } from './types';
+```
+
+ESLint's `import/order` enforces the value-import ordering; the type-only block is a project convention.
+
+## style.ts — Style Function Patterns
+
+### Curried theme-aware style
+
+When the style needs theme tokens, use the curried form:
+
+```ts
+import { css } from '@wanteddev/wds-engine';
+import type { Theme } from '@wanteddev/wds-engine';
+import type { ButtonProps } from './types';
+
+export const buttonStyle =
+  ({ loading, xs, sm, md, lg, xl, ...props }: ButtonProps) =>
+  (theme: Theme) => css`
+    display: inline-flex;
+    color: ${theme.semantic.label.normal};
+    background-color: ${theme.semantic.primary.normal};
+    /* ... */
+  `;
+```
+
+The outer call captures props; the inner function receives `theme` from `Box`. This lets the same function be passed directly into `sx={[buttonStyle({...}), props.sx]}`.
+
+### Theme-free style
+
+When no theme tokens are needed, drop the curry:
+
+```ts
+export const accordionContentStyle = css`
+  display: flex;
+  flex-direction: column;
+`;
+```
+
+### Splitting variants into sub-functions
+
+Once a style has more than one switchable axis (variant × color × size), extract sub-functions to keep the main one readable:
+
+```ts
+export const buttonStyle = ({ ... }: ButtonProps) => (theme: Theme) => css`
+  /* base styles */
+  ${buttonColorStyle({ variant, color }, theme)}
+  ${buttonSizeStyle({ size, iconOnly, color })}
+`;
+
+const buttonColorStyle = ({ variant, color }: ButtonProps, theme: Theme) => {
+  switch (true) {
+    case variant === 'solid' && color === 'primary':
+      return css`/* ... */`;
+    // ...
+  }
+};
+```
+
+`switch (true)` with boolean cases reads cleanly when discriminating on multiple props.
+
+### Responsive styles
+
+Use `createResponsiveStyle` from `utils/internal/responsive-props` — never write media queries by hand:
+
+```ts
+${createResponsiveStyle({ xs, sm, md, lg, xl }, theme)(
+  (params) => css`
+    ${buttonSizeStyle({ ...params, color: props.color })}
+    ${params?.fullWidth && 'width: 100%;'}
+  `,
+)}
+```
+
+This expands to the project's breakpoint media queries and applies styles only to the props that were overridden at each breakpoint.
+
+### Always use theme tokens
+
+Reference `theme.semantic.*` (semantic tokens — light/dark aware) over `theme.color.*` (raw atomic tokens). Never hardcode hex values. If a token doesn't exist, the right move is to add one in `wds-theme`, not to inline a literal.
+
+## contexts.ts — Compound Component Context
+
+```ts
+import { createContext } from '@radix-ui/react-context';
+
+import { ACCORDION_NAME } from './constants';
+
+type AccordionContextType = {
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  // ...
+};
+
+export const [AccordionProvider, useAccordionContext] =
+  createContext<AccordionContextType>(ACCORDION_NAME);
+```
+
+Usage in `index.tsx`:
+
+```tsx
+const { expanded, onExpandedChange } = useAccordionContext(
+  ACCORDION_SUMMARY_NAME,
+);
+```
+
+The argument to `useAccordionContext` is the _consumer_ name (used in error messages like `AccordionSummary must be used within Accordion`), so pass the displayName of the component that's calling it — not the provider's name.
+
+## Unit testing
+
+- Unit tests use **Vitest** with **@testing-library/react** and **vitest-axe** for accessibility
+- Test globals are enabled (`describe`, `it`, `expect`, `vi` available without imports)
+- Setup mocks: `matchMedia`, `ResizeObserver`, `HTMLCanvasElement`
+- Bundle size limits enforced via **size-limit** (e.g., wds: 5KB gzipped)
+- Test file lives next to the component as `index.test.tsx` — no separate `__tests__/` directory
+- Always include at least one `vitest-axe` accessibility assertion for interactive components
+
+For visual regression tests, snapshot updates, and CI specifics, see [workflow.md](./workflow.md).

--- a/.claude/references/workflow.md
+++ b/.claude/references/workflow.md
@@ -1,0 +1,110 @@
+# Workflow
+
+How work flows from a fresh branch to a merged PR. Read this once; the per-step skills (`create-pr`, `sync-icons`) handle the actual mechanics.
+
+## Branch naming
+
+The ideal pattern is **`feature/<git-username>/<JIRA-ID>`** — short, traceable, and the commit-msg hook can auto-stamp the Jira ID into every commit.
+
+| Situation                                 | Pattern                                  | Example                          |
+| ----------------------------------------- | ---------------------------------------- | -------------------------------- |
+| Standard work with a Jira ticket          | `feature/<git-username>/<JIRA-ID>`       | `feature/sh031224/PI-82494`      |
+| Standard work, no Jira (rare — see below) | `feature/<git-username>/<short-summary>` | `feature/sh031224/gradient-icon` |
+| Major version (breaking changes)          | `feature/<x.y.z>`                        | `feature/4.0.0`                  |
+| Documentation-only                        | `docs/<short-summary>`                   | `docs/v2`                        |
+
+The `<short-summary>` is kebab-case, focused on the _what_, not the _how_.
+
+### Recognized Jira project keys
+
+The repo's commit-msg hook (`scripts/commit-msg.mjs`) detects these prefixes case-insensitively and auto-stamps the ID into commit subjects:
+
+```
+pi-… | fe-… | dp-… | def-… | live-… | wrp-…
+```
+
+If your ticket lives in another project, the hook won't auto-stamp it — but you can still put the ID in the branch and reference it in the PR body manually.
+
+### No Jira ticket? Create one first.
+
+When work starts without a ticket — a designer ad-hoc fix, a polish task, a refactor that wasn't planned — **the right move is to create a Jira ticket _before_ opening the branch**, not to skip Jira and use a summary slug.
+
+Why:
+
+- The commit-msg hook prints a warning on every commit when a `feature/*` branch has no Jira ID. That noise compounds.
+- Release notes and changelog generation pull context from Jira links. PRs without tickets are harder to triage at release time.
+- A 60-second ticket creation now is much cheaper than reconstructing context for a reviewer who asks "왜 이거 하는 거예요?" days later.
+
+Use the `atlassian:triage-issue` skill (or just create the ticket in Jira directly) **before** branching. Then use the standard `feature/<git-username>/<JIRA-ID>` pattern.
+
+The summary-only fallback (`feature/sh031224/gradient-icon`) is for genuinely throwaway work where ticket overhead exceeds the change cost — e.g. a typo fix, a one-line docs nudge. If you find yourself reaching for it on anything bigger, stop and create a ticket.
+
+## Base branch rules
+
+- **Default — `main`.** Patch and minor work targets `main`.
+- **Major (breaking) — `feature/<x.y.z>`.** When the work introduces breaking changes (`feat!:` / `BREAKING CHANGE:`), the base must be the long-running major-version branch. Breaking changes must not land directly on `main` because there's no way to stage them — they'd ship to every consumer on the next patch.
+
+The `create-pr` skill enforces this: a major bump with `main` as base or a missing `feature/<x.y.z>` branch will halt and ask for confirmation. See [the create-pr skill](../skills/create-pr/SKILL.md) for the full guard logic.
+
+## Commit conventions
+
+Conventional Commits are mandatory: `<type>(<scope>): <description>`. `commitlint` enforces this on every commit.
+
+- **Allowed types** (matching repo history): `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `style`, `build`, `ci`
+- **Common scopes**: package names — `wds`, `wds-engine`, `wds-icon`, `wds-mcp`, `ci`. Match what `git log --oneline -20` shows.
+- **Breaking changes**: append `!` after the type/scope (`feat!:`, `feat(wds)!:`) or include a `BREAKING CHANGE:` footer. Either form bumps the major version.
+- **Body**: focus on the _why_, not the _what_ — the diff already shows the what.
+
+The commit-msg hook (`scripts/commit-msg.mjs`) does extra work for you:
+
+- If the branch name contains a Jira ID, it gets auto-prepended to the commit subject.
+- A Jira link gets auto-added to the commit body.
+- The author's git name is added to the body.
+
+Don't fight the hook — let it run.
+
+## PR conventions
+
+Every PR must have:
+
+1. **Conventional Commits title** — squash merge means the PR title becomes the merged commit, which lerna parses for version bumps and changelog. Non-conventional titles silently break release tooling.
+2. **Self-assignment** (`--assignee @me`) — review queues filter by assignee.
+3. **Release milestone** (`<major>.<minor>.<patch>`, computed from `lerna.json`) — release notes group merged PRs by milestone. No milestone → invisible to release.
+4. **Jira link in the body** when a ticket exists — saves reviewers a context switch.
+
+Mechanics (creating the PR, computing the milestone, auto-creating it if missing, validating the major-branch base) live in [the create-pr skill](../skills/create-pr/SKILL.md). Don't replicate them in your head — invoke the skill.
+
+## Visual regression tests
+
+Visual tests run with Playwright + Chromium and compare PNG snapshots committed to the repo. **Snapshots are taken in GitHub Actions, not on developer machines** — font rendering, sub-pixel anti-aliasing, and headless-browser quirks all differ between macOS/Linux/Windows, so a snapshot that looks fine locally will almost always diff against the CI baseline.
+
+Consequence: **don't update visual snapshots locally and commit them.** Local diffs are noise. The CI environment is the source of truth.
+
+When a PR's visual test fails:
+
+1. Confirm the diff is intentional (the failing job uploads actual vs. expected images as artifacts — open them and verify the new rendering is what you want).
+2. Trigger the **`visual-test-update.yml`** workflow against your PR branch:
+
+   ```bash
+   gh workflow run visual-test-update.yml --ref <your-branch>
+   # or via the UI: Actions → "visual-test-update" → Run workflow → pick the branch
+   ```
+
+3. The workflow reruns the visual tests, regenerates the snapshots in the CI environment, and commits them back to your branch. Pull the new commit locally before continuing.
+4. Re-run CI on the PR — visual tests should now pass.
+
+If the diff is **not** intentional, don't update the snapshots — fix the underlying style/component regression instead.
+
+## CI checks on PRs
+
+The following run automatically on every pull request:
+
+- Size-limit analysis (bundle size budgets)
+- Unit tests (Vitest + jsdom)
+- Visual regression tests (Playwright + Chromium)
+- CommonJS compatibility checks
+- Tree-shaking validation
+- Lint and format
+- commitlint on commit messages
+
+A red CI is a real signal — investigate before requesting review.

--- a/.claude/scripts/format-on-write.sh
+++ b/.claude/scripts/format-on-write.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format files written/edited by Claude.
+# - .ts/.tsx/.js/.jsx/.mjs/.cjs → eslint --fix (block on failure)
+# - everything else            → prettier --write (best-effort)
+#
+# Reads the tool event JSON from stdin and pulls the touched file path.
+
+set -u
+
+file="$(jq -r '.tool_response.filePath // .tool_input.file_path // empty')"
+
+if [ -z "$file" ]; then
+  exit 0
+fi
+
+case "$file" in
+  *.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs)
+    if ! out=$(pnpm exec eslint --fix --no-warn-ignored "$file" 2>&1); then
+      echo "$out" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    pnpm exec prettier --write --ignore-unknown "$file" 2>/dev/null || true
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "atlassian@claude-plugins-official": true
+  },
+  "permissions": {
+    "deny": ["Read(**/.env*)"]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/format-on-write.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: create-pr
+description: Create a GitHub pull request from the current branch. Handles uncommitted/unpushed changes by asking the user before committing, always self-assigns, attaches a semver release milestone derived from `lerna.json` (creating it if missing) for release-relevant PRs and skips the milestone for release-irrelevant PRs (docs-only / `.claude/` / root-meta changes), and enriches the PR description with Jira issue details when the branch name contains an issue ID like PROJ-123. Use this skill whenever the user says "PR 만들어줘", "PR 생성해줘", "PR 올려줘", "open a PR", "create a pull request", or signals they're ready to ship the current branch — even if they don't explicitly say "PR".
+---
+
+# create-pr
+
+A workflow for opening a GitHub pull request from the current branch with sensible defaults: confirm-before-commit, push if needed, self-assign, and Jira-enriched description.
+
+## When to trigger
+
+- User says "PR 만들어줘", "PR 생성", "PR 올려줘", "open a PR", "create PR", "send it up for review", etc.
+- User finishes implementation and asks "이제 뭐 하면 돼?" / "이제 올리면 돼?" — interpret as PR creation intent
+
+## Core invariants
+
+These are non-negotiable. Build the workflow around them.
+
+1. **Self-assign is mandatory** — every PR must include `--assignee @me`. Unassigned PRs sit in review queues invisibly because reviewers filter by assignee.
+2. **A release milestone is mandatory — _unless_ the PR has no release impact.** PRs that change shipped package code must be attached to a semver milestone (`<major>.<minor>.<patch>`) computed from `lerna.json`; the milestone is what release tooling and the changelog generator key off, and an unmilestoned package PR is invisible to the release. **Exception**: PRs whose entire diff is release-irrelevant (docs-only, `.claude/` environment files, root-level meta files like `AGENTS.md` / `CLAUDE.md`) do not produce a published package version and **must not** carry a milestone — attaching one would pollute the release notes with non-shipping changes. See step 8 for the classifier.
+3. **Never commit without explicit user approval** — uncommitted changes might be intentional WIP, debug code, or someone else's work in progress.
+4. **Never push to `main`/`master`** — abort and ask the user to switch to a feature branch.
+5. **Never use `--no-verify`** to skip hooks. If a hook fails, surface the error and let the user decide.
+6. **Never use `git add -A` / `git add .`** — stage files by name. Wildcards routinely sweep up `.env`, credentials, and stray build artifacts.
+
+## Workflow
+
+### 1. Probe the environment
+
+Run these in parallel — they're independent:
+
+```bash
+git rev-parse --git-dir                                # confirm git repo
+gh auth status                                         # confirm gh CLI auth
+git rev-parse --abbrev-ref HEAD                        # current branch
+git status --porcelain                                  # uncommitted changes
+git log --oneline -10                                   # recent commit style
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null  # upstream
+```
+
+If any precondition fails (not a repo, not authed, on `main`/`master`, branch has zero commits ahead of base), stop and explain — don't try to recover silently.
+
+### 2. Check for an existing PR for this branch
+
+```bash
+gh pr view --json url,state,title 2>/dev/null
+```
+
+If one exists and is open, show the URL and ask whether the user wants to update its description, leave a comment, or push more commits. Don't create a duplicate.
+
+### 3. Handle uncommitted changes
+
+If `git status --porcelain` is non-empty:
+
+1. Show the user a concise summary (file list with M/A/D/?? markers).
+2. Ask explicitly: **"다음 변경사항을 모두 커밋하고 PR을 생성할까요?"** — list the files. Wait for an answer.
+3. If the user says yes:
+   - Run `git diff` and `git diff --cached` to understand what's changing.
+   - Read recent commits (`git log --oneline -10`) to match the repo's style — this codebase uses Conventional Commits (`feat(scope): ...`, `fix(scope): ...`, `chore: ...`).
+   - Draft a commit message that focuses on **why**, not **what**. One subject line, optional body.
+   - Stage files **by name** (never `-A` / `.`). Skip anything that looks like a secret (`.env*`, `credentials*`, `*.pem`).
+   - Commit with a heredoc to preserve formatting:
+
+     ```bash
+     git commit -m "$(cat <<'EOF'
+     feat(scope): short subject
+
+     Optional body explaining why.
+     EOF
+     )"
+     ```
+
+   - If a pre-commit hook fails, fix the underlying issue and create a **new** commit. Never `--amend` to dodge the failure (the failed commit didn't happen, so amend would rewrite the previous one).
+
+4. If the user says no, ask: "이미 커밋된 변경사항만으로 PR을 생성할까요, 아니면 중단할까요?"
+
+### 4. Push if needed
+
+- No upstream → `git push -u origin <branch>`
+- Upstream exists but local is ahead → `git push`
+- Local is behind upstream → surface the divergence and ask before doing anything; never `--force` without explicit user confirmation.
+
+### 5. Extract Jira issue ID from branch name
+
+Apply this regex to the current branch: `[A-Z][A-Z0-9]+-\d+`
+
+The ideal branch pattern in this repo is `feature/<git-username>/<JIRA-ID>` (e.g. `feature/sh031224/PI-82494`). Other shapes still match: `feat/PROJ-123-add-thing`, `PROJ-123_fix_bug`, `bugfix/PROJ-123`. The recognized Jira project keys are `PI`, `FE`, `DP`, `DEF`, `LIVE`, `WRP` — see [workflow.md](../../references/workflow.md#recognized-jira-project-keys).
+
+#### If a match is found
+
+- **If the Atlassian MCP is available** (look for `mcp__plugin_atlassian_atlassian__getJiraIssue` in available tools), fetch the issue. Extract: summary, status, issue type, assignee, and the first paragraph of the description (skip if the description is empty or noisy).
+- **If the MCP is unavailable or the fetch fails**, fall back to including just the bare ticket reference. Don't block the PR on Jira lookup failure.
+
+#### If no match is found
+
+Don't silently proceed. The repo's commit-msg hook warns on every commit when a `feature/*` branch lacks a Jira ID, and release notes lose context without a ticket link. Before opening the PR, surface this and recommend creating a Jira ticket first:
+
+> "현재 브랜치(`<branch>`)에 Jira 이슈 ID가 없습니다. 이 repo는 `feature/<username>/<JIRA-ID>` 패턴이 표준이라, PR 열기 전에 Jira 티켓을 먼저 만드는 걸 추천드려요.
+>
+> 1. `atlassian:triage-issue` 스킬로 티켓을 만들거나, 직접 Jira에서 만든 뒤
+> 2. 새 브랜치 `feature/<username>/<JIRA-ID>` 로 cherry-pick / rebase 해서 다시 시도
+>
+> 그래도 지금 PR을 그대로 진행할까요? (typo fix 같은 throwaway 변경이면 OK)"
+
+Wait for the user's answer:
+
+- **They want to create a ticket first** → stop, hand off to `atlassian:triage-issue` or let them do it manually. Don't try to rename the branch yourself; cherry-picking onto a freshly named branch is their call.
+- **They confirm it's throwaway** → proceed without a Jira section in the body. Note in the body something like "_No Jira ticket — minor/throwaway change._" so reviewers understand the omission was deliberate.
+- **They're on a non-`feature/*` branch shape** (e.g. `fix/...`, `docs/...`) where the hook doesn't warn → the recommendation is softer; mention it once but don't block.
+
+### 6. Build the PR title
+
+**The PR title must be Conventional Commits format** — `<type>(<scope>): <subject>` (or `<type>: <subject>` if no scope, `<type>!:` for breaking). This is non-negotiable: PRs are squash-merged here, so the PR title becomes the merged commit message, which lerna parses to compute the version bump and generate the changelog. A non-conventional title silently breaks both. `commitlint` enforces it on commits but **not** on PR titles, so this skill is the gate.
+
+Allowed types (matching the existing repo history): `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `style`, `build`, `ci`. Common scopes are package names (`wds`, `wds-engine`, `wds-icon`, `wds-mcp`, `ci`) — check `git log --oneline -20` to match what's in use.
+
+How to derive the title:
+
+1. **If the branch has a single commit** with a valid Conventional Commits subject, use that subject verbatim.
+2. **If the branch has multiple commits**, summarize them into one Conventional Commits line. Type follows the same rules as the milestone bump: any `!` / `BREAKING CHANGE` → `<type>!:`, any `feat` → `feat:`, otherwise pick the dominant type.
+3. **If the latest commit isn't conventional** (e.g. "wip", "fix typo"), derive from the branch name: `feat/PROJ-123-add-modal` → `feat: add modal`. Don't copy a non-conventional commit subject into the PR title — fix it.
+4. Keep under 70 characters. Details belong in the body, not the title.
+
+Validate the final title against the regex roughly as `^(feat|fix|chore|docs|refactor|perf|test|style|build|ci)(\([a-z0-9-]+\))?!?: .+$` before passing it to `gh`. If it doesn't match, fix it — don't ship a malformed title.
+
+The Jira ID does **not** belong in the title (Conventional Commits has no slot for it and prefixing breaks the regex). Keep it in the body.
+
+### 7. Build the PR body
+
+Template:
+
+```markdown
+## Summary
+
+- <bullet derived from commits / diff>
+- <one bullet per logical change>
+
+## Jira
+
+[PROJ-123](https://your-domain.atlassian.net/browse/PROJ-123) — <issue summary>
+
+- Status: <status>
+- Type: <type>
+
+<first paragraph of issue description, if useful>
+
+## Test plan
+
+- [ ] <derived from what changed — UI changes get a manual check, logic gets test coverage notes>
+```
+
+Drop the **Jira** section entirely if no ticket was found. Drop **Test plan** items if the change is trivial (typo fix, dep bump) — don't pad with filler checkboxes.
+
+For the Summary, look at `git log <base>..HEAD --oneline` and the cumulative diff — not just the latest commit. Multi-commit branches need a unified summary.
+
+### 8. Determine and ensure the release milestone
+
+The PR **must** be attached to a semver milestone (`<major>.<minor>.<patch>`) — **unless** it has zero release impact, in which case it must _not_ carry one. Run the classifier first.
+
+#### 8.0. Classify: release-relevant or not?
+
+Inspect the cumulative diff on this branch:
+
+```bash
+BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null \
+  || gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+git diff --name-only "origin/$BASE...HEAD"
+```
+
+The PR is **release-irrelevant** (skip the milestone entirely — do not run 8a–8e, and omit `--milestone` in step 9) when **every** changed path matches one of:
+
+- `docs/**` (the docs site package — not published)
+- `.claude/**` (Claude Code environment: settings, hooks, skills, references, scripts)
+- Root meta files: `AGENTS.md`, `CLAUDE.md`, `README.md`, `.gitignore`, `.editorconfig`, `.prettierrc*`, `.eslintrc*` (and similar tooling configs that don't ship inside any package)
+
+If **any** changed path falls outside that set — especially anything under `packages/<pkg>/src/**`, `packages/<pkg>/package.json`, or `lerna.json` — the PR _is_ release-relevant and must follow the normal milestone flow (8a–8e).
+
+When you classify a PR as release-irrelevant, briefly say so to the user before creating it: "이 PR은 docs/.claude 변경만 있어서 배포 영향이 없으므로 마일스톤 없이 생성할게요." This lets them correct you if they actually wanted a release.
+
+When in doubt — mixed diff, or a single suspicious file in `packages/**` — treat it as release-relevant and ask if it should be split.
+
+If release-irrelevant, skip to step 9. Otherwise continue with 8a.
+
+#### 8a. Read the current version
+
+```bash
+node -p "require('./lerna.json').version"   # or: cat lerna.json | jq -r .version
+```
+
+This returns something like `3.5.0`. If `lerna.json` is missing or the version is malformed, abort and tell the user — don't guess.
+
+#### 8b. Decide the bump type
+
+Inspect the commits on this branch (`git log <base>..HEAD --pretty=%s`) and apply Conventional Commits rules:
+
+| Highest-impact commit on branch                           | Bump  |
+| --------------------------------------------------------- | ----- |
+| Any commit with `!` (e.g. `feat!:`) or `BREAKING CHANGE:` | major |
+| Any `feat:` / `feat(scope):`                              | minor |
+| Otherwise (`fix`, `perf`, `refactor`, `docs`, `chore`, …) | patch |
+
+Use the **highest** bump any single commit triggers — one breaking change wins over ten fix commits.
+
+If the bump type is genuinely ambiguous (mixed commit types where the impact isn't clear, or non-conventional messages), ask the user: **"이 PR을 patch / minor / major 중 어디로 릴리즈할까요? (현재 버전: 3.5.0 → patch=3.5.1, minor=3.6.0, major=4.0.0)"**
+
+#### 8c. Compute the target version
+
+From `<major>.<minor>.<patch>`:
+
+- **patch** → `<major>.<minor>.<patch + 1>`
+- **minor** → `<major>.<minor + 1>.0`
+- **major** → `<major + 1>.0.0`
+
+Examples (current version `3.5.0`): patch → `3.5.1`, minor → `3.6.0`, major → `4.0.0`.
+
+#### 8d. Ensure the milestone exists on GitHub
+
+```bash
+OWNER_REPO=$(gh repo view --json owner,name -q '.owner.login + "/" + .name')
+
+# List existing open milestones
+gh api "repos/$OWNER_REPO/milestones?state=open" --jq '.[].title'
+```
+
+If the target version is **not** in that list, create it:
+
+```bash
+gh api -X POST "repos/$OWNER_REPO/milestones" -f title="3.6.0"
+```
+
+Don't create milestones speculatively for the other bump types — only the one this PR ships under.
+
+#### 8e. Major bump → require the `feature/<version>` base branch
+
+**This sub-step only runs when the bump type is `major`.** Skip it for patch/minor.
+
+Major releases never merge straight into `main`. They live on a long-running branch named `feature/<major>.<minor>.<patch>` (e.g. `feature/4.0.0`) so breaking changes can pile up safely while `main` keeps shipping the current major. The PR's base branch must be that major branch.
+
+Run these checks:
+
+```bash
+TARGET_VERSION="4.0.0"                                 # from step 8c
+MAJOR_BRANCH="feature/$TARGET_VERSION"
+CURRENT_BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null \
+  || gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+
+# Does the major branch exist on the remote?
+git ls-remote --exit-code --heads origin "$MAJOR_BRANCH" >/dev/null 2>&1
+```
+
+Then branch on the result:
+
+1. **Major branch doesn't exist on the remote** → **stop and warn**:
+
+   > "이 PR은 major 버전 bump (4.0.0) 으로 판단됐는데 `feature/4.0.0` 브랜치가 원격에 없습니다. 정말 major 작업이 맞나요?
+   >
+   > - 정말 major면: 먼저 `git checkout main && git pull && git checkout -b feature/4.0.0 && git push -u origin feature/4.0.0` 으로 major 브랜치를 만든 다음, 현재 브랜치를 `git rebase feature/4.0.0` 로 그 위에 다시 올리고 PR을 다시 시도해주세요.
+   > - major가 아니라면 (실수로 `feat!:`/`BREAKING CHANGE:` 가 들어간 거면) 커밋 메시지를 정정해서 minor/patch 로 다시 판정되게 해주세요."
+
+   Wait for the user — never auto-create the major branch yourself, since that's a release-management decision the user owns.
+
+2. **Major branch exists, but the PR's base is `main`/default branch** → **stop and warn**:
+
+   > "major bump (4.0.0) 인데 base 브랜치가 `main` 입니다. major 작업은 `feature/4.0.0` 위로 올라가야 합니다. 다음 둘 중 하나로 진행해주세요:
+   >
+   > - 정말 major: `git fetch origin && git rebase origin/feature/4.0.0` 후 다시 PR (또는 `gh pr create --base feature/4.0.0 ...`)
+   > - 사실 major 아님: 커밋 메시지에서 `!` / `BREAKING CHANGE:` 를 제거해 minor/patch 로 다시 판정"
+
+   Wait for confirmation. If the user confirms it's really major, prefer rebasing locally onto the major branch over just changing `--base` — rebasing surfaces conflicts with the in-progress major work _now_ instead of at merge time.
+
+3. **Major branch exists AND base is already `feature/<version>`** → proceed to step 9, passing `--base feature/<version>` to `gh pr create`.
+
+The point of this gate is to prevent breaking changes from leaking into the current major's release line. Don't skip it just because the user is in a hurry — a misrouted major PR is much more expensive to clean up after merge than the 30 seconds of friction here.
+
+### 9. Create the PR
+
+```bash
+gh pr create \
+  --title "..." \
+  --body "$(cat <<'EOF'
+...body here...
+EOF
+)" \
+  --assignee @me \
+  --milestone "3.6.0" \
+  # for major bumps only — base must be the major branch:
+  # --base "feature/4.0.0"
+```
+
+`--assignee @me` is always mandatory. `--milestone <version>` is mandatory for release-relevant PRs and **must be omitted** for release-irrelevant ones (the docs-only / `.claude/` / root-meta classification from step 8.0). For **major** bumps, also pass `--base feature/<version>` (the major branch you validated in step 8e); for patch/minor or release-irrelevant PRs, omit `--base` and let `gh` use the default.
+
+If the branch is clearly still in progress (commit messages like "wip", "fixup", or the user mentioned it's not ready), pass `--draft` as well.
+
+### 10. Report
+
+Print the PR URL the gh command returned. That's it — no summary recap.
+
+## Edge cases
+
+| Situation                                                                                                               | Behavior                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Detached HEAD                                                                                                           | Abort. Ask the user to checkout a branch.                                                                                                             |
+| On `main`/`master`                                                                                                      | Abort. Tell user to create a feature branch.                                                                                                          |
+| Zero commits ahead of base                                                                                              | Abort. Nothing to PR.                                                                                                                                 |
+| PR already open for branch                                                                                              | Show URL, ask what they want to do. Don't duplicate.                                                                                                  |
+| Push rejected (non-fast-forward)                                                                                        | Surface error, ask before resolving. Never auto `--force`.                                                                                            |
+| Pre-commit hook fails                                                                                                   | Fix root cause, create new commit. Never `--no-verify`.                                                                                               |
+| Jira ticket inaccessible / MCP unavailable                                                                              | Include bare `[PROJ-123]` reference in body, don't block.                                                                                             |
+| Branch has Jira-looking string but it's not really a ticket (e.g. `RFC-2119`)                                           | Try fetching; if 404, fall back gracefully.                                                                                                           |
+| Multiple Jira IDs in branch                                                                                             | Use the first match; mention others in the body if relevant.                                                                                          |
+| `lerna.json` missing or version unparseable                                                                             | Abort _only if the PR is release-relevant_. If the diff is docs-only / `.claude/` / root-meta, no milestone is needed so `lerna.json` doesn't matter. |
+| Diff is entirely under `docs/`, `.claude/`, or root meta files (`AGENTS.md`, `CLAUDE.md`, `README.md`, tooling configs) | Skip the milestone (steps 8a–8e and `--milestone` in step 9). Tell the user "배포 영향이 없어 마일스톤 없이 생성합니다." before opening.              |
+| Mixed diff — some release-relevant files plus some docs/`.claude/` files                                                | Treat as release-relevant (the package files determine the bump). Optionally suggest splitting into two PRs if the docs/.claude portion is unrelated. |
+| Bump type ambiguous (mixed commit types, non-conventional messages)                                                     | Ask the user explicitly; don't guess.                                                                                                                 |
+| Target milestone already exists                                                                                         | Reuse it. Don't create a duplicate.                                                                                                                   |
+| Milestone create fails (permissions / race)                                                                             | Surface the error and stop — don't open the PR unmilestoned.                                                                                          |
+| Major bump but `feature/<version>` branch missing on remote                                                             | Stop. Warn user, confirm "정말 major 작업?", recommend creating the major branch from `main` and rebasing. Never auto-create the major branch.        |
+| Major bump but PR base is `main`/default                                                                                | Stop. Warn, confirm intent, recommend `git rebase origin/feature/<version>` (or fix commit messages if it's actually not major).                      |
+| Major bump confirmed and base is correct                                                                                | Pass `--base feature/<version>` to `gh pr create`.                                                                                                    |
+
+## After the PR is open: visual test failures
+
+Visual regression snapshots are taken in GitHub Actions — local environments produce different pixels (font rendering, anti-aliasing) so you can't update them from your machine. If CI's visual test job fails on the PR:
+
+1. Open the failing job's artifacts and confirm the rendering diff is intentional.
+2. If it is, run the snapshot-update workflow against the PR branch:
+
+   ```bash
+   gh workflow run visual-test-update.yml --ref <branch-name>
+   ```
+
+   This regenerates snapshots inside CI and commits them back to the branch. Pull the new commit before pushing more changes.
+
+3. If the diff is **not** intentional, don't update the snapshots — fix the underlying regression in the component/style.
+
+See [coding-style.md › Visual regression tests](../../references/coding-style.md#visual-regression-tests) for the longer explanation.
+
+## Why these defaults
+
+- **Self-assign**: review queues filter by assignee — unassigned PRs are invisible.
+- **Release milestone (when release-relevant)**: this repo's release/changelog tooling groups merged PRs by milestone. A release-relevant PR without one is silently excluded from the release notes, even if it lands on `main`. Conversely, attaching a milestone to a PR that ships nothing (docs-only, `.claude/` env changes, root meta) inflates the changelog with non-shipping entries — so those PRs intentionally _omit_ the milestone.
+- **Major bumps require `feature/<version>` base branch**: breaking changes that land on `main` immediately go out to every consumer on the next patch — there's no way to stage them. The `feature/<version>` branch is the staging area where breaking changes accumulate until the major release is intentional. Letting one major PR slip onto `main` corrupts the entire current major's release line.
+- **Confirm-before-commit**: working trees often hold WIP, debug logs, or local-only config the user doesn't want shipped.
+- **Conventional Commits**: this monorepo uses them for changelog generation and release automation. Matching the existing style keeps tooling working — and is also what the milestone bump-type decision keys off.
+- **Jira enrichment**: reviewers shouldn't have to context-switch to Jira to understand the "why". Inline summaries cut review time.
+- **No `--force`, no `--no-verify`, no `git add -A`**: each shortcut has a real way to lose work or leak secrets. The friction is the feature.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -60,7 +60,7 @@ If `git status --porcelain` is non-empty:
    - Read recent commits (`git log --oneline -10`) to match the repo's style — this codebase uses Conventional Commits (`feat(scope): ...`, `fix(scope): ...`, `chore: ...`).
    - Draft a commit message that focuses on **why**, not **what**. One subject line, optional body.
    - Stage files **by name** (never `-A` / `.`). Skip anything that looks like a secret (`.env*`, `credentials*`, `*.pem`).
-   - Commit with a heredoc to preserve formatting. **The trailing `Co-Authored-By: Claude ...` trailer is mandatory** — it's required by the top-level system instructions, and it's easy to forget when copying this template. Put it as the last line, separated by a blank line so git's trailer parser picks it up:
+   - Commit with a heredoc to preserve formatting. **The trailing `Co-Authored-By:` trailer is mandatory** — it's required by the top-level system instructions and is easy to forget when copying this template. Put it as the last line, separated by a blank line so git's trailer parser picks it up. **Use the model you actually are right now** — read your own model name/version from the runtime environment (the system prompt surfaces it) and substitute it into `<your-model-name>` below. Do not copy a hardcoded model from this example.
 
      ```bash
      git commit -m "$(cat <<'EOF'
@@ -68,12 +68,10 @@ If `git status --porcelain` is non-empty:
 
      Optional body explaining why.
 
-     Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+     Co-Authored-By: <your-model-name> <noreply@anthropic.com>
      EOF
      )"
      ```
-
-     Match the trailer line to whichever Claude model is actually authoring the commit (e.g. `Claude Sonnet 4.6`, `Claude Haiku 4.5`).
 
    - If a pre-commit hook fails, fix the underlying issue and create a **new** commit. Never `--amend` to dodge the failure (the failed commit didn't happen, so amend would rewrite the previous one).
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -336,7 +336,7 @@ Visual regression snapshots are taken in GitHub Actions — local environments p
 
 3. If the diff is **not** intentional, don't update the snapshots — fix the underlying regression in the component/style.
 
-See [coding-style.md › Visual regression tests](../../references/coding-style.md#visual-regression-tests) for the longer explanation.
+See [workflow.md › Visual regression tests](../../references/workflow.md#visual-regression-tests) for the longer explanation.
 
 ## Why these defaults
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -22,6 +22,7 @@ These are non-negotiable. Build the workflow around them.
 4. **Never push to `main`/`master`** — abort and ask the user to switch to a feature branch.
 5. **Never use `--no-verify`** to skip hooks. If a hook fails, surface the error and let the user decide.
 6. **Never use `git add -A` / `git add .`** — stage files by name. Wildcards routinely sweep up `.env`, credentials, and stray build artifacts.
+7. **Every commit you author must end with a `Co-Authored-By: Claude ...` trailer.** This is required by the top-level system instructions and is easy to forget when copying the heredoc template — surface it explicitly here. See step 3 for the exact format.
 
 ## Workflow
 
@@ -59,16 +60,20 @@ If `git status --porcelain` is non-empty:
    - Read recent commits (`git log --oneline -10`) to match the repo's style — this codebase uses Conventional Commits (`feat(scope): ...`, `fix(scope): ...`, `chore: ...`).
    - Draft a commit message that focuses on **why**, not **what**. One subject line, optional body.
    - Stage files **by name** (never `-A` / `.`). Skip anything that looks like a secret (`.env*`, `credentials*`, `*.pem`).
-   - Commit with a heredoc to preserve formatting:
+   - Commit with a heredoc to preserve formatting. **The trailing `Co-Authored-By: Claude ...` trailer is mandatory** — it's required by the top-level system instructions, and it's easy to forget when copying this template. Put it as the last line, separated by a blank line so git's trailer parser picks it up:
 
      ```bash
      git commit -m "$(cat <<'EOF'
      feat(scope): short subject
 
      Optional body explaining why.
+
+     Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
      EOF
      )"
      ```
+
+     Match the trailer line to whichever Claude model is actually authoring the commit (e.g. `Claude Sonnet 4.6`, `Claude Haiku 4.5`).
 
    - If a pre-commit hook fails, fix the underlying issue and create a **new** commit. Never `--amend` to dodge the failure (the failed commit didn't happen, so amend would rewrite the previous one).
 

--- a/.claude/skills/sync-icons/SKILL.md
+++ b/.claude/skills/sync-icons/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: sync-icons
+description: Sync icons from the Figma file into `wds-icon` and open a PR by dispatching the `figma-icon-sync-code-connect.yml` GitHub Actions workflow. The workflow pulls the latest icon set from Figma, generates Code Connect bindings, and opens a PR against the branch you dispatched from. Use this skill whenever the user says "아이콘 업데이트해줘", "아이콘 싱크해줘", "Figma에서 아이콘 가져와줘", "sync icons", "update icons from Figma", "code connect publish", or otherwise indicates they want the icon set refreshed from the Figma source of truth.
+---
+
+# sync-icons
+
+Triggers the `figma-icon-sync-code-connect.yml` workflow that does all the actual work — pulls icons from Figma, regenerates `wds-icon`, wires up Code Connect, and opens a PR. This skill just dispatches the workflow with the right inputs against the right branch.
+
+## When to trigger
+
+- "아이콘 업데이트해줘" / "아이콘 싱크해줘" / "Figma 아이콘 가져와줘"
+- "code connect publish 해줘" / "code connect 갱신"
+- "sync icons" / "update icons from figma"
+- User mentions new icons added to the Figma library and wants them in the codebase
+
+## What the workflow does (so you know what's about to happen)
+
+You don't run any of this yourself — it's all in the workflow. But knowing the steps helps you set expectations for the user:
+
+1. Pulls the icon set from the Figma file (uses `FIGMA_TOKEN` secret).
+2. Runs `scripts/figma-icon.mjs` to regenerate `packages/wds-icon`.
+3. Creates a branch named `feature/code-connect/<run_id>`, commits, pushes.
+4. Opens a PR with that branch as the **head** and the **branch you dispatched from** as the **base**.
+5. If `publish=true`, also publishes Code Connect mappings to Figma (so designers see the codebase ↔ Figma binding).
+
+The PR title is auto-set to `feat(wds,wds-icon): icon figma sync and new code connect publish`.
+
+## Workflow inputs
+
+| Input     | Type   | Default  | Meaning                                                              |
+| --------- | ------ | -------- | -------------------------------------------------------------------- |
+| `publish` | choice | `'true'` | Whether to push Code Connect mappings up to Figma after the PR opens |
+
+That's the only input. **If the user doesn't mention publishing, default to `true`** — that's the documented behavior. Only set `publish=false` if the user explicitly asks to skip the Code Connect publish step ("publish 빼고", "publish 하지마", "code connect는 다음에" etc).
+
+## Workflow
+
+### 1. Pick the dispatch branch (the future PR base)
+
+**Almost always `main`.** Routine icon syncs are run from `main` so the resulting PR targets `main` and ships in the next regular release. Default to `main` and only deviate when the user explicitly says otherwise.
+
+The exception is when icon work is bundled with other in-progress changes — e.g. dispatching from a major version branch like `feature/4.0.0` if breaking icon renames are part of the next major. This is rare; assume `main` unless told.
+
+Confirm with the user before dispatching: **"`main` 기준으로 아이콘 싱크 PR 만들면 될까요? (대부분 main에서 실행합니다. 다른 브랜치 필요하면 알려주세요)"**
+
+The branch must exist on the remote — verify with:
+
+```bash
+git ls-remote --exit-code --heads origin "<branch>" >/dev/null
+```
+
+If it doesn't exist, surface the error and stop.
+
+### 2. Confirm the `publish` input
+
+If the user explicitly opted out (`publish=false`), use that. Otherwise default to `publish=true` without re-asking — the user shouldn't have to confirm the default every time.
+
+If you're unsure (e.g. user said "먼저 코드 변화만 보고 싶어"), ask once: **"Figma에 Code Connect 매핑도 publish 할까요? (기본값: 예)"**
+
+### 3. Dispatch the workflow
+
+```bash
+gh workflow run figma-icon-sync-code-connect.yml \
+  --ref <dispatch-branch> \
+  -f publish=true
+```
+
+That's it. The workflow is responsible for the branch creation, commit, push, and PR. Don't try to do any of it yourself.
+
+### 4. Surface progress
+
+Print the latest run URL so the user can watch:
+
+```bash
+# Wait a couple seconds for the run to register, then:
+gh run list --workflow=figma-icon-sync-code-connect.yml --limit 1 \
+  --json databaseId,url,status,createdAt
+```
+
+Tell the user:
+
+- The workflow is running.
+- The PR will be opened **against `<dispatch-branch>`** when it finishes (~few minutes).
+- If `publish=true`, Code Connect will be pushed to Figma after the PR is created.
+- They can watch progress at the run URL.
+
+Don't poll for completion unless the user asks — the workflow takes minutes, and the user can refresh the run page themselves.
+
+## Release classification: icon adds are minor
+
+When the auto-generated PR shows up, it should be milestoned as a **minor** version bump — adding icons is a non-breaking feature add, so it falls under `feat` in Conventional Commits and bumps the minor version.
+
+The workflow titles the PR `feat(wds,wds-icon): icon figma sync and new code connect publish`, which `create-pr`'s bump-type detection will already classify as minor. But the workflow opens the PR via the `github-actions[bot]` and doesn't attach a milestone, so:
+
+- After the workflow finishes, attach the next minor milestone (e.g. current `3.5.0` → `3.6.0`) to the PR. The `create-pr` skill's milestone logic explains how to compute and ensure the milestone exists.
+- The only situation where it's _not_ minor: if the sync also removes or renames existing icons in a way that breaks consumers (i.e. the diff has icon deletions). That's a `feat!:` and bumps major — but it should also be on a major branch, not `main`. Surface the deletion to the user and confirm before touching the milestone.
+
+## Edge cases
+
+| Situation                                                 | Behavior                                                                                                                 |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| User on a non-`main` branch with uncommitted changes      | Doesn't matter — the workflow runs on the remote, not the local working tree. No need to commit/stash first.             |
+| User asks "main이 아니라 내 브랜치 기준으로"              | Use the user's current branch as `--ref`. Verify it's pushed to origin first.                                            |
+| User says "publish 하지 마" / "Figma에 안 올려도 돼"      | Pass `-f publish=false`. Mention that Code Connect bindings won't be reflected in Figma until a future publish.          |
+| Workflow run fails to register / `gh workflow run` errors | Surface the error and stop — common cause is the branch not being pushed to origin yet, or the user lacking permissions. |
+| Recent run already in progress                            | Mention it and ask if they want to wait or dispatch another. Multiple concurrent runs will produce duplicate PRs.        |
+
+## Why these defaults
+
+- **`publish=true` by default**: this is the documented default in the workflow itself — the whole point of running the sync is to keep Figma's Code Connect bindings in step with what the codebase advertises. Skipping publish is the unusual case (typically only when you want to inspect generated code first).
+- **Default to dispatching from `main`**: routine icon adds are non-breaking and ship in the next minor release on `main`. Dispatching elsewhere is the exception, not the norm.
+- **Icon adds are minor bumps**: adding icons is a `feat` in Conventional Commits → minor version bump. Only icon removals/renames promote it to `feat!:` / major, and those don't belong on `main` anyway.
+- **Don't hand-do any of the git work**: the workflow's branch / commit / PR sequence is deliberately atomic and uses a bot identity. Replicating it locally just creates noise and parallel branches.

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no -- commitlint --edit ${1}
+npx --no -- commitlint --edit ${1} && node scripts/commit-msg.mjs "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,6 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
-## Project Overview
-
-Montage (formerly WDS) is Wanted Lab's design system for web. It's a Lerna + Nx monorepo containing 9 packages, all published under `@wanteddev/*` to GitHub Package Registry.
-
 ## Common Commands
 
 ```bash
@@ -30,113 +26,12 @@ pnpm lint
 # Format code
 pnpm format
 
-# Dev mode (all packages)
-pnpm dev
-
 # Run docs site locally
 pnpm -F docs dev
 ```
 
-## Package Dependency Graph
+## References
 
-```text
-wds-theme (design tokens, no React dependency)
-    ↓
-wds-engine (Box, ThemeProvider, polymorphic types — depends on wds-theme + Emotion)
-    ↓
-wds, wds-icon, wds-lottie (UI components — depend on wds-engine)
-    ↓
-wds-nextjs (Next.js integration — depends on wds-engine)
-```
-
-Tooling packages (`wds-codemod`, `wds-mcp`, `eslint-plugin-wds`) are standalone.
-
-## Architecture
-
-### Polymorphic Component Pattern
-
-Components use a two-tier type system for the `as` prop:
-
-- **Public API**: `PolymorphicProps<P, C>` / `PolymorphicComponent<P, E>` — includes `sx` prop
-- **Internal API**: `PolymorphicPropsInternal<P, C>` / `PolymorphicComponentInternal<P, E>` — excludes `sx` (handled separately via `Box`)
-
-Component implementation pattern:
-
-```tsx
-const MyComponent = forwardRef(
-  <T extends ElementType = 'div'>(
-    { as, ...props }: PolymorphicPropsInternal<MyComponentProps, T>,
-    ref: ForwardedRef<T>,
-  ) => {
-    return (
-      <Box
-        as={(as || 'div') as T}
-        ref={ref}
-        sx={[myStyle, props.sx]}
-        {...props}
-      />
-    );
-  },
-) as PolymorphicComponentInternal<MyComponentProps, 'div'>;
-```
-
-**Critical TypeScript caveat**: When using `PolymorphicPropsInternal`, event handlers (`onClick`, `onKeyDown`, etc.) accessed via `...props` spread may cause TypeScript errors because `Omit` types don't resolve properly. Fix by destructuring event handlers explicitly: `{ onClick, onKeyDown, ...rest }`.
-
-### Component File Structure
-
-Each component follows this layout:
-
-```text
-component-name/
-├── index.tsx       # Implementation (uses Box from wds-engine)
-├── types.ts        # Props defined with WithSxProps<{...}> + ResponsiveProps
-├── style.ts        # Style functions using theme tokens
-├── constants.ts    # Optional constants
-└── index.test.tsx  # Unit tests
-```
-
-### Theme System
-
-Three-layer architecture:
-
-1. **wds-theme**: Raw atomic tokens + semantic tokens (light/dark) + design tokens (spacing, opacity, breakpoint, zIndex)
-2. **wds-engine**: Emotion-based runtime (ThemeProvider, Box with `sx` prop, `useSxProps` hook)
-3. **wds**: Components compose styles using theme tokens via style functions
-
-### Responsive Props
-
-Components support per-breakpoint prop overrides:
-
-```tsx
-type ButtonProps = Merge<
-  ButtonDefaultProps,
-  ResponsiveProps<Pick<ButtonDefaultProps, 'fullWidth' | 'size'>>
->;
-// Usage: <Button xs={{ size: 'small' }} md={{ size: 'large' }} />
-```
-
-### Build System
-
-- **tsdown** bundles each package to CJS + ESM with DTS generation
-- Post-build hook injects `'use client'` directive for RSC-compatible files
-- External: `react`, `react-dom`, `next`
-
-## Code Conventions
-
-- **Conventional Commits**: `<type>(<scope>): <description>` — enforced by commitlint
-- **Arrow functions only** for React components (`react/function-component-definition`)
-- **Type imports**: Use `import type { ... }` consistently (`@typescript-eslint/consistent-type-imports`)
-- **Array types**: Use `Array<T>` generic syntax, not `T[]` (`@typescript-eslint/array-type`)
-- **Import ordering**: Groups separated by newlines — builtin, external, internal, parent, sibling, index, object, type
-- **Naming**: PascalCase for interfaces/types, camelCase for variables/functions
-
-## Testing
-
-- Unit tests use **Vitest** with **@testing-library/react** and **vitest-axe** for accessibility
-- Test globals are enabled (`describe`, `it`, `expect`, `vi` available without imports)
-- Setup mocks: `matchMedia`, `ResizeObserver`, `HTMLCanvasElement`
-- Bundle size limits enforced via **size-limit** (e.g., wds: 5KB gzipped)
-
-## CI Checks on PRs
-
-Size-limit analysis, unit tests, visual regression tests, CommonJS compatibility, and tree-shaking validation all run on pull requests.
+- [Architecture](.claude/references/architecture.md) — Project overview, package dependency graph, where to make changes (and where not to), component type system, theme system, responsive props, build system
+- [Coding Style](.claude/references/coding-style.md) — Code conventions, component folder structure, types/index/style patterns, contexts, unit testing
+- [Workflow](.claude/references/workflow.md) — Branch naming, base branch rules, commit conventions, PR rules, visual regression workflow, CI checks

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "build": "NX_REJECT_UNKNOWN_LOCAL_CACHE=0 lerna run build",
     "build:api": "pnpm -F @wanteddev/api-generator build",
-    "dev": "lerna run dev --no-cache --continue",
     "lint": "NX_REJECT_UNKNOWN_LOCAL_CACHE=0 lerna run lint",
     "clean": "pnpm store prune && rm -rf node_modules",
     "watch": "NX_REJECT_UNKNOWN_LOCAL_CACHE=0 lerna watch -- echo \\$LERNA_PACKAGE_NAME \\$LERNA_FILE_CHANGES",

--- a/scripts/commit-msg.mjs
+++ b/scripts/commit-msg.mjs
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const exceptionBranches = ['main'];
+
+const requiredIssueID =
+  /^pi-[0-9]|fe-[0-9]|^dp-[0-9]|^def-[0-9]|^live-[0-9]|^wrp-[0-9]/i;
+const hasIssueID = (str) => requiredIssueID.test(str);
+
+const exec = (cmd) => execSync(cmd, { encoding: 'utf-8' });
+
+const getSubject = (preSubject, issueNo) => {
+  if (hasIssueID(preSubject)) {
+    return preSubject;
+  }
+
+  return `${issueNo.toUpperCase()} ${preSubject}`;
+};
+
+const getDescription = (preDescription, issueNo) => {
+  const jiraIssueUrl = issueNo
+    ? `- https://wantedlab.atlassian.net/browse/${issueNo} \n`
+    : '';
+  const identity = exec('git var GIT_AUTHOR_IDENT');
+  const author = identity.split(' ')[0];
+
+  return `- ${author}\n${jiraIssueUrl}${preDescription}`.replace(/,/gi, '');
+};
+
+const getJiraIssueNumber = (branch) =>
+  branch.split('/').filter((word) => hasIssueID(word));
+
+const checkStartWithComment = (line) => (line.startsWith('#') ? '' : line);
+
+const parseCommitMsg = (commitMsgData) => {
+  const [subject, secondLine, ...descriptions] = commitMsgData.split('\n');
+  const descriptionsNewLine = descriptions
+    .map((description) => `${description}\n`)
+    .join('');
+  const parsedSubject = checkStartWithComment((subject ?? '').trim());
+
+  return !secondLine
+    ? [parsedSubject, descriptionsNewLine]
+    : [parsedSubject, `${secondLine}${descriptionsNewLine}`];
+};
+
+const createCommitMsg = () => {
+  const currentBranch = exec('git rev-parse --abbrev-ref HEAD').trim();
+  const commitMsgArg = process.argv[2];
+  const COMMIT_MSG_FILE_PATH = path.isAbsolute(commitMsgArg)
+    ? commitMsgArg
+    : `./${commitMsgArg}`; // .git/EDIT_MSG
+  const isFeatureBranch = currentBranch.includes('feature');
+  const jiraIssueNo = (getJiraIssueNumber(currentBranch)[0] ?? '').replace(
+    /\n/i,
+    '',
+  );
+  const editedCommitMsgData = fs.readFileSync(COMMIT_MSG_FILE_PATH, 'utf-8');
+
+  if (exceptionBranches.includes(currentBranch)) {
+    return;
+  }
+
+  if (isFeatureBranch && !jiraIssueNo) {
+    console.error(
+      `현재 브랜치: "${currentBranch}"에 지라 이슈번호가 포함되지 않았습니다.`,
+    );
+  }
+
+  const [preSubject = '', preDescription = ''] =
+    parseCommitMsg(editedCommitMsgData);
+  const subject = getSubject(preSubject, jiraIssueNo);
+  const description = getDescription(preDescription, jiraIssueNo);
+
+  if (preSubject && jiraIssueNo && isFeatureBranch && !hasIssueID(preSubject)) {
+    console.log(
+      '현재 커밋 Commit Title 에 이슈번호가 포함되지 않아 현재 브랜치의 이슈 번호로 Commit Title을 생성합니다.',
+    );
+    console.log(`as-is : ${preSubject}`);
+    console.log(`to-be : ${subject}`);
+  }
+
+  const replacedCommitMsg = `${subject}\n\n${description}`;
+  const commitMsg = preSubject ? replacedCommitMsg : '';
+
+  fs.writeFileSync(COMMIT_MSG_FILE_PATH, commitMsg, 'utf-8');
+};
+
+createCommitMsg();

--- a/scripts/commit-msg.mjs
+++ b/scripts/commit-msg.mjs
@@ -20,12 +20,10 @@ const getSubject = (preSubject, issueNo) => {
 
 const getDescription = (preDescription, issueNo) => {
   const jiraIssueUrl = issueNo
-    ? `- https://wantedlab.atlassian.net/browse/${issueNo} \n`
+    ? `https://wantedlab.atlassian.net/browse/${issueNo} \n`
     : '';
-  const identity = exec('git var GIT_AUTHOR_IDENT');
-  const author = identity.split(' ')[0];
 
-  return `- ${author}\n${jiraIssueUrl}${preDescription}`.replace(/,/gi, '');
+  return `${jiraIssueUrl}${preDescription}`.replace(/,/gi, '');
 };
 
 const getJiraIssueNumber = (branch) =>


### PR DESCRIPTION
## Summary

- AGENTS.md를 슬림화하고 상세 내용(architecture / coding-style / workflow)을 `.claude/references/*.md` 로 분리. 최상위 가이드는 인덱스로만 유지.
- Claude Code 환경 파일 추가: `.claude/settings.json`(format-on-write 훅 + 허용 플러그인 / 시크릿 파일 read 차단), `.claude/scripts/format-on-write.sh`, 그리고 로컬 스킬(`create-pr`, `sync-icons`) / 플러그인 설정.
- 커밋 메시지 훅 보강: `.husky/commit-msg` 가 commitlint 이후 `scripts/commit-msg.mjs` 를 실행해 `feature/*` 브랜치의 Jira 이슈 ID 를 subject prefix · body 링크로 자동 주입.
- 루트 `package.json` 에서 사용하지 않는 `dev` 스크립트 제거.

## Notes

- 배포 영향이 없는 변경(`.claude/`, root meta, husky/scripts, 루트 `package.json` 의 dev 스크립트)이라 release milestone 은 부착하지 않았습니다.
- `scripts/commit-msg.mjs` 의 `getSubject` 가 `jiraIssueNo` 가 빈 문자열일 때도 `" " + preSubject` 를 반환해서, Jira ID 없는 브랜치(`chore/*` 등)의 커밋 subject 앞에 공백 1칸이 붙는 이슈가 있습니다. squash merge 시 PR title 로 덮어써져 release 에는 영향 없지만, 후속 작업으로 `if (!issueNo || hasIssueID(preSubject)) return preSubject;` 형태로 가드하는 게 좋아 보입니다.

## Test plan

- [ ] `feature/<user>/PI-12345` 형태 브랜치에서 커밋해 subject 가 `PI-12345 ...` 로, body 에 Jira 링크가 들어가는지 확인
- [ ] `chore/*` 등 Jira ID 없는 브랜치에서 커밋이 정상 통과하는지 확인
- [ ] Claude Code 에서 파일 Edit/Write 시 `.claude/scripts/format-on-write.sh` 가 eslint --fix / prettier --write 를 돌리는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 디자인 시스템 아키텍처 참조 가이드 추가
  * React/TypeScript 코딩 스타일 규칙 문서화
  * 브랜치/커밋/PR 워크플로우 표준 문서화 및 시각검증 절차 명시
  * 에이전트 안내 문서 정리 및 참조 분리

* **기타**
  * 파일 포맷터 자동 실행 훅 및 포맷 스크립트 추가
  * 커밋 메시지 보강 자동화 스크립트 도입 및 커밋 훅 확장
  * PR 생성/아이콘 동기화 등 작업 흐름 관련 스킬 문서 추가
  * 루트 개발 스크립트(dev) 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->