### PR TITLE
WRP-521 fix(wds-mcp): oauth provider throw를 OAuthError 서브클래스로 교체

### DIFF
--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -3,6 +3,13 @@ import crypto from 'node:crypto';
 import { cert, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
+import {
+  AccessDeniedError,
+  InvalidGrantError,
+  InvalidRequestError,
+  InvalidTokenError,
+  ServerError,
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
 
 import type {
   AuthorizationParams,
@@ -82,17 +89,25 @@ class TtlMap<K, V> {
 
 const clientRegistrationStore = {
   async set(clientId: string, client: OAuthClientInformationFull) {
-    await clientsCollection
-      .doc(clientId)
-      .set(JSON.parse(JSON.stringify(client)));
+    try {
+      await clientsCollection
+        .doc(clientId)
+        .set(JSON.parse(JSON.stringify(client)));
+    } catch {
+      throw new ServerError('Failed to persist client registration');
+    }
   },
 
   async get(clientId: string): Promise<OAuthClientInformationFull | undefined> {
-    const doc = await clientsCollection.doc(clientId).get();
+    try {
+      const doc = await clientsCollection.doc(clientId).get();
 
-    if (!doc.exists) return undefined;
+      if (!doc.exists) return undefined;
 
-    return doc.data() as OAuthClientInformationFull;
+      return doc.data() as OAuthClientInformationFull;
+    } catch {
+      throw new ServerError('Failed to load client registration');
+    }
   },
 };
 
@@ -148,7 +163,9 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
     res: Response,
   ) {
     if (!client.redirect_uris.includes(params.redirectUri)) {
-      throw new Error('Redirect URI not registered for this client');
+      throw new InvalidRequestError(
+        'Redirect URI not registered for this client',
+      );
     }
 
     const state = crypto.randomUUID();
@@ -197,7 +214,7 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
     const codeInfo = authCodes.get(authorizationCode);
 
     if (!codeInfo || codeInfo.clientId !== client.client_id) {
-      throw new Error('Invalid authorization code');
+      throw new InvalidGrantError('Invalid authorization code');
     }
 
     // Exchange the Google auth code for tokens
@@ -214,14 +231,13 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     }).catch((error) => {
       if (error instanceof DOMException && error.name === 'TimeoutError') {
-        throw new Error('Google token exchange timed out');
+        throw new ServerError('Google token exchange timed out');
       }
-      throw error;
+      throw new ServerError('Google token exchange failed');
     });
 
     if (!tokenResponse.ok) {
-      const error = await tokenResponse.text();
-      throw new Error(`Failed to exchange code with Google: ${error}`);
+      throw new InvalidGrantError('Failed to exchange code with Google');
     }
 
     const googleTokens = (await tokenResponse.json()) as {
@@ -247,14 +263,13 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
       },
     ).catch((error) => {
       if (error instanceof DOMException && error.name === 'TimeoutError') {
-        throw new Error('Firebase sign-in timed out');
+        throw new ServerError('Firebase sign-in timed out');
       }
-      throw error;
+      throw new ServerError('Firebase sign-in failed');
     });
 
     if (!firebaseResponse.ok) {
-      const error = await firebaseResponse.text();
-      throw new Error(`Firebase sign-in failed: ${error}`);
+      throw new ServerError('Firebase sign-in failed');
     }
 
     const firebaseTokens = (await firebaseResponse.json()) as {
@@ -264,7 +279,9 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
     };
 
     if (!firebaseTokens.email?.endsWith(`@${ALLOWED_DOMAIN}`)) {
-      throw new Error(`Access restricted to @${ALLOWED_DOMAIN} accounts`);
+      throw new AccessDeniedError(
+        `Access restricted to @${ALLOWED_DOMAIN} accounts`,
+      );
     }
 
     authCodes.delete(authorizationCode);
@@ -299,7 +316,7 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
     );
 
     if (!googleRefreshToken) {
-      throw new Error('Invalid or expired refresh token');
+      throw new InvalidGrantError('Invalid or expired refresh token');
     }
 
     // Use Google refresh token to get new tokens
@@ -315,20 +332,18 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     }).catch((error) => {
       if (error instanceof DOMException && error.name === 'TimeoutError') {
-        throw new Error('Google token refresh timed out');
+        throw new ServerError('Google token refresh timed out');
       }
-      throw error;
+      throw new ServerError('Google token refresh failed');
     });
 
     if (!tokenResponse.ok) {
-      const error = await tokenResponse.text();
-
       // Only delete on permanent failures (token revoked/invalid)
       if (tokenResponse.status === 400 || tokenResponse.status === 401) {
         await refreshTokenStore.delete(refreshToken);
       }
 
-      throw new Error(`Failed to refresh Google token: ${error}`);
+      throw new InvalidGrantError('Failed to refresh Google token');
     }
 
     const googleTokens = (await tokenResponse.json()) as {
@@ -362,14 +377,13 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
       },
     ).catch((error) => {
       if (error instanceof DOMException && error.name === 'TimeoutError') {
-        throw new Error('Firebase sign-in timed out');
+        throw new ServerError('Firebase sign-in timed out');
       }
-      throw error;
+      throw new ServerError('Firebase sign-in failed');
     });
 
     if (!firebaseResponse.ok) {
-      const error = await firebaseResponse.text();
-      throw new Error(`Firebase sign-in failed: ${error}`);
+      throw new ServerError('Firebase sign-in failed');
     }
 
     const firebaseTokens = (await firebaseResponse.json()) as {
@@ -379,7 +393,9 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
     };
 
     if (!firebaseTokens.email?.endsWith(`@${ALLOWED_DOMAIN}`)) {
-      throw new Error(`Access restricted to @${ALLOWED_DOMAIN} accounts`);
+      throw new AccessDeniedError(
+        `Access restricted to @${ALLOWED_DOMAIN} accounts`,
+      );
     }
 
     return {
@@ -392,12 +408,14 @@ export const createOAuthProvider = (): OAuthServerProvider => ({
   },
 
   async verifyAccessToken(token: string): Promise<AuthInfo> {
-    const decoded = await firebaseAuth.verifyIdToken(token).catch((error) => {
-      throw error;
+    const decoded = await firebaseAuth.verifyIdToken(token).catch(() => {
+      throw new InvalidTokenError('Invalid or expired token');
     });
 
     if (!decoded.email?.endsWith(`@${ALLOWED_DOMAIN}`)) {
-      throw new Error(`Access restricted to @${ALLOWED_DOMAIN} accounts`);
+      throw new InvalidTokenError(
+        `Access restricted to @${ALLOWED_DOMAIN} accounts`,
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

- wds-mcp의 OAuth provider 메서드들이 raw `Error`를 throw → MCP SDK가 모든 예외를 `500 server_error`로 변환 → opencode 같은 일부 클라이언트에서 토큰 만료 시 자동 재인증 흐름이 깨지는 문제 수정
- Claude Code는 500도 너그럽게 재시도하는 자체 fallback이 있어 가려져 있던 버그
- SDK가 제공하는 OAuthError 서브클래스(`InvalidTokenError` / `InvalidGrantError` / `AccessDeniedError` / `InvalidRequestError` / `ServerError`)로 교체하여 표준 OAuth 응답 형식 준수

## 변경 매핑

| 상황 | 이전 | 이후 |
| --- | --- | --- |
| `verifyAccessToken` 실패/만료 | `Error` → 500 | `InvalidTokenError` → 401 |
| `exchangeRefreshToken` 잘못된 토큰 | `Error` → 500 | `InvalidGrantError` → 400 |
| `exchangeAuthorizationCode` 잘못된 코드 | `Error` → 500 | `InvalidGrantError` → 400 |
| 도메인 제한 | `Error` → 500 | `AccessDeniedError` / `InvalidTokenError` → 403/401 |
| Google/Firebase 외부 호출 실패 | `Error` → 500 | `ServerError` → 500 (명시적) |
| redirect_uri 미등록 | `Error` → 500 | `InvalidRequestError` → 400 |

## Jira

- WRP-521: https://wantedlab.atlassian.net/browse/WRP-521

## Test plan

- [x] 로컬에서 토큰 만료 후 opencode 재인증 흐름 정상 동작 확인
  ```
  POST /mcp -> 401
  GET /.well-known/oauth-protected-resource
  GET /.well-known/oauth-authorization-server
  POST /token -> 200
  POST /mcp -> 200
  ```
- [ ] Claude Code에서도 기존 동작 유지되는지 확인
- [ ] 배포 후 opencode 사용자 측 재인증 정상 동작 확인

## 후속 과제 (별건)

- `pendingAuths` / `authCodes`가 in-memory `TtlMap` — 멀티 인스턴스/재시작에 취약. Firestore 등으로 이전 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 인증 등록 및 OAuth 플로우에서 오류 처리 개선
* 토큰 검증 및 도메인 접근 제한 강화
* 네트워크 오류 및 권한 문제에 대한 더 정확한 오류 응답 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->