### PR TITLE
feat: add wds-dummy/wds-brand packages and wire them into MCP

### DIFF
--- a/.claude-plugin/montage-web-guide/README.ko.md
+++ b/.claude-plugin/montage-web-guide/README.ko.md
@@ -20,18 +20,20 @@ Wanted Design System(WDS) MCP와 skill이 포함된 플러그인입니다.
 
 `@wanteddev/wds-mcp` MCP 서버를 통해 다음 도구를 사용할 수 있습니다:
 
-| 도구                     | 설명                      |
-| ------------------------ | ------------------------- |
-| `wds_coding_guidelines`  | WDS 코딩 가이드라인 조회  |
-| `list_components`        | 컴포넌트 목록 조회        |
-| `get_component`          | 컴포넌트 상세 스펙 조회   |
-| `list_tokens`            | 디자인 토큰 목록 조회     |
-| `get_color_usage`        | 색상 토큰 사용법 조회     |
-| `list_icons`             | 아이콘 목록 조회          |
-| `list_utility_functions` | 유틸리티 함수 목록 조회   |
-| `get_utility_function`   | 유틸리티 함수 상세 조회   |
-| `getting_started`        | WDS 초기 셋팅 가이드 조회 |
-| `health_check`           | MCP 서버 상태 확인        |
+| 도구                     | 설명                                                                          |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `wds_coding_guidelines`  | WDS 코딩 가이드라인 조회                                                      |
+| `list_components`        | 컴포넌트 목록 조회                                                            |
+| `get_component`          | 컴포넌트 상세 스펙 조회                                                       |
+| `list_tokens`            | 디자인 토큰 목록 조회                                                         |
+| `get_color_usage`        | 색상 토큰 사용법 조회                                                         |
+| `list_icons`             | 아이콘 목록 조회                                                              |
+| `list_utility_functions` | 유틸리티 함수 목록 조회                                                       |
+| `get_utility_function`   | 유틸리티 함수 상세 조회                                                       |
+| `list_dummy_components`  | 데모/프리뷰용 레이아웃 스캐폴드(`NavBar`, `Footer`, `BottomTabBar`) 목록 조회 |
+| `list_brand_assets`      | Wanted 브랜드 마크 목록 조회 (`LogoWanted` 워드마크, `IconSymbol` 심볼 전용)  |
+| `getting_started`        | WDS 초기 셋팅 가이드 조회                                                     |
+| `health_check`           | MCP 서버 상태 확인                                                            |
 
 ### Skill: montage-react
 
@@ -43,6 +45,8 @@ React 프로젝트에서 컴포넌트/UI 작업 시 자동으로 적용되는 sk
 - UI 컴포넌트를 생성하거나 수정할 때
 - 스타일링 작업을 할 때
 - 아이콘을 사용할 때
+- 데모/프리뷰 페이지에 placeholder GNB / Footer / 하단 탭바가 필요할 때
+- Wanted 브랜드 로고(워드마크 또는 심볼)가 필요할 때
 
 **워크플로우:**
 

--- a/.claude-plugin/montage-web-guide/README.md
+++ b/.claude-plugin/montage-web-guide/README.md
@@ -20,18 +20,20 @@ A plugin that includes the Wanted Design System (WDS) MCP server and skills.
 
 The following tools are available through the `@wanteddev/wds-mcp` MCP server:
 
-| Tool                     | Description                          |
-| ------------------------ | ------------------------------------ |
-| `wds_coding_guidelines`  | View WDS coding guidelines           |
-| `list_components`        | List available components            |
-| `get_component`          | View detailed component specs        |
-| `list_tokens`            | List design tokens                   |
-| `get_color_usage`        | View color token usage guide         |
-| `list_icons`             | List available icons                 |
-| `list_utility_functions` | List utility functions               |
-| `get_utility_function`   | View detailed utility function specs |
-| `getting_started`        | View WDS initial setup guide         |
-| `health_check`           | Check MCP server health status       |
+| Tool                     | Description                                                                               |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| `wds_coding_guidelines`  | View WDS coding guidelines                                                                |
+| `list_components`        | List available components                                                                 |
+| `get_component`          | View detailed component specs                                                             |
+| `list_tokens`            | List design tokens                                                                        |
+| `get_color_usage`        | View color token usage guide                                                              |
+| `list_icons`             | List available icons                                                                      |
+| `list_utility_functions` | List utility functions                                                                    |
+| `get_utility_function`   | View detailed utility function specs                                                      |
+| `list_dummy_components`  | List dummy layout scaffolds (`NavBar`, `Footer`, `BottomTabBar`) for demo / preview pages |
+| `list_brand_assets`      | List Wanted brand marks (`LogoWanted` wordmark, `IconSymbol` symbol-only)                 |
+| `getting_started`        | View WDS initial setup guide                                                              |
+| `health_check`           | Check MCP server health status                                                            |
 
 ### Skill: montage-react
 
@@ -43,6 +45,8 @@ A skill that is automatically applied when working on components/UI in React pro
 - When creating or modifying UI components
 - When working on styling
 - When using icons
+- When a placeholder GNB / Footer / bottom tab bar is needed for a demo or preview page
+- When the Wanted brand logo (wordmark or symbol) is needed
 
 **Workflow:**
 

--- a/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
+++ b/.claude-plugin/montage-web-guide/skills/montage-react/SKILL.md
@@ -11,11 +11,13 @@ Skill that is automatically applied when developing components based on Wanted D
 
 Apply this skill when any of the following conditions are met:
 
-- Working in a project that uses Montage packages such as `@wanteddev/wds`, `@wanteddev/wds-icon`
+- Working in a project that uses Montage packages such as `@wanteddev/wds`, `@wanteddev/wds-icon`, `@wanteddev/wds-dummy`, `@wanteddev/wds-brand`
 - Creating, modifying, or looking up UI components
 - Implementing pages or screens
 - Working on styling (sx prop, theme tokens, colors, typography)
 - Finding or using icons
+- Need a placeholder GNB / Footer / bottom tab bar for a demo or preview page
+- Need to render the Wanted brand logo
 - Implementing Figma designs as code
 - Asking questions about Montage / design system
 
@@ -51,6 +53,8 @@ When setting up React.js or Next.js from scratch, use:
 - `mcp__montage-mcp-server__list_tokens` — when custom styling is required
 - `mcp__montage-mcp-server__get_color_usage` — when color application is needed
 - `mcp__montage-mcp-server__list_icons` — when icons are needed
+- `mcp__montage-mcp-server__list_dummy_components` — when a placeholder GNB / Footer / bottom tab bar is needed for a demo or preview
+- `mcp__montage-mcp-server__list_brand_assets` — when the Wanted brand logo (or other brand mark) is needed
 
 ### 2. Component Usage Principles
 
@@ -229,6 +233,60 @@ Use Montage design tokens instead of hardcoded values. Look up available tokens 
 
 - Do not use spacing tokens. Use px values directly.
 
+### 8. Dummy Layout Components (`@wanteddev/wds-dummy`)
+
+The `@wanteddev/wds-dummy` package provides presentational-only reference scaffolds (`NavBar`, `Footer`, `BottomTabBar`) that mirror the wanted.co.kr layout.
+
+- **Use for**: demo pages, sandboxes, storybook entries, visual previews — anywhere a realistic-looking GNB / Footer / mobile tab bar is needed without wiring real behavior.
+- **Do NOT use as-is in production.** They take no behavior props (no `onClick`, no routing, no state). For real product code, copy the structure and rebuild it against your own data, links, and handlers using primitives from `@wanteddev/wds`.
+- All three are `forwardRef` components and accept a standard `sx` prop. `BottomTabBar` is intended for viewports below the `sm` breakpoint — wrap it accordingly if you also render `NavBar` on the same page.
+- Look up the full list and usage via `mcp__montage-mcp-server__list_dummy_components`. To see the exact JSX (e.g. to copy and adapt), read the source from `packages/wds-dummy/src/components/<component>/index.tsx`.
+
+```tsx
+import { NavBar, Footer, BottomTabBar } from '@wanteddev/wds-dummy';
+
+<>
+  <NavBar />
+  <main>{/* page content */}</main>
+  <Footer />
+  <BottomTabBar />
+</>;
+```
+
+### 9. Brand Assets
+
+Official Wanted brand marks. **Use as-is** — do not recolor, restyle, redraw, or crop.
+
+#### 9.1 Full wordmark — `LogoWanted` (`@wanteddev/wds-brand`)
+
+Use when you need the **"[symbol] wanted" wordmark** (symbol + text together) — e.g. GNB, footer, splash, marketing surfaces.
+
+- Props: `width` (default `112`), `height` (default `32`), plus standard `sx` and any `<svg>` attributes. Forwards ref to `SVGSVGElement`.
+- Pass `aria-label` (e.g. `"Wanted Logo"`) when the logo stands alone in an interactive or landmark element.
+- Keep the default `112:32` (≈ 3.5:1) aspect ratio when resizing.
+
+```tsx
+import { LogoWanted } from '@wanteddev/wds-brand';
+
+<LogoWanted aria-label="Wanted Logo" />
+<LogoWanted width={168} height={48} aria-label="Wanted Logo" />;
+```
+
+#### 9.2 Symbol only — `IconSymbol` (`@wanteddev/wds-icon`)
+
+Use when you need **just the Wanted symbol mark** (no wordmark) — e.g. favicons, app icons, compact headers, loading indicators, badges. Renders as a 1:1 square.
+
+- Sized via `fontSize` (defaults to `1em`). Built-in `<title>` provides accessible name "원티드 심벌".
+- Do **not** crop or extract the symbol portion of `LogoWanted` to fake a symbol-only mark — always use `IconSymbol`.
+
+```tsx
+import { IconSymbol } from '@wanteddev/wds-icon';
+
+<IconSymbol sx={{ fontSize: '32px' }} />;
+```
+
+Look up the full list of brand assets via `mcp__montage-mcp-server__list_brand_assets`. Prefer these over importing or recreating any other Wanted logo SVG.
+
 ## Checklist
 
 Verify the following after completing a component/page:
@@ -240,3 +298,6 @@ Verify the following after completing a component/page:
 - [ ] Used FlexBox/Grid/containerStyle appropriately for layout?
 - [ ] Used Montage icons? (when applicable)
 - [ ] Used appropriate responsive method when needed?
+- [ ] For demo/preview pages, used `@wanteddev/wds-dummy` scaffolds instead of hand-rolling a fake GNB/Footer/tab bar?
+- [ ] For the Wanted wordmark, used `LogoWanted` from `@wanteddev/wds-brand` (not a custom SVG)?
+- [ ] For the symbol-only mark, used `IconSymbol` from `@wanteddev/wds-icon` (not a cropped `LogoWanted`)?

--- a/packages/wds-brand/.npmignore
+++ b/packages/wds-brand/.npmignore
@@ -1,0 +1,5 @@
+src/
+tsdown.config.ts
+scripts/
+tsconfig.json
+tsconfig.node.json

--- a/packages/wds-brand/package.json
+++ b/packages/wds-brand/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@wanteddev/wds-brand",
+  "version": "3.5.0",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "types": "./dist/index.d.ts",
+      "module": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "repository": {
+    "url": "https://github.com/wanteddev/montage-web",
+    "type": "git",
+    "directory": "packages/wds-brand"
+  },
+  "scripts": {
+    "build": "tsc --noEmit && tsdown",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "watch": "tsup --watch"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "react": "^19.2.4",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@wanteddev/wds-engine": "workspace:*"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/wds-brand/src/components/index.ts
+++ b/packages/wds-brand/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './logo-wanted';

--- a/packages/wds-brand/src/components/logo-wanted/index.tsx
+++ b/packages/wds-brand/src/components/logo-wanted/index.tsx
@@ -1,0 +1,451 @@
+import { Box } from '@wanteddev/wds-engine';
+import { forwardRef, useId } from 'react';
+
+import { LOGO_SYMBOL_GRADIENT } from '../../constants/gradient';
+
+import type { DefaultComponentPropsInternal } from '@wanteddev/wds-engine';
+import type { LogoWantedProps } from './types';
+
+/**
+ * @description Wanted brand logo rendered as the "[x] wanted" wordmark
+ */
+const LogoWanted = forwardRef<
+  SVGSVGElement,
+  DefaultComponentPropsInternal<LogoWantedProps, 'svg'>
+>(({ width = 112, height = 32, ...props }, ref) => {
+  const idSuffix = useId();
+
+  return (
+    <Box
+      as="svg"
+      viewBox="0 0 4744 1356"
+      ref={ref}
+      {...props}
+      sx={[{ width, height }, props.sx]}
+    >
+      <mask
+        id={`WantedLogoSymbolMask_${idSuffix}`}
+        style={{ maskType: 'alpha' }}
+        maskUnits="userSpaceOnUse"
+        x="38"
+        y="278"
+        width="1272"
+        height="869"
+      >
+        <path
+          d="M480 1147C515 1147 546 1119 546 1075V735H451V994C451 1002 444 1004 439 999L185 748C179 741 182 735 191 735H819V640H111C66 640 38 671 38 707C38 724 45 742 62 759L427 1124C443 1141 462 1147 480 1147ZM1064 1131C1199 1131 1310 1020 1310 885C1310 750 1199 640 1064 640H914V735H1064C1145 735 1215 801 1215 885C1215 969 1146 1036 1064 1036C982 1036 914 967 914 885V360C914 313 878 278 832 278H534C486 278 451 314 451 361V640H546V384C546 378 550 373 556 373H808C814 373 819 378 819 384V885C819 1020 929 1131 1064 1131Z"
+          fill="#D9D9D9"
+        />
+      </mask>
+      <g mask={`url(#WantedLogoSymbolMask_${idSuffix})`}>
+        <rect x="117" y="630" width="330" height="116" fill="#216BFF" />
+        <path
+          d="M556 1075C556 1098.26 547.94 1119.37 533.3 1134.46C519.2 1148.99 500.27 1157 480 1157C456.71 1157 435.91 1148 419.82 1130.96L54.9301 766.07C37.3101 748.45 28.0001 728.03 28.0001 707C28.0001 685.97 36.0501 667 50.6601 652.82C65.8301 638.1 87.2601 630 111 630H196.19V745L441 986.92H556V1075Z"
+          fill={`url(#WantedLogoGradient0Linear_${idSuffix})`}
+        />
+        <path
+          d="M441 996.5V361C441 307.98 480.98 268 534 268H556.18L556 1006.92L441 996.5Z"
+          fill={`url(#WantedLogoGradient1Linear_${idSuffix})`}
+        />
+        <mask
+          id={`mask1_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="441"
+          y="268"
+          width="110"
+          height="110"
+        >
+          <path d="M441 378H551V268H534C480.98 268 441 307.98 441 361V378Z" />
+        </mask>
+        <g mask={`url(#mask1_${idSuffix})`}>
+          <rect
+            x="441"
+            y="268"
+            width="220"
+            height="220"
+            fill={`url(#WantedLogoGradientFallback1_${idSuffix})`}
+          />
+          <foreignObject
+            x="441"
+            y="268"
+            width="220"
+            height="220"
+            style={LOGO_SYMBOL_GRADIENT.foreignObjectStyle1}
+          />
+        </g>
+        <mask
+          id={`mask2_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="28"
+          y="630"
+          width="158"
+          height="189"
+        >
+          <path d="M185.52 739.98L107.18 818.32L54.93 766.07C37.31 748.45 28 728.03 28 707C28 685.97 36.05 667 50.66 652.82C65.83 638.1 87.26 630 111 630H185.52V739.98Z" />
+        </mask>
+        <g mask={`url(#mask2_${idSuffix})`}>
+          <rect
+            x="28"
+            y="582.5"
+            width="315"
+            height="315"
+            fill={`url(#WantedLogoGradientFallback2_${idSuffix})`}
+          />
+          <foreignObject
+            x="28"
+            y="582.5"
+            width="315"
+            height="315"
+            style={LOGO_SYMBOL_GRADIENT.foreignObjectStyle2}
+          />
+        </g>
+        <mask
+          id={`mask3_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="367"
+          y="999"
+          width="190"
+          height="158"
+        >
+          <path d="M445.5 1000V999.86L556 1033.48V1074.99C556 1098.25 547.94 1119.36 533.3 1134.45C519.2 1148.98 500.27 1156.99 480 1156.99C456.71 1156.99 435.91 1147.99 419.82 1130.95L367.18 1078.32L445.5 1000Z" />
+        </mask>
+        <g mask={`url(#mask3_${idSuffix})`}>
+          <rect
+            x="288.5"
+            y="843"
+            width="314"
+            height="314"
+            fill={`url(#WantedLogoGradientFallback3_${idSuffix})`}
+          />
+          <foreignObject
+            x="288.5"
+            y="843"
+            width="314"
+            height="314"
+            style={LOGO_SYMBOL_GRADIENT.foreignObjectStyle3}
+          />
+        </g>
+        <path
+          d="M441 998.5L556 1033.5V950.34H441V998.5Z"
+          fill={`url(#WantedLogoGradient5Linear_${idSuffix})`}
+        />
+        <path
+          d="M556 1058.5L441 998.5L441 961L556 1001L556 1058.5Z"
+          fill={`url(#WantedLogoGradient6Linear_${idSuffix})`}
+        />
+        <path
+          d="M556 725H441V830.5H556V725Z"
+          fill={`url(#WantedLogoGradient7Linear_${idSuffix})`}
+        />
+        <mask
+          id={`mask4_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="809"
+          y="630"
+          width="511"
+          height="511"
+        >
+          <path d="M965.35 984.2C938.692 957.292 924.003 922.066 924 885V871H809V885C809 953.02 835.55 1017.18 883.78 1065.68C932.09 1114.25 996.03 1141 1064 1141C1131.97 1141 1196.14 1114.26 1244.7 1065.7C1293.26 1017.14 1320 952.92 1320 885C1320 817.08 1293.25 753.08 1244.68 704.78C1196.18 656.56 1132.01 630 1064 630H900V744.99H1064C1100.95 744.99 1136.07 759.43 1162.89 785.64C1190.04 812.19 1205 847.47 1205 884.99C1205 961.42 1140.43 1025.99 1064 1025.99C1027.09 1025.99 992.05 1011.15 965.35 984.2Z" />
+        </mask>
+        <g mask={`url(#mask4_${idSuffix})`}>
+          <rect
+            x="809"
+            y="630"
+            width="511"
+            height="511"
+            fill={`url(#WantedLogoGradientFallback4_${idSuffix})`}
+          />
+          <foreignObject
+            x="809"
+            y="630"
+            width="511"
+            height="511"
+            style={LOGO_SYMBOL_GRADIENT.foreignObjectStyle4}
+          />
+        </g>
+        <rect x="809" y="739" width="115" height="132" fill="#FF8EBD" />
+        <mask
+          id={`mask5_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="28"
+          y="630"
+          width="1292"
+          height="512"
+        >
+          <path d="M924 884.99C924 922.06 938.69 957.29 965.35 984.2C992.05 1011.15 1027.09 1025.99 1064 1025.99C1140.43 1025.99 1205 961.42 1205 884.99C1205 847.47 1190.04 812.19 1162.89 785.64C1136.07 759.43 1100.95 744.99 1064 744.99H556V734.99H441V744.99H196.19L204.82 753.52L28.05 704.22C28.73 684.53 36.7 666.36 50.66 652.82C65.83 638.1 87.26 630 111 630H441V640H556V630H1064C1132.01 630 1196.18 656.56 1244.68 704.78C1293.25 753.08 1320 817.08 1320 885C1320 952.92 1293.26 1017.14 1244.7 1065.7C1196.14 1114.26 1131.97 1141 1064 1141C996.03 1141 932.09 1114.25 883.78 1065.68C835.55 1017.18 809 953.02 809 885H924V884.99Z" />
+        </mask>
+        <g mask={`url(#mask5_${idSuffix})`}>
+          <path
+            d="M1064 630H176.19L186 745H1064V630Z"
+            fill={`url(#WantedLogoGradient9Linear_${idSuffix})`}
+          />
+        </g>
+        <path
+          d="M1011.5 745V630H904V745H1011.5Z"
+          fill={`url(#WantedLogoGradient10Linear_${idSuffix})`}
+        />
+        <mask
+          id={`mask6_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="550"
+          y="268"
+          width="374"
+          height="617"
+        >
+          <path d="M809 885V745H819V630H809V384C809 383.52 808.48 383 808 383H550V268H832C857.02 268 880.2 277.33 897.29 294.27C914.51 311.35 924 334.69 924 360V630H914V745H924V885H809Z" />
+        </mask>
+        <g mask={`url(#mask6_${idSuffix})`}>
+          <path
+            d="M809 268V885H924V360C924 334.69 914.51 311.35 897.29 294.27C880.2 277.33 857.01 268 832 268H809Z"
+            fill={`url(#WantedLogoGradient11Linear_${idSuffix})`}
+          />
+        </g>
+        <path
+          d="M815 268H550V384H815V268Z"
+          fill={`url(#WantedLogoGradient12Linear_${idSuffix})`}
+        />
+        <mask
+          id={`mask7_${idSuffix}`}
+          style={{ maskType: 'alpha' }}
+          maskUnits="userSpaceOnUse"
+          x="812"
+          y="268"
+          width="112"
+          height="111"
+        >
+          <path
+            d="M832 268H812.5V378.5H924V360C924 334.69 914.51 311.35 897.29 294.27C880.2 277.33 857.01 268 832 268Z"
+            fill={`url(#WantedLogoGradient13Linear_${idSuffix})`}
+          />
+        </mask>
+        <g mask={`url(#mask7_${idSuffix})`}>
+          <rect
+            x="691"
+            y="257"
+            width="243"
+            height="243"
+            fill={`url(#WantedLogoGradientFallback5_${idSuffix})`}
+          />
+          <foreignObject
+            x="691"
+            y="257"
+            width="243"
+            height="243"
+            style={LOGO_SYMBOL_GRADIENT.foreignObjectStyle5}
+          />
+        </g>
+      </g>
+      <Box
+        as="path"
+        sx={(theme) => ({ fill: theme.semantic.label.normal })}
+        d="M4424 1008C4487 1008 4540 981 4569 939V998H4673V278H4569V552C4540 513 4486 488 4423 488C4278 488 4167 605 4167 748C4167 891 4279 1008 4424 1008ZM4424 908C4339 908 4269 835 4269 748C4269 661 4339 588 4424 588C4509 588 4579 661 4579 748C4579 835 4509 908 4424 908ZM3729 706C3733 642 3796 581 3874 581C3952 581 4011 642 4015 706H3729ZM3883 1008C3984 1008 4072 950 4108 870L4025 842C4001 885 3945 915 3884 915C3796 915 3733 861 3729 788H4114C4134 620 4033 488 3883 488C3733 488 3627 595 3627 748C3627 901 3732 1008 3883 1008ZM3510 1007C3541 1007 3572 1000 3592 989V898C3568 910 3547 915 3533 915C3493 915 3473 891 3473 842V580H3592V498H3473V398H3369V498H3289V580H3369V846C3369 947 3421 1007 3510 1007ZM2797 998H2901V714C2901 627 2950 578 3021 578C3092 578 3140 627 3140 714V998H3244V708C3244 567 3179 488 3053 488C2986 488 2926 515 2901 562V498H2797V998ZM2458 908C2373 908 2303 835 2303 748C2303 661 2373 588 2458 588C2543 588 2613 661 2613 748C2613 835 2543 908 2458 908ZM2458 1008C2521 1008 2574 981 2603 939V998H2707V498H2603V552C2574 513 2520 488 2457 488C2312 488 2201 605 2201 748C2201 891 2313 1008 2458 1008ZM1636 998H1735L1828 718L1921 998H2020L2196 498H2087L1972 850L1867 498H1789L1684 850L1569 498H1460L1636 998Z"
+      />
+      <defs>
+        <linearGradient
+          id={`WantedLogoGradient0Linear_${idSuffix}`}
+          x1="27.7716"
+          y1="630.227"
+          x2="555.522"
+          y2="1157.48"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#4C75FF" />
+          <stop offset="0.310893" stopColor="#0B66FF" />
+          <stop offset="0.41658" stopColor="#0064FF" />
+          <stop offset="0.522267" stopColor="#0067FF" />
+          <stop offset="0.733645" stopColor="#0074FF" />
+          <stop offset="1" stopColor="#0084FF" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient1Linear_${idSuffix}`}
+          x1="498.59"
+          y1="268"
+          x2="498.59"
+          y2="1006.92"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.0130872" stopColor="#25B9FF" />
+          <stop offset="0.632316" stopColor="#07BEFF" />
+          <stop offset="0.745954" stopColor="#00BEFF" />
+          <stop offset="1" stopColor="#0092FF" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient5Linear_${idSuffix}`}
+          x1="498.5"
+          y1="950.34"
+          x2="498.5"
+          y2="1033.49"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#009FFF" />
+          <stop offset="0.578979" stopColor="#0094FF" />
+          <stop offset="1" stopColor="#0092FF" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient6Linear_${idSuffix}`}
+          x1="510.338"
+          y1="982.668"
+          x2="496.815"
+          y2="1025.94"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#0098FF" stopOpacity="0" />
+          <stop offset="0.249864" stopColor="#0096FF" />
+          <stop offset="0.499891" stopColor="#0093FF" />
+          <stop offset="0.749808" stopColor="#0091FF" stopOpacity="0.65" />
+          <stop offset="1" stopColor="#0090FF" stopOpacity="0" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient7Linear_${idSuffix}`}
+          x1="498.5"
+          y1="735.78"
+          x2="498.5"
+          y2="825.5"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#0087FF" />
+          <stop offset="1" stopColor="#67B8FF" stopOpacity="0" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient9Linear_${idSuffix}`}
+          x1="176"
+          y1="688"
+          x2="1064"
+          y2="688"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#697DFF" />
+          <stop offset="0.0251928" stopColor="#757FFF" />
+          <stop offset="0.238039" stopColor="#CF94FF" />
+          <stop offset="0.291258" stopColor="#ED9BFF" />
+          <stop offset="0.344471" stopColor="#FE9FFF" />
+          <stop offset="0.46271" stopColor="#FF99E6" />
+          <stop offset="0.580945" stopColor="#FF859C" />
+          <stop offset="0.628242" stopColor="#FF786E" />
+          <stop offset="0.722828" stopColor="#FF5A00" />
+          <stop offset="0.830944" stopColor="#FF5A00" />
+          <stop offset="0.999838" stopColor="#FF5A00" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient10Linear_${idSuffix}`}
+          x1="914.8"
+          y1="687.5"
+          x2="1006.4"
+          y2="687.5"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FF2900" />
+          <stop offset="1" stopColor="#FF5534" stopOpacity="0" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient11Linear_${idSuffix}`}
+          x1="866.5"
+          y1="268"
+          x2="866.5"
+          y2="885"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.0170303" stopColor="#76B0FF" />
+          <stop offset="0.2715" stopColor="#9DACFF" />
+          <stop offset="0.636231" stopColor="#F3A1FF" />
+          <stop offset="0.727132" stopColor="#FF9EFD" />
+          <stop offset="0.818033" stopColor="#FF97E8" />
+          <stop offset="0.999848" stopColor="#FF8EBD" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient12Linear_${idSuffix}`}
+          x1="550"
+          y1="326"
+          x2="812.5"
+          y2="326"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#29B8FF" />
+          <stop offset="1" stopColor="#6DB1FF" />
+        </linearGradient>
+        <linearGradient
+          id={`WantedLogoGradient13Linear_${idSuffix}`}
+          x1="869.5"
+          y1="257"
+          x2="869.5"
+          y2="874"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.0170303" stopColor="#76B0FF" />
+          <stop offset="0.2715" stopColor="#9DACFF" />
+          <stop offset="0.636231" stopColor="#F3A1FF" />
+          <stop offset="0.727132" stopColor="#FF9EFD" />
+          <stop offset="0.818033" stopColor="#FF97E8" />
+          <stop offset="0.999848" stopColor="#FF8EBD" />
+        </linearGradient>
+        <radialGradient
+          id={`WantedLogoGradientFallback1_${idSuffix}`}
+          fx="0%"
+          fy="50%"
+          cx="0%"
+          cy="50%"
+          r="50%"
+        >
+          <stop offset="0%" stopColor="#20BAFF" />
+          <stop offset="100%" stopColor="#2AB8FF" />
+        </radialGradient>
+        <radialGradient
+          id={`WantedLogoGradientFallback2_${idSuffix}`}
+          fx="40%"
+          fy="60%"
+          cx="30%"
+          cy="80%"
+          r="50%"
+        >
+          <stop offset="0%" stopColor="#1A6AFF" />
+          <stop offset="100%" stopColor="#717EFF" />
+        </radialGradient>
+        <radialGradient
+          id={`WantedLogoGradientFallback3_${idSuffix}`}
+          fx="40%"
+          fy="65%"
+          cx="30%"
+          cy="70%"
+          r="50%"
+        >
+          <stop offset="0%" stopColor="#0075FF" />
+          <stop offset="100%" stopColor="#0096FF" />
+        </radialGradient>
+        <radialGradient
+          id={`WantedLogoGradientFallback4_${idSuffix}`}
+          fx="50%"
+          fy="0%"
+          cx="100%"
+          cy="5%"
+          r="95%"
+        >
+          <stop offset="0%" stopColor="#FF5A00" />
+          <stop offset="100%" stopColor="#FF8EBD" />
+        </radialGradient>
+        <radialGradient
+          id={`WantedLogoGradientFallback5_${idSuffix}`}
+          fx="25%"
+          fy="55%"
+          cx="25%"
+          cy="0%"
+          r="55%"
+        >
+          <stop offset="0%" stopColor="#6DB1FF" />
+          <stop offset="100%" stopColor="#8FADFF" />
+        </radialGradient>
+      </defs>
+    </Box>
+  );
+});
+
+LogoWanted.displayName = 'LogoWanted';
+
+export { LogoWanted };
+
+export type { LogoWantedProps };

--- a/packages/wds-brand/src/components/logo-wanted/types.ts
+++ b/packages/wds-brand/src/components/logo-wanted/types.ts
@@ -1,0 +1,6 @@
+import type { WithSxProps } from '@wanteddev/wds-engine';
+
+export type LogoWantedProps = WithSxProps<{
+  width?: number | string;
+  height?: number | string;
+}>;

--- a/packages/wds-brand/src/constants/gradient.ts
+++ b/packages/wds-brand/src/constants/gradient.ts
@@ -1,0 +1,22 @@
+export const LOGO_SYMBOL_GRADIENT = {
+  foreignObjectStyle1: {
+    background:
+      'conic-gradient(#2AB8FF 0deg, #20BAFF 180deg, #20BAFF 270deg, #2AB8FF 360deg)',
+  },
+  foreignObjectStyle2: {
+    background:
+      'conic-gradient(#717EFF 0deg, #4E76FF 90deg, #1368FF 180deg, #1A6AFF 225deg, #316FFF 270deg, #5076FF 315deg, #717EFF 360deg)',
+  },
+  foreignObjectStyle3: {
+    background:
+      'conic-gradient(#0091FF 0deg, #0096FF 90deg, #0089FF 135deg, #007EFF 180deg, #0075FF 225deg, #006EFF 270deg, #0091FF 360deg)',
+  },
+  foreignObjectStyle4: {
+    background:
+      'conic-gradient(#FF5A00 0deg, #FF5E0F 90deg, #FF7259 180deg, #FF8EBD 270deg, #FF9FFE 315deg, #FF5A00 360deg)',
+  },
+  foreignObjectStyle5: {
+    background:
+      'conic-gradient(#6DB1FF 0deg, #7BB0FF 45deg, #8FADFF 90deg, #B4A8FF 180deg, #6DB1FF 360deg)',
+  },
+} as const;

--- a/packages/wds-brand/src/index.ts
+++ b/packages/wds-brand/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/packages/wds-brand/tsconfig.json
+++ b/packages/wds-brand/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.react.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/wds-brand/tsconfig.node.json
+++ b/packages/wds-brand/tsconfig.node.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.node.json",
+  "include": ["tsdown.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/wds-brand/tsdown.config.ts
+++ b/packages/wds-brand/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfiguration } from '../../.tsdown/define-configuration.ts';
+import { injectUseClient } from '../../.tsdown/inject-use-client.ts';
+
+export default defineConfiguration({
+  entry: ['src/**/*.ts', 'src/**/*.tsx'],
+  onSuccess: () => injectUseClient(['./dist/**/*.{js,mjs}']),
+});

--- a/packages/wds-dummy/.npmignore
+++ b/packages/wds-dummy/.npmignore
@@ -1,0 +1,5 @@
+src/
+tsdown.config.ts
+scripts/
+tsconfig.json
+tsconfig.node.json

--- a/packages/wds-dummy/package.json
+++ b/packages/wds-dummy/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@wanteddev/wds-dummy",
+  "version": "3.5.0",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "types": "./dist/index.d.ts",
+      "module": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "repository": {
+    "url": "https://github.com/wanteddev/montage-web",
+    "type": "git",
+    "directory": "packages/wds-dummy"
+  },
+  "scripts": {
+    "build": "tsc --noEmit && tsdown",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "watch": "tsup --watch"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "react": "^19.2.4",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@wanteddev/wds": "workspace:*",
+    "@wanteddev/wds-brand": "workspace:*",
+    "@wanteddev/wds-engine": "workspace:*",
+    "@wanteddev/wds-icon": "workspace:*"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/wds-dummy/src/components/bottom-tab-bar/index.tsx
+++ b/packages/wds-dummy/src/components/bottom-tab-bar/index.tsx
@@ -1,0 +1,64 @@
+import { BottomNavigation, BottomNavigationItem, Box } from '@wanteddev/wds';
+import { forwardRef } from 'react';
+import {
+  IconNavigationCareer,
+  IconNavigationMypage,
+  IconNavigationRecruit,
+  IconNavigationSocial,
+} from '@wanteddev/wds-icon';
+
+import {
+  bottomNavigationItemStyle,
+  bottomNavigationStyle,
+  bottomNavigationWrapperStyle,
+} from './style';
+
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+
+/**
+ * @description A mobile-only bottom tab bar that is rendered only at viewports below the `sm` breakpoint
+ */
+const BottomTabBar = forwardRef<
+  HTMLDivElement,
+  DefaultComponentProps<{}, 'div'>
+>((props, ref) => {
+  return (
+    <Box {...props} sx={[bottomNavigationWrapperStyle, props.sx]} ref={ref}>
+      <BottomNavigation
+        value=""
+        sx={bottomNavigationStyle}
+        aria-label="하단 네비게이션"
+        role="navigation"
+      >
+        <BottomNavigationItem
+          value="recruit"
+          sx={bottomNavigationItemStyle}
+          icon={<IconNavigationRecruit />}
+          label="채용"
+        />
+        <BottomNavigationItem
+          value="event"
+          sx={bottomNavigationItemStyle}
+          icon={<IconNavigationCareer />}
+          label="교육•이벤트"
+        />
+        <BottomNavigationItem
+          value="social"
+          sx={bottomNavigationItemStyle}
+          icon={<IconNavigationSocial />}
+          label="소셜"
+        />
+        <BottomNavigationItem
+          value="mywanted"
+          sx={bottomNavigationItemStyle}
+          icon={<IconNavigationMypage />}
+          label="MY 원티드"
+        />
+      </BottomNavigation>
+    </Box>
+  );
+});
+
+BottomTabBar.displayName = 'BottomTabBar';
+
+export { BottomTabBar };

--- a/packages/wds-dummy/src/components/bottom-tab-bar/style.ts
+++ b/packages/wds-dummy/src/components/bottom-tab-bar/style.ts
@@ -1,0 +1,38 @@
+import { css, respondMore } from '@wanteddev/wds';
+
+import { BOTTOM_TAB_NAVIGATION_HEIGHT } from '../../constants';
+
+import type { Theme } from '@wanteddev/wds';
+
+export const bottomNavigationWrapperStyle = (theme: Theme) => css`
+  padding-bottom: ${BOTTOM_TAB_NAVIGATION_HEIGHT};
+  padding-bottom: calc(
+    constant(safe-area-inset-bottom, 0px) + ${BOTTOM_TAB_NAVIGATION_HEIGHT}
+  );
+  padding-bottom: calc(
+    env(safe-area-inset-bottom, 0px) + ${BOTTOM_TAB_NAVIGATION_HEIGHT}
+  );
+
+  ${respondMore(theme.breakpoint.sm)} {
+    display: none;
+  }
+`;
+
+export const bottomNavigationStyle = css`
+  z-index: 780;
+  height: ${BOTTOM_TAB_NAVIGATION_HEIGHT};
+  position: fixed;
+  right: 0;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 0px);
+  left: 0;
+`;
+
+export const bottomNavigationItemStyle = (theme: Theme) => css`
+  && {
+    color: ${theme.semantic.interaction.inactive};
+
+    &[aria-current='page'] {
+      color: ${theme.semantic.primary.normal};
+    }
+  }
+`;

--- a/packages/wds-dummy/src/components/footer/index.tsx
+++ b/packages/wds-dummy/src/components/footer/index.tsx
@@ -50,7 +50,7 @@ const Footer = forwardRef<HTMLDivElement, DefaultComponentProps<{}, 'div'>>(
             <FlexBox
               gap="8px 24px"
               flexWrap="wrap"
-              justify-content="flex-start"
+              justifyContent="flex-start"
               sm={{
                 gap: '32px',
                 flexWrap: 'initial',
@@ -251,22 +251,46 @@ const Footer = forwardRef<HTMLDivElement, DefaultComponentProps<{}, 'div'>>(
                 margin: '8px 0px',
               }}
             >
-              <IconButton size={20} color="semantic.label.alternative">
+              <IconButton
+                size={20}
+                color="semantic.label.alternative"
+                aria-label="인스타그램"
+              >
                 <IconLogoInstagram />
               </IconButton>
-              <IconButton size={20} color="semantic.label.alternative">
+              <IconButton
+                size={20}
+                color="semantic.label.alternative"
+                aria-label="페이스북"
+              >
                 <IconLogoFacebook />
               </IconButton>
-              <IconButton size={20} color="semantic.label.alternative">
+              <IconButton
+                size={20}
+                color="semantic.label.alternative"
+                aria-label="유튜브"
+              >
                 <IconLogoYoutube />
               </IconButton>
-              <IconButton size={20} color="semantic.label.alternative">
+              <IconButton
+                size={20}
+                color="semantic.label.alternative"
+                aria-label="네이버 블로그"
+              >
                 <IconLogoNaverBlog />
               </IconButton>
-              <IconButton size={20} color="semantic.label.alternative">
+              <IconButton
+                size={20}
+                color="semantic.label.alternative"
+                aria-label="App Store"
+              >
                 <IconLogoApple />
               </IconButton>
-              <IconButton size={20} color="semantic.label.alternative">
+              <IconButton
+                size={20}
+                color="semantic.label.alternative"
+                aria-label="Google Play"
+              >
                 <IconLogoGooglePlay />
               </IconButton>
             </FlexBox>

--- a/packages/wds-dummy/src/components/footer/index.tsx
+++ b/packages/wds-dummy/src/components/footer/index.tsx
@@ -1,0 +1,282 @@
+import {
+  Box,
+  Divider,
+  FlexBox,
+  IconButton,
+  Typography,
+  containerStyle,
+} from '@wanteddev/wds';
+import { forwardRef, useState } from 'react';
+import { LogoWanted } from '@wanteddev/wds-brand';
+import {
+  IconLogoApple,
+  IconLogoFacebook,
+  IconLogoGooglePlay,
+  IconLogoInstagram,
+  IconLogoNaverBlog,
+  IconLogoYoutube,
+} from '@wanteddev/wds-icon';
+
+import {
+  askLinkWrapperStyle,
+  footerStyle,
+  lintWrapperStyle,
+  logoWantedStyle,
+  socialWrapperStyle,
+  summaryStyle,
+  summaryWrapperStyle,
+} from './style';
+
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+
+/**
+ * @description A presentational footer component that renders UI only and provides no interactive behavior
+ */
+const Footer = forwardRef<HTMLDivElement, DefaultComponentProps<{}, 'div'>>(
+  (props, ref) => {
+    const [currentYear] = useState(new Date().getFullYear());
+
+    return (
+      <Box as="footer" ref={ref} {...props} sx={[footerStyle, props.sx]}>
+        <FlexBox flexDirection="column" sx={containerStyle(true)}>
+          <FlexBox
+            flexDirection="column"
+            justifyContent="space-between"
+            alignItems="flex-start"
+            sm={{ flexDirection: 'row', alignItems: 'center' }}
+          >
+            <LogoWanted aria-label="Wanted Logo" sx={logoWantedStyle} />
+
+            <FlexBox
+              gap="8px 24px"
+              flexWrap="wrap"
+              justify-content="flex-start"
+              sm={{
+                gap: '32px',
+                flexWrap: 'initial',
+                justifyContent: 'initial',
+              }}
+              sx={lintWrapperStyle}
+            >
+              <Typography
+                variant="body2"
+                sm={{ variant: 'body1-reading' }}
+                weight="medium"
+                color="semantic.label.normal"
+              >
+                기업소개
+              </Typography>
+
+              <Typography
+                variant="body2"
+                sm={{ variant: 'body1-reading' }}
+                weight="medium"
+                color="semantic.label.normal"
+              >
+                광고문의
+              </Typography>
+
+              <Typography
+                variant="body2"
+                sm={{ variant: 'body1-reading' }}
+                weight="medium"
+                color="semantic.label.normal"
+              >
+                고객센터
+              </Typography>
+
+              <Typography
+                variant="body2"
+                sm={{ variant: 'body1-reading' }}
+                weight="medium"
+                color="semantic.label.normal"
+              >
+                이용약관
+              </Typography>
+
+              <Typography
+                variant="body2"
+                sm={{ variant: 'body1-reading' }}
+                weight="medium"
+                color="semantic.label.normal"
+              >
+                블로그
+              </Typography>
+
+              <Typography
+                variant="body2"
+                sm={{ variant: 'body1-reading' }}
+                weight="bold"
+                color="semantic.label.normal"
+                data-role="privacy-policy"
+              >
+                개인정보 처리방침
+              </Typography>
+            </FlexBox>
+          </FlexBox>
+
+          <FlexBox flexDirection="column" gap="8px" sx={summaryWrapperStyle}>
+            <Typography
+              variant="caption1"
+              weight="medium"
+              color="semantic.label.alternative"
+              sm={{ variant: 'label2' }}
+              sx={summaryStyle}
+              as="p"
+            >
+              <span>(주)원티드랩</span>
+              <span>대표이사 이복기</span>
+            </Typography>
+            <Typography
+              variant="caption1"
+              weight="medium"
+              color="semantic.label.alternative"
+              sm={{ variant: 'label2' }}
+              sx={summaryStyle}
+              as="p"
+            >
+              <span>서울특별시 송파구 올림픽로 300, 롯데월드타워 35층</span>
+              <span>전화번호: 02-539-7118</span>
+            </Typography>
+            <Typography
+              variant="caption1"
+              weight="medium"
+              color="semantic.label.alternative"
+              sm={{ variant: 'label2' }}
+              sx={summaryStyle}
+              as="p"
+            >
+              <span>사업자등록번호: 299-86-00021</span>
+              <span>통신판매번호: 2020-서울송파-3147</span>
+              <span>
+                유료직업소개사업등록번호: (국내) 제2020-3230259-14-5-00018호
+              </span>
+            </Typography>
+          </FlexBox>
+
+          <FlexBox
+            gap="8px 20px"
+            flexWrap="wrap"
+            sm={{ gap: '8px 24px' }}
+            sx={askLinkWrapperStyle}
+          >
+            <Typography
+              display="inline-flex"
+              variant="caption1"
+              sm={{ variant: 'label2' }}
+              weight="bold"
+              color="semantic.label.alternative"
+            >
+              채용서비스 문의
+            </Typography>
+
+            <Typography
+              display="inline-flex"
+              variant="caption1"
+              sm={{ variant: 'label2' }}
+              weight="bold"
+              color="semantic.label.alternative"
+            >
+              원티드스페이스 문의
+            </Typography>
+
+            <Typography
+              display="inline-flex"
+              variant="caption1"
+              sm={{ variant: 'label2' }}
+              weight="bold"
+              color="semantic.label.alternative"
+            >
+              원티드긱스 문의
+            </Typography>
+
+            <Typography
+              display="inline-flex"
+              variant="caption1"
+              sm={{ variant: 'label2' }}
+              weight="bold"
+              color="semantic.label.alternative"
+            >
+              프리온보딩 문의
+            </Typography>
+
+            <Typography
+              display="inline-flex"
+              variant="caption1"
+              sm={{ variant: 'label2' }}
+              weight="bold"
+              color="semantic.label.alternative"
+            >
+              취업지원시스템 문의
+            </Typography>
+
+            <Typography
+              display="inline-flex"
+              variant="caption1"
+              sm={{ variant: 'label2' }}
+              weight="bold"
+              color="semantic.label.alternative"
+            >
+              IR 문의
+            </Typography>
+          </FlexBox>
+
+          <Divider color="semantic.line.normal.alternative" size="100%" />
+
+          <FlexBox
+            flexDirection="column"
+            alignItems="flex-start"
+            justifyContent="initial"
+            gap="8px"
+            sm={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: 'initial',
+            }}
+            sx={socialWrapperStyle}
+          >
+            <Typography
+              variant="label2"
+              weight="medium"
+              color="semantic.label.alternative"
+            >
+              {`© ${currentYear} Wanted Lab, Inc.`}
+            </Typography>
+
+            <FlexBox
+              flexWrap="wrap"
+              gap="10px"
+              sx={{
+                margin: '8px 0px',
+              }}
+            >
+              <IconButton size={20} color="semantic.label.alternative">
+                <IconLogoInstagram />
+              </IconButton>
+              <IconButton size={20} color="semantic.label.alternative">
+                <IconLogoFacebook />
+              </IconButton>
+              <IconButton size={20} color="semantic.label.alternative">
+                <IconLogoYoutube />
+              </IconButton>
+              <IconButton size={20} color="semantic.label.alternative">
+                <IconLogoNaverBlog />
+              </IconButton>
+              <IconButton size={20} color="semantic.label.alternative">
+                <IconLogoApple />
+              </IconButton>
+              <IconButton size={20} color="semantic.label.alternative">
+                <IconLogoGooglePlay />
+              </IconButton>
+            </FlexBox>
+          </FlexBox>
+        </FlexBox>
+      </Box>
+    );
+  },
+);
+
+Footer.displayName = 'Footer';
+
+export { Footer };

--- a/packages/wds-dummy/src/components/footer/style.ts
+++ b/packages/wds-dummy/src/components/footer/style.ts
@@ -78,7 +78,7 @@ export const summaryStyle = (theme: Theme) => css`
       word-break: break-all;
     }
 
-    p + p::before {
+    & + &::before {
       content: '|';
       margin: 0 8px;
       color: ${theme.semantic.line.normal.normal};

--- a/packages/wds-dummy/src/components/footer/style.ts
+++ b/packages/wds-dummy/src/components/footer/style.ts
@@ -1,0 +1,102 @@
+import { css, respondTo } from '@wanteddev/wds';
+
+import type { Theme } from '@wanteddev/wds';
+
+export const footerStyle = (theme: Theme) => css`
+  width: 100%;
+  padding: 40px 0 16px 0;
+  background-color: ${theme.semantic.background.normal.normal};
+  border-top: 1px solid ${theme.semantic.line.normal.neutral};
+
+  ${respondTo(theme.breakpoint.sm)} {
+    padding: 32px 0 16px 0;
+  }
+`;
+
+export const logoWantedStyle = (theme: Theme) => css`
+  width: 112px;
+  height: 32px;
+
+  ${respondTo(theme.breakpoint.sm)} {
+    width: 98px;
+    height: 28px;
+  }
+`;
+
+export const lintWrapperStyle = (theme: Theme) => css`
+  ${respondTo(theme.breakpoint.sm)} {
+    margin-top: 24px;
+    width: 100%;
+
+    > span {
+      &:nth-child(3) {
+        order: 4;
+      }
+      &:nth-child(4) {
+        order: 5;
+      }
+
+      [data-role='privacy-policy'] {
+        order: 3;
+      }
+    }
+  }
+`;
+
+export const summaryWrapperStyle = (theme: Theme) => css`
+  margin-top: 28px;
+
+  ${respondTo(theme.breakpoint.sm)} {
+    margin-top: 23px;
+    width: 100%;
+    display: inline;
+  }
+`;
+
+export const summaryStyle = (theme: Theme) => css`
+  line-height: 138.5%;
+  letter-spacing: 0.25px;
+
+  span {
+    word-wrap: break-word;
+    word-break: keep-all;
+    text-rendering: optimizeLegibility;
+  }
+
+  span + span::before {
+    content: '|';
+    margin: 0 8px;
+    color: ${theme.semantic.line.normal.normal};
+  }
+
+  ${respondTo(theme.breakpoint.sm)} {
+    display: inline;
+    line-height: 133.4%;
+    letter-spacing: 0.3px;
+
+    span {
+      word-break: break-all;
+    }
+
+    p + p::before {
+      content: '|';
+      margin: 0 8px;
+      color: ${theme.semantic.line.normal.normal};
+    }
+  }
+`;
+export const askLinkWrapperStyle = (theme: Theme) => css`
+  margin: 28px 0 32px 0;
+
+  ${respondTo(theme.breakpoint.sm)} {
+    margin: 24px 0 28px 0;
+  }
+`;
+
+export const socialWrapperStyle = (theme: Theme) => css`
+  margin-top: 12px;
+
+  ${respondTo(theme.breakpoint.sm)} {
+    margin-top: 20px;
+  }
+`;

--- a/packages/wds-dummy/src/components/index.ts
+++ b/packages/wds-dummy/src/components/index.ts
@@ -1,0 +1,3 @@
+export * from './bottom-tab-bar';
+export * from './footer';
+export * from './nav-bar';

--- a/packages/wds-dummy/src/components/nav-bar/hooks.ts
+++ b/packages/wds-dummy/src/components/nav-bar/hooks.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export const useIsNavSticky = () => {
+  const [isSticky, setIsSticky] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.scrollY === 0) {
+        setIsSticky(true);
+      } else {
+        setIsSticky(false);
+      }
+    };
+
+    handleScroll();
+
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return isSticky;
+};

--- a/packages/wds-dummy/src/components/nav-bar/hooks.ts
+++ b/packages/wds-dummy/src/components/nav-bar/hooks.ts
@@ -6,9 +6,9 @@ export const useIsNavSticky = () => {
   useEffect(() => {
     const handleScroll = () => {
       if (window.scrollY === 0) {
-        setIsSticky(true);
-      } else {
         setIsSticky(false);
+      } else {
+        setIsSticky(true);
       }
     };
 

--- a/packages/wds-dummy/src/components/nav-bar/index.tsx
+++ b/packages/wds-dummy/src/components/nav-bar/index.tsx
@@ -1,0 +1,198 @@
+import {
+  Box,
+  Button,
+  FlexBox,
+  IconButton,
+  Typography,
+  containerStyle,
+} from '@wanteddev/wds';
+import { forwardRef } from 'react';
+import { LogoWanted } from '@wanteddev/wds-brand';
+import { IconListCategory, IconMenu, IconSearch } from '@wanteddev/wds-icon';
+
+import {
+  asideWrapperStyle,
+  dashboardButtonWrapperStyle,
+  mainBarNavLogoStyle,
+  mainBarNavStyle,
+  mainBarStyle,
+  mainNavLinkItemStyle,
+  mainNavLinkStyle,
+  mainNavStyle,
+  menuButtonWrapperStyle,
+  navBarBackgroundStyle,
+  navBarPaddingStyle,
+  navBarStyle,
+  signUpContainerStyle,
+  signUpDesktopStyle,
+  signUpMobileStyle,
+} from './style';
+import { useIsNavSticky } from './hooks';
+
+import type { DefaultComponentProps } from '@wanteddev/wds-engine';
+
+/**
+ * @description A presentational top navigation bar that renders UI only and provides no interactive behavior
+ */
+const NavBar = forwardRef<HTMLDivElement, DefaultComponentProps<{}, 'div'>>(
+  (props, ref) => {
+    const isSticky = useIsNavSticky();
+
+    return (
+      <>
+        <Box
+          ref={ref}
+          data-is-sticky={isSticky}
+          {...props}
+          sx={[navBarStyle, props.sx]}
+        >
+          <Box sx={navBarBackgroundStyle} />
+
+          <Box sx={[containerStyle(true), mainBarStyle]} role="presentation">
+            <FlexBox as="nav" sx={mainBarNavStyle} alignItems="center">
+              <Box sx={mainBarNavLogoStyle}>
+                <LogoWanted />
+              </Box>
+
+              <FlexBox as="ul" sx={mainNavStyle} alignItems="stretch">
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>
+                      <IconListCategory data-role="category-icon" />
+                      채용
+                    </span>
+                  </Typography>
+                </Box>
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>이력서</span>
+                  </Typography>
+                </Box>
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>교육•이벤트</span>
+                  </Typography>
+                </Box>
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>콘텐츠</span>
+                  </Typography>
+                </Box>
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>소셜</span>
+                  </Typography>
+                </Box>
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>프리랜서</span>
+                  </Typography>
+                </Box>
+                <Box as="li" sx={mainNavLinkStyle}>
+                  <Typography
+                    variant="body2"
+                    weight="bold"
+                    color="semantic.label.normal"
+                    sx={mainNavLinkItemStyle}
+                  >
+                    <span>더보기</span>
+                  </Typography>
+                </Box>
+              </FlexBox>
+
+              <Box as="aside" sx={asideWrapperStyle}>
+                <FlexBox
+                  as="ul"
+                  alignItems="center"
+                  sx={{ '& > li': { flexShrink: 0 } }}
+                >
+                  <li>
+                    <IconButton
+                      type="button"
+                      size={24}
+                      sx={{ margin: '0px 8px' }}
+                      aria-label={'검색'}
+                    >
+                      <IconSearch />
+                    </IconButton>
+                  </li>
+                  <Box as="li" sx={signUpContainerStyle}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="primary"
+                      type="button"
+                      sx={signUpMobileStyle}
+                    >
+                      회원가입
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="primary"
+                      type="button"
+                      sx={signUpDesktopStyle}
+                    >
+                      회원가입/로그인
+                    </Button>
+                  </Box>
+                  <Box as="li" sx={dashboardButtonWrapperStyle}>
+                    <Button
+                      type="button"
+                      variant="outlined"
+                      size="small"
+                      color="assistive"
+                    >
+                      기업 서비스
+                    </Button>
+                  </Box>
+                  <Box as="li" sx={menuButtonWrapperStyle}>
+                    <IconButton size={24} type="button" aria-label="더보기">
+                      <IconMenu />
+                    </IconButton>
+                  </Box>
+                </FlexBox>
+              </Box>
+            </FlexBox>
+          </Box>
+        </Box>
+
+        <Box role="presentation" sx={navBarPaddingStyle} />
+      </>
+    );
+  },
+);
+
+NavBar.displayName = 'NavBar';
+
+export { NavBar };

--- a/packages/wds-dummy/src/components/nav-bar/style.ts
+++ b/packages/wds-dummy/src/components/nav-bar/style.ts
@@ -1,0 +1,144 @@
+import { addOpacity, css, respondMore, respondTo } from '@wanteddev/wds';
+
+import { GNB_HEIGHT_DEFAULT, GNB_HEIGHT_MOBILE } from '../../constants';
+
+import type { Theme } from '@wanteddev/wds';
+
+export const navBarPaddingStyle = (theme: Theme) => css`
+  height: ${GNB_HEIGHT_DEFAULT};
+
+  ${respondTo(theme.breakpoint.md)} {
+    height: ${GNB_HEIGHT_MOBILE};
+  }
+`;
+
+export const navBarStyle = (theme: Theme) => css`
+  width: 100%;
+  position: fixed;
+  top: 0;
+  border-bottom: 1px solid ${theme.semantic.line.normal.neutral};
+  z-index: 800;
+
+  ${respondTo(theme.breakpoint.md)} {
+    &[data-is-sticky='true'] {
+      border-bottom: none;
+    }
+  }
+`;
+
+export const navBarBackgroundStyle = (theme: Theme) => css`
+  position: absolute;
+  z-index: -1;
+  background: ${addOpacity(
+    theme.semantic.background.elevated.normal,
+    theme.opacity[88],
+  )};
+  backdrop-filter: saturate(150%) blur(32px);
+  -webkit-backdrop-filter: saturate(150%) blur(32px);
+  height: 100%;
+  width: 100%;
+`;
+
+export const mainBarStyle = (theme: Theme) => css`
+  margin: 0 auto;
+  height: ${GNB_HEIGHT_DEFAULT};
+
+  ${respondTo(theme.breakpoint.md)} {
+    height: ${GNB_HEIGHT_MOBILE};
+  }
+`;
+
+export const mainBarNavStyle = css`
+  height: 100%;
+`;
+
+export const mainBarNavLogoStyle = css`
+  max-width: calc(112px + 58px);
+  min-width: calc(112px + 40px);
+  width: 12.1428571429%;
+
+  svg {
+    display: flex;
+  }
+`;
+
+export const mainNavStyle = css`
+  height: 100%;
+
+  ${respondTo('1100px')} {
+    display: none;
+  }
+`;
+
+export const mainNavLinkStyle = css`
+  margin-right: 40px;
+  flex-shrink: 0;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;
+
+export const mainNavLinkItemStyle = css`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  background-color: transparent;
+  border: none;
+
+  & > span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    svg {
+      font-size: 20px;
+    }
+  }
+`;
+
+export const asideWrapperStyle = (theme: Theme) => css`
+  margin-left: auto;
+
+  ${respondTo(theme.breakpoint.md)} {
+    margin-right: -8px;
+  }
+`;
+
+export const signUpContainerStyle = (theme: Theme) => css`
+  margin-left: 12px;
+  margin-right: 8px;
+
+  ${respondTo(theme.breakpoint.md)} {
+    order: -1;
+    margin-left: 0;
+    margin-right: 12px;
+  }
+`;
+
+export const signUpMobileStyle = (theme: Theme) => css`
+  ${respondMore(theme.breakpoint.md)} {
+    display: none;
+  }
+`;
+
+export const signUpDesktopStyle = (theme: Theme) => css`
+  ${respondTo(theme.breakpoint.md)} {
+    display: none;
+  }
+`;
+
+export const dashboardButtonWrapperStyle = (theme: Theme) => css`
+  ${respondTo(theme.breakpoint.md)} {
+    display: none;
+  }
+`;
+
+export const menuButtonWrapperStyle = (theme: Theme) => css`
+  margin: 0px 8px;
+  display: none;
+
+  ${respondTo(theme.breakpoint.md)} {
+    display: flex;
+  }
+`;

--- a/packages/wds-dummy/src/components/nav-bar/style.ts
+++ b/packages/wds-dummy/src/components/nav-bar/style.ts
@@ -20,7 +20,7 @@ export const navBarStyle = (theme: Theme) => css`
   z-index: 800;
 
   ${respondTo(theme.breakpoint.md)} {
-    &[data-is-sticky='true'] {
+    &[data-is-sticky='false'] {
       border-bottom: none;
     }
   }

--- a/packages/wds-dummy/src/components/nav-bar/types.ts
+++ b/packages/wds-dummy/src/components/nav-bar/types.ts
@@ -1,0 +1,19 @@
+import type {
+  Merge,
+  ResponsiveProps,
+  WithSxProps,
+} from '@wanteddev/wds-engine';
+
+type WantedLogoDefaultProps = WithSxProps<{
+  width: number;
+  height: number;
+}>;
+
+type WantedLogoResponsiveProps = ResponsiveProps<
+  Pick<WantedLogoDefaultProps, 'width' | 'height'>
+>;
+
+export type WantedLogoProps = Merge<
+  WantedLogoDefaultProps,
+  WantedLogoResponsiveProps
+>;

--- a/packages/wds-dummy/src/constants/index.ts
+++ b/packages/wds-dummy/src/constants/index.ts
@@ -1,0 +1,4 @@
+export const GNB_HEIGHT_DEFAULT = '60px';
+export const GNB_HEIGHT_MOBILE = '56px';
+
+export const BOTTOM_TAB_NAVIGATION_HEIGHT = '58px';

--- a/packages/wds-dummy/src/index.ts
+++ b/packages/wds-dummy/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/packages/wds-dummy/tsconfig.json
+++ b/packages/wds-dummy/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.react.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/wds-dummy/tsconfig.node.json
+++ b/packages/wds-dummy/tsconfig.node.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.node.json",
+  "include": ["tsdown.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/wds-dummy/tsdown.config.ts
+++ b/packages/wds-dummy/tsdown.config.ts
@@ -1,0 +1,7 @@
+import { defineConfiguration } from '../../.tsdown/define-configuration.ts';
+import { injectUseClient } from '../../.tsdown/inject-use-client.ts';
+
+export default defineConfiguration({
+  entry: ['src/**/*.ts', 'src/**/*.tsx'],
+  onSuccess: () => injectUseClient(['./dist/**/*.{js,mjs}']),
+});

--- a/packages/wds-mcp/README.ko.md
+++ b/packages/wds-mcp/README.ko.md
@@ -8,18 +8,20 @@ AI 코딩 어시스턴트에게 WDS 컴포넌트 문서, 디자인 토큰, 아�
 
 ## 제공 도구
 
-| 도구                     | 설명                                                   |
-| ------------------------ | ------------------------------------------------------ |
-| `list_components`        | 사용 가능한 모든 WDS 컴포넌트 목록 조회                |
-| `get_component`          | 특정 컴포넌트의 문서 및 사용법 조회                    |
-| `wds_coding_guidelines`  | WDS 기반 UI 코드 작성 가이드라인 조회                  |
-| `list_icons`             | `@wanteddev/wds-icon`에서 사용 가능한 아이콘 목록 조회 |
-| `list_tokens`            | 사용 가능한 디자인 토큰 목록 조회                      |
-| `get_color_usage`        | 색상 적용 가이드라인 조회                              |
-| `list_utility_functions` | 사용 가능한 유틸리티 함수 목록 조회                    |
-| `get_utility_function`   | 특정 유틸리티 함수의 문서 조회                         |
-| `getting_started`        | 설치 및 초기 설정 가이드 조회                          |
-| `health_check`           | MCP 서버의 상태 확인                                   |
+| 도구                     | 설명                                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `list_components`        | 사용 가능한 모든 WDS 컴포넌트 목록 조회                                                                         |
+| `get_component`          | 특정 컴포넌트의 문서 및 사용법 조회                                                                             |
+| `wds_coding_guidelines`  | WDS 기반 UI 코드 작성 가이드라인 조회                                                                           |
+| `list_icons`             | `@wanteddev/wds-icon`에서 사용 가능한 아이콘 목록 조회                                                          |
+| `list_tokens`            | 사용 가능한 디자인 토큰 목록 조회                                                                               |
+| `get_color_usage`        | 색상 적용 가이드라인 조회                                                                                       |
+| `list_utility_functions` | 사용 가능한 유틸리티 함수 목록 조회                                                                             |
+| `get_utility_function`   | 특정 유틸리티 함수의 문서 조회                                                                                  |
+| `list_dummy_components`  | `@wanteddev/wds-dummy`의 데모/프리뷰용 레이아웃 스캐폴드(`NavBar`, `Footer`, `BottomTabBar`) 목록 조회          |
+| `list_brand_assets`      | 공식 Wanted 브랜드 마크 목록 조회 (`@wanteddev/wds-brand`의 `LogoWanted`, `@wanteddev/wds-icon`의 `IconSymbol`) |
+| `getting_started`        | 설치 및 초기 설정 가이드 조회                                                                                   |
+| `health_check`           | MCP 서버의 상태 확인                                                                                            |
 
 ## 설정
 

--- a/packages/wds-mcp/README.md
+++ b/packages/wds-mcp/README.md
@@ -8,18 +8,20 @@ It provides AI coding assistants with access to WDS component documentation, des
 
 ## Available Tools
 
-| Tool                     | Description                                                  |
-| ------------------------ | ------------------------------------------------------------ |
-| `list_components`        | List all available WDS components                            |
-| `get_component`          | Get documentation and usage details for a specific component |
-| `wds_coding_guidelines`  | Get coding guidelines for writing WDS-based UI code          |
-| `list_icons`             | List all available icons from `@wanteddev/wds-icon`          |
-| `list_tokens`            | List all available design tokens                             |
-| `get_color_usage`        | Get guidelines for applying colors                           |
-| `list_utility_functions` | List all available utility functions                         |
-| `get_utility_function`   | Get documentation for a specific utility function            |
-| `getting_started`        | Get installation and initial configuration guide             |
-| `health_check`           | Check the health status of the MCP server                    |
+| Tool                     | Description                                                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `list_components`        | List all available WDS components                                                                                                    |
+| `get_component`          | Get documentation and usage details for a specific component                                                                         |
+| `wds_coding_guidelines`  | Get coding guidelines for writing WDS-based UI code                                                                                  |
+| `list_icons`             | List all available icons from `@wanteddev/wds-icon`                                                                                  |
+| `list_tokens`            | List all available design tokens                                                                                                     |
+| `get_color_usage`        | Get guidelines for applying colors                                                                                                   |
+| `list_utility_functions` | List all available utility functions                                                                                                 |
+| `get_utility_function`   | Get documentation for a specific utility function                                                                                    |
+| `list_dummy_components`  | List presentational dummy layout scaffolds (`NavBar`, `Footer`, `BottomTabBar`) from `@wanteddev/wds-dummy` for demo / preview pages |
+| `list_brand_assets`      | List official Wanted brand marks (`LogoWanted` from `@wanteddev/wds-brand`, `IconSymbol` from `@wanteddev/wds-icon`)                 |
+| `getting_started`        | Get installation and initial configuration guide                                                                                     |
+| `health_check`           | Check the health status of the MCP server                                                                                            |
 
 ## Setup
 

--- a/packages/wds-mcp/src/server.ts
+++ b/packages/wds-mcp/src/server.ts
@@ -537,6 +537,109 @@ or with the Typography component like:
   );
 
   server.registerTool(
+    'list_dummy_components',
+    {
+      description:
+        'List presentational dummy layout components (NavBar, Footer, BottomTabBar) provided by the @wanteddev/wds-dummy package. These are reference scaffolds for demos and previews — render UI only, expose no behavior props, and should NOT be reused as-is in production code.',
+    },
+    async () => {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `The following dummy components are available in the @wanteddev/wds-dummy package.
+
+## Intent
+
+These are **presentational-only reference scaffolds** that mirror the wanted.co.kr layout. Use them when you need a realistic-looking GNB / Footer / mobile tab bar for a demo, sandbox, storybook page, or visual preview.
+
+**Do NOT use them as-is in production.** They take no behavior props (no \`onClick\`, no routing, no state). For real product code, copy the structure and rebuild it against your own data, links, and handlers using primitives from \`@wanteddev/wds\`.
+
+## Components
+
+- **NavBar** — Top global navigation bar (logo + main menu + sign-up / enterprise / search / menu buttons). Becomes sticky on scroll.
+- **Footer** — Site footer (logo, link list, company info, social icon buttons, copyright).
+- **BottomTabBar** — Mobile-only bottom tab bar. Rendered only below the \`sm\` breakpoint; the component itself does not hide on larger screens, so wrap it accordingly if needed.
+
+All three are \`forwardRef\` components, accept a standard \`sx\` prop, and render as a \`div\` (or semantic equivalent).
+
+## Usage
+
+\`\`\`tsx
+import { NavBar, Footer, BottomTabBar } from '@wanteddev/wds-dummy';
+
+export default function DemoPage() {
+  return (
+    <>
+      <NavBar />
+      <main>{/* page content */}</main>
+      <Footer />
+      <BottomTabBar />
+    </>
+  );
+}
+\`\`\`
+
+If you need to know the exact JSX of a dummy component (to copy and adapt it for production), read the source from \`packages/wds-dummy/src/components/<component>/index.tsx\` directly — there is no separate docs page for these.`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'list_brand_assets',
+    {
+      description:
+        'List Wanted brand assets (e.g. LogoWanted) provided by the @wanteddev/wds-brand package. These are official brand marks — use them as-is, do not recolor or restyle.',
+    },
+    async () => {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `The following brand assets are available in the @wanteddev/wds-brand package.
+
+## Intent
+
+These are **official Wanted brand marks**. Use them whenever you need the Wanted logo in any UI. Do not recolor, restyle, or redraw them — they ship with the correct gradient and proportions baked in.
+
+## Assets
+
+- **LogoWanted** (\`@wanteddev/wds-brand\`) — The full **"[symbol] wanted" wordmark** (symbol + text), rendered as an inline SVG with the official brand gradient.
+  - Props: \`width\` (default \`112\`), \`height\` (default \`32\`), plus standard \`sx\` and any \`<svg>\` attributes.
+  - Forwards ref to the underlying \`SVGSVGElement\`.
+  - Pass \`aria-label\` (e.g. \`"Wanted Logo"\`) when the logo is the only content of an interactive or landmark element.
+
+- **IconSymbol** (\`@wanteddev/wds-icon\`) — The **symbol mark only** (no wordmark), rendered as a 1:1 square icon. Use this when you need just the Wanted symbol — e.g. favicons, app icons, compact headers, loading indicators, badges.
+  - Sized via \`fontSize\` (defaults to \`1em\`); built-in \`<title>\` provides accessible name "원티드 심벌".
+  - Do **not** crop or extract the symbol portion of \`LogoWanted\` to fake a symbol-only mark — always use \`IconSymbol\`.
+
+## Usage
+
+\`\`\`tsx
+// Full wordmark
+import { LogoWanted } from '@wanteddev/wds-brand';
+
+<LogoWanted aria-label="Wanted Logo" />
+
+// Custom size — keep the 112:32 (≈ 3.5:1) aspect ratio
+<LogoWanted width={168} height={48} aria-label="Wanted Logo" />
+
+// Symbol only
+import { IconSymbol } from '@wanteddev/wds-icon';
+
+<IconSymbol sx={{ fontSize: '32px' }} />
+\`\`\`
+
+Prefer these over importing or recreating any other Wanted logo SVG.`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
     'health_check',
     {
       description:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,22 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/wds-brand:
+    dependencies:
+      '@wanteddev/wds-engine':
+        specifier: workspace:*
+        version: link:../wds-engine
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/wds-codemod:
     dependencies:
       execa:
@@ -474,6 +490,31 @@ importers:
       '@types/jscodeshift':
         specifier: 0.12.0
         version: 0.12.0
+
+  packages/wds-dummy:
+    dependencies:
+      '@wanteddev/wds':
+        specifier: workspace:*
+        version: link:../wds
+      '@wanteddev/wds-brand':
+        specifier: workspace:*
+        version: link:../wds-brand
+      '@wanteddev/wds-engine':
+        specifier: workspace:*
+        version: link:../wds-engine
+      '@wanteddev/wds-icon':
+        specifier: workspace:*
+        version: link:../wds-icon
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/wds-engine:
     dependencies:


### PR DESCRIPTION
## Summary

- `@wanteddev/wds-dummy` 신규 패키지 추가 — wanted.co.kr 스타일의 presentational-only 레이아웃 스캐폴드 (`NavBar`, `Footer`, `BottomTabBar`). 데모/프리뷰/스토리북 전용으로, 동작 props 없음.
- `@wanteddev/wds-brand` 신규 패키지 추가 — 공식 Wanted 워드마크 `LogoWanted`. (심볼 단독은 기존 `@wanteddev/wds-icon`의 `IconSymbol` 사용)
- `@wanteddev/wds-mcp`에 `list_dummy_components`, `list_brand_assets` MCP tool 추가 — AI 코딩 어시스턴트가 fetch 없이 사용 시점·import path·props·anti-pattern을 한 번에 파악.
- `montage-react` skill 및 plugin/MCP README 업데이트 (트리거 조건, 사용 가이드, 체크리스트).

## Why

팀 채용솔루션에서 바이브코딩(데모/프리뷰 페이지 빠르게 만들기) 시 매번 가짜 GNB·Footer를 손으로 짜거나 Wanted 로고 SVG를 임의로 끌어다 쓰는 비효율이 반복되고 있었음. 표준 dummy/brand 패키지를 제공하고 MCP·skill에 노출해 AI 도구에서도 일관되게 쓰이도록 함.

## Jira

[WRP-499](https://wantedlab.atlassian.net/browse/WRP-499) — [디자인시스템] 바이브코딩용 mock GNB/Footer 및 브랜드 에셋 제공

- Status: 열림
- Type: 작업
- Priority: P3

## Test plan

- [ ] `pnpm build`로 신규 패키지 빌드 확인
- [ ] 데모 페이지에서 `NavBar` / `Footer` / `BottomTabBar` 렌더링 시각 확인
- [ ] `LogoWanted` 다양한 size에서 비율 유지 확인 (default 112×32, 168×48 등)
- [ ] MCP에서 `list_dummy_components`, `list_brand_assets` 호출 시 응답 텍스트 정상 출력
- [ ] `montage-react` skill 트리거 시 새 가이드 섹션 노출 확인

[WRP-499]: https://wantedlab.atlassian.net/browse/WRP-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 원티드 브랜드 로고 컴포넌트(LogoWanted) 추가 및 사용·접근성 가이드 제공
  * 레이아웃 스캐폴딩 더미 컴포넌트 추가(네비게이션 바, 푸터, 하단 탭 바 등)
  * MCP 도구 확장: 더미 컴포넌트 목록과 브랜드 자산 목록 조회 도구 추가

* **문서**
  * MCP 도구 목록 표 재포맷 및 montage-react 스킬의 자동 발동 조건·검증 체크리스트 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->