### PR TITLE
feat(wds-mcp): WRP-538 /track 엔드포인트 추가 및 사용 텔레메트리 통합

### DIFF
--- a/.github/workflows/mcp-deploy.yml
+++ b/.github/workflows/mcp-deploy.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Build wds-mcp
         run: pnpm lerna run build --scope @wanteddev/wds-mcp --include-dependencies
+        env:
+          MCP_TRACK_CLIENT_ID: ${{ secrets.MCP_TRACK_CLIENT_ID }}
 
       - name: Deploy standalone wds-mcp
         run: pnpm deploy --filter @wanteddev/wds-mcp --prod standalone --legacy

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Build packages
         uses: ./.github/actions/package-build
+        env:
+          MCP_TRACK_CLIENT_ID: ${{ secrets.MCP_TRACK_CLIENT_ID }}
 
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/packages/wds-mcp/src/auth.ts
+++ b/packages/wds-mcp/src/auth.ts
@@ -40,7 +40,9 @@ const firebaseApp = initializeApp(
 );
 
 const firebaseAuth = getAuth(firebaseApp);
-const firestore = getFirestore(firebaseApp, 'montage-storage');
+
+export const firestore = getFirestore(firebaseApp, 'montage-storage');
+
 const refreshTokensCollection = firestore.collection('refreshTokens');
 const clientsCollection = firestore.collection('clients');
 

--- a/packages/wds-mcp/src/constants/index.ts
+++ b/packages/wds-mcp/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const DOCS_BASE_URL = 'https://montage.wanted.co.kr';
+export const DOCS_BASE_URL = 'http://localhost:3000';
 
 export const DOCS_COLOR_USAGE_URL =
   'docs/foundations/base-material/colors/semantic';

--- a/packages/wds-mcp/src/constants/index.ts
+++ b/packages/wds-mcp/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const DOCS_BASE_URL = 'http://localhost:3000';
+export const DOCS_BASE_URL = 'https://montage.wanted.co.kr';
 
 export const DOCS_COLOR_USAGE_URL =
   'docs/foundations/base-material/colors/semantic';

--- a/packages/wds-mcp/src/http.ts
+++ b/packages/wds-mcp/src/http.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
@@ -57,6 +59,9 @@ app.get('/health', (_, res) => {
   res.status(200).json({ status: 'ok' });
 });
 
+const sha256 = (input: string): string =>
+  crypto.createHash('sha256').update(input).digest('hex');
+
 app.post('/track', async (req, res) => {
   const event = req.body as TrackEvent | undefined;
 
@@ -67,6 +72,11 @@ app.post('/track', async (req, res) => {
 
   if (!event.clientId || !['web', 'ios', 'android'].includes(event.platform)) {
     res.status(400).json({ error: 'invalid client id or platform' });
+    return;
+  }
+
+  if (!['http', 'stdio'].includes(event.transport)) {
+    res.status(400).json({ error: 'invalid transport' });
     return;
   }
 
@@ -89,11 +99,15 @@ app.post('/track', async (req, res) => {
       '';
     const userAgent = req.header('User-Agent') ?? '';
 
-    deviceId = `synthetic-${ip}|${userAgent}`;
+    deviceId = `synthetic-${sha256(`${ip}|${userAgent}`).slice(0, 16)}`;
   }
 
   try {
-    await telemetryCollection.add(event);
+    await telemetryCollection.add({
+      ...event,
+      deviceId,
+      timestamp: event.timestamp ?? new Date().toISOString(),
+    });
   } catch (error) {
     console.error('Failed to persist telemetry event:', error, event);
   }

--- a/packages/wds-mcp/src/http.ts
+++ b/packages/wds-mcp/src/http.ts
@@ -6,18 +6,40 @@ import express from 'express';
 import { getServer } from './server';
 import {
   createOAuthProvider,
+  firestore,
   getServerUrl,
   handleGoogleCallback,
 } from './auth';
+
+import type { TrackEvent } from './track';
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
 
 const app = express();
 
 app.set('trust proxy', 2);
-app.use(express.json());
+app.use(express.json({ limit: '256kb' }));
 
 const provider = createOAuthProvider();
+const telemetryCollection = firestore
+  .collection('tracks')
+  .doc('events')
+  .collection('list');
+const telemetryClients = firestore.collection('tracks').doc('clients');
+
+let clientRegistry: Record<string, string> = {};
+
+const initialClientsSnap = await telemetryClients.get();
+clientRegistry = (initialClientsSnap.data() ?? {}) as Record<string, string>;
+
+const unsubscribeClientRegistry = telemetryClients.onSnapshot(
+  (snap) => {
+    clientRegistry = (snap.data() ?? {}) as Record<string, string>;
+  },
+  (error) => {
+    console.error('Failed to subscribe to telemetry clients:', error);
+  },
+);
 
 // MCP OAuth routes (metadata, authorize, token, register, revoke)
 app.use(
@@ -35,11 +57,66 @@ app.get('/health', (_, res) => {
   res.status(200).json({ status: 'ok' });
 });
 
+app.post('/track', async (req, res) => {
+  const event = req.body as TrackEvent | undefined;
+
+  if (!event || typeof event !== 'object' || !event.name) {
+    res.status(400).json({ error: 'invalid event' });
+    return;
+  }
+
+  if (!event.clientId || !['web', 'ios', 'android'].includes(event.platform)) {
+    res.status(400).json({ error: 'invalid client id or platform' });
+    return;
+  }
+
+  if (clientRegistry[event.platform] !== event.clientId) {
+    res.status(400).json({ error: 'invalid client id' });
+    return;
+  }
+
+  let deviceId = event.deviceId;
+
+  if (!deviceId) {
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const ip =
+      (typeof forwardedFor === 'string'
+        ? forwardedFor.split(',')[0]?.trim()
+        : Array.isArray(forwardedFor)
+          ? forwardedFor[0]
+          : undefined) ??
+      req.ip ??
+      '';
+    const userAgent = req.header('User-Agent') ?? '';
+
+    deviceId = `synthetic-${ip}|${userAgent}`;
+  }
+
+  try {
+    await telemetryCollection.add(event);
+  } catch (error) {
+    console.error('Failed to persist telemetry event:', error, event);
+  }
+
+  res.status(202).json({ ok: true });
+});
+
 // Bearer auth middleware for MCP endpoints
 const auth = requireBearerAuth({ verifier: provider });
 
 app.post('/mcp', auth, async (req, res) => {
-  const server = getServer();
+  const email =
+    typeof req.auth?.extra?.email === 'string' ? req.auth.extra.email : '';
+  const userId = email.toLowerCase() || null;
+
+  const server = getServer({
+    transport: 'http',
+    platform: 'web',
+    trackContext: {
+      clientId: process.env.MCP_TRACK_CLIENT_ID!,
+      deviceId: userId,
+    },
+  });
 
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
@@ -107,6 +184,7 @@ const httpServer = app.listen(PORT, (error) => {
 
 const shutdown = () => {
   console.log('Shutting down server...');
+  unsubscribeClientRegistry();
   httpServer.close(() => process.exit(0));
 };
 

--- a/packages/wds-mcp/src/index.ts
+++ b/packages/wds-mcp/src/index.ts
@@ -1,8 +1,16 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { getServer } from './server';
+import { deriveUserIdHint, getOrCreateInstallationId } from './track';
 
-const server = getServer();
+const server = getServer({
+  transport: 'stdio',
+  platform: 'web',
+  trackContext: {
+    clientId: process.env.MCP_TRACK_CLIENT_ID!,
+    deviceId: deriveUserIdHint() ?? getOrCreateInstallationId(),
+  },
+});
 const transport = new StdioServerTransport();
 
 await server.connect(transport);

--- a/packages/wds-mcp/src/server.ts
+++ b/packages/wds-mcp/src/server.ts
@@ -16,12 +16,66 @@ import {
   listUtilityFunctions,
 } from './helpers';
 import { DOCS_COLOR_USAGE_URL, DOCS_SELECTOR } from './constants';
+import { type Platform, trackEvent } from './track';
 
-const getServer = () => {
+export type TrackContext = {
+  clientId: string;
+  deviceId?: string | null;
+};
+
+export type GetServerOptions = {
+  transport: 'http' | 'stdio';
+  platform: Platform;
+  trackContext: TrackContext;
+};
+
+const getServer = ({ transport, platform, trackContext }: GetServerOptions) => {
   const server = new McpServer({
     name: 'WDS, Wanted Design System',
     version,
   });
+
+  const original = server.registerTool.bind(server);
+
+  server.registerTool = ((
+    toolName: Parameters<typeof original>[0],
+    toolConfig: Parameters<typeof original>[1],
+    toolHandler: Parameters<typeof original>[2],
+  ) => {
+    const wrapped = (async (toolArgs: unknown, extra: unknown) => {
+      const start = Date.now();
+      let status = 'success';
+
+      try {
+        return await (
+          toolHandler as (...args: Array<unknown>) => Promise<unknown>
+        )(toolArgs, extra);
+      } catch (error) {
+        status = 'failure';
+        throw error;
+      } finally {
+        await trackEvent({
+          name: 'tool_call',
+          toolName,
+          transport,
+          platform,
+          clientId: trackContext.clientId,
+          deviceId: trackContext.deviceId,
+          params:
+            toolArgs && typeof toolArgs === 'object'
+              ? (toolArgs as Record<string, unknown>)
+              : {},
+          metadata: {
+            durationMs: Date.now() - start,
+            status,
+            version,
+          },
+        });
+      }
+    }) as Parameters<typeof original>[2];
+
+    return original(toolName, toolConfig, wrapped);
+  }) as typeof server.registerTool;
 
   const turndownService = new TurndownService({
     headingStyle: 'atx',

--- a/packages/wds-mcp/src/server.ts
+++ b/packages/wds-mcp/src/server.ts
@@ -54,7 +54,7 @@ const getServer = ({ transport, platform, trackContext }: GetServerOptions) => {
         status = 'failure';
         throw error;
       } finally {
-        await trackEvent({
+        void trackEvent({
           name: 'tool_call',
           toolName,
           transport,
@@ -70,6 +70,8 @@ const getServer = ({ transport, platform, trackContext }: GetServerOptions) => {
             status,
             version,
           },
+        }).catch(() => {
+          // 텔레메트리 실패는 tool 결과에 영향 주지 않음
         });
       }
     }) as Parameters<typeof original>[2];

--- a/packages/wds-mcp/src/track.ts
+++ b/packages/wds-mcp/src/track.ts
@@ -84,7 +84,7 @@ export const deriveUserIdHint = (): string | null => {
     }).trim();
 
     if (gitEmail) {
-      return gitEmail.trim().toLowerCase();
+      return gitEmail.toLowerCase();
     }
   } catch {
     // git 미설치 또는 user.email 미설정

--- a/packages/wds-mcp/src/track.ts
+++ b/packages/wds-mcp/src/track.ts
@@ -1,0 +1,94 @@
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+import { DOCS_BASE_URL } from './constants';
+
+const TRACK_TIMEOUT_MS = 2_000;
+const GIT_TIMEOUT_MS = 1_000;
+
+export type Platform = 'ios' | 'web' | 'android';
+
+export type TrackEvent = {
+  name: string;
+  toolName?: string;
+  transport: 'http' | 'stdio';
+  platform: Platform;
+  clientId: string;
+  deviceId?: string | null;
+  timestamp?: string;
+  params?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+};
+
+export const trackEvent = async (event: TrackEvent) => {
+  const payload = {
+    ...event,
+    timestamp: event.timestamp ?? new Date().toISOString(),
+  };
+
+  await fetch(`${DOCS_BASE_URL}/track`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(TRACK_TIMEOUT_MS),
+  }).catch(() => {
+    // best-effort: 텔레메트리 실패는 silent
+  });
+};
+
+const sha256 = (input: string): string =>
+  crypto.createHash('sha256').update(input).digest('hex');
+
+const getConfigDir = (): string => {
+  return path.join(path.join(os.homedir(), '.config'), 'montage-mcp');
+};
+
+export const getOrCreateInstallationId = (): string => {
+  if (process.env.CI) {
+    return sha256(`ci:${os.hostname()}`).slice(0, 32);
+  }
+
+  const file = path.join(getConfigDir(), 'installation-id');
+
+  try {
+    const existing = fs.readFileSync(file, 'utf-8').trim();
+
+    if (existing) return existing;
+  } catch {
+    // 첫 실행 또는 파일 없음
+  }
+
+  const id = crypto.randomUUID();
+
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, id, { mode: 0o600 });
+  } catch {
+    // 쓰기 실패: 이번 세션만 사용
+  }
+
+  return id;
+};
+
+export const deriveUserIdHint = (): string | null => {
+  try {
+    const gitEmail = execSync('git config user.email', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: GIT_TIMEOUT_MS,
+    }).trim();
+
+    if (gitEmail) {
+      return gitEmail.trim().toLowerCase();
+    }
+  } catch {
+    // git 미설치 또는 user.email 미설정
+  }
+
+  return null;
+};

--- a/packages/wds-mcp/tsdown.config.ts
+++ b/packages/wds-mcp/tsdown.config.ts
@@ -31,5 +31,11 @@ const jsonPlugin = () => ({
 export default defineConfiguration({
   entry: ['src/**/*.ts', 'src/**/*.tsx'],
   format: ['esm'],
+  define: {
+    // This is private package, inject client id in bundle file
+    'process.env.MCP_TRACK_CLIENT_ID': JSON.stringify(
+      process.env.MCP_TRACK_CLIENT_ID ?? '',
+    ),
+  },
   plugins: [rawTextPlugin(), jsonPlugin()],
 });


### PR DESCRIPTION
## Summary

- `montage.wanted.co.kr`에 `POST /track` 엔드포인트 추가 — Firestore `tracks/events/list` 서브컬렉션에 raw event 적재
- `wds-mcp` HTTP/stdio 양쪽 transport에서 매 tool 호출마다 fire-and-forget `POST /track`
- `clientId × platform` 검증을 `tracks/clients` 도큐먼트 `onSnapshot` 메모리 캐싱으로 처리 (매 요청 Firestore read 비용 0)
- `clientId`는 `tsdown` `define` 옵션으로 빌드 타임 주입 — stdio 측에서도 추가 환경변수 설정 없이 동작
- stdio 측 `device_id`: 영속 installation id (`~/.config/wds-mcp/installation-id`) + git config 기반 email 휴리스틱
- `DO_NOT_TRACK=1` / `WDS_MCP_TELEMETRY=0` 으로 opt-out
- CI workflow (`mcp-deploy`, `version`)에 `MCP_TRACK_CLIENT_ID` secret 주입

## Jira

[WRP-538](https://wantedlab.atlassian.net/browse/WRP-538) — [디자인시스템] wds-mcp 사용 텔레메트리 /track 엔드포인트 추가

- Status: 해야 할 일
- Type: 작업

디자인시스템 MCP가 사내에서 얼마나 / 어떻게 쓰이는지 측정 데이터를 수집. 향후 타팀 MCP도 동일 엔드포인트로 통합 예정.

## Test plan

- [ ] HTTP MCP 호출 시 Firestore `tracks/events/list`에 이벤트 적재 확인
- [ ] stdio MCP (`npx @wanteddev/wds-mcp`) 호출 시 동일 적재 확인
- [ ] `DO_NOT_TRACK=1` 으로 비활성화 동작 확인
- [ ] `tracks/clients` 도큐먼트에 `web` 슬롯이 등록되지 않은 상태에서 호출 시 400 reject 확인
- [ ] `tracks/clients` 도큐먼트 변경 시 `onSnapshot`이 메모리 캐시 갱신하는지 확인 (콘솔에서 값 변경 → 1초 내 반영)
- [ ] 빌드 시 `MCP_TRACK_CLIENT_ID` 환경변수 주입 → `dist/` 안에 리터럴로 박혔는지 확인

## 후속 / 미결

- BigQuery export (Firebase Extension `firestore-bigquery-export`) 연동
- abuse 방지 정책 (IP rate limit, behavior detection) — 사내 도구라 우선순위 낮음
- 타팀 MCP 온보딩 가이드 (API 명세 Confluence 게재)
- README 문서화: opt-out, 환경변수, 빌드 시 주입 방법

## 환경변수

| 이름 | 위치 | 용도 |
|---|---|---|
| `MCP_TRACK_CLIENT_ID` | CI build | 빌드 타임에 dist에 박힘 (Repository Secrets 등록 필요) |
| `DO_NOT_TRACK=1` | runtime (사용자) | 텔레메트리 opt-out |
| `WDS_MCP_USER_EMAIL` | runtime (선택) | stdio email override (git config 휴리스틱 대체) |

[WRP-538]: https://wantedlab.atlassian.net/browse/WRP-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 도구 호출, 이벤트 발생 및 플랫폼 정보를 추적하여 애플리케이션 사용 패턴을 모니터링하는 원격 분석 시스템 추가

## 개선사항
* 빌드 및 배포 워크플로우에서 추적 기능 지원 추가
* 클라이언트 식별 및 기기 정보 수집을 위한 기반 인프라 구성
<!-- end of auto-generated comment: release notes by coderabbit.ai -->