### PR TITLE
fix(ci): figma-icon-sync 아이콘 description을 components에서 조회

### DIFF
--- a/.github/workflows/figma-icon-sync.yml
+++ b/.github/workflows/figma-icon-sync.yml
@@ -192,7 +192,7 @@ jobs:
 
               const getIconNames = (nodes, type = '') => {
                 if (nodes) {
-                  nodes.children.forEach((component) => {
+                  nodes.children.forEach((component, i) => {
                     if (component.type === 'COMPONENT_SET') {
                       const components = component.children.filter(
                         (child) => child.type === 'COMPONENT',
@@ -214,7 +214,7 @@ jobs:
                           idsToNameAndComponentSetId[child.id] = {
                             name,
                             id: component.id,
-                            description: response.componentSets[component.id]?.description,
+                            description: response.components[child.id]?.description,
                           };
                         });
                       }

--- a/.github/workflows/figma-icon-sync.yml
+++ b/.github/workflows/figma-icon-sync.yml
@@ -192,7 +192,7 @@ jobs:
 
               const getIconNames = (nodes, type = '') => {
                 if (nodes) {
-                  nodes.children.forEach((component, i) => {
+                  nodes.children.forEach((component) => {
                     if (component.type === 'COMPONENT_SET') {
                       const components = component.children.filter(
                         (child) => child.type === 'COMPONENT',


### PR DESCRIPTION
## Summary

- `figma-icon-sync.yml` 워크플로우에서 아이콘의 `description`을 잘못된 위치(`response.componentSets[component.id]`)에서 조회하던 문제를 수정
- 개별 child 컴포넌트의 `description`은 `response.components[child.id]`에 있으므로 그쪽에서 조회하도록 변경

## Jira

[WRP-761](https://wantedlab.atlassian.net/browse/WRP-761) — [디자인시스템] 피그마 아이콘 동기화

- Status: 열림
- Type: 작업

연동 안됨

## Test plan

- [ ] 워크플로우를 dispatch해서 아이콘 description이 정상적으로 가져와지는지 확인

[WRP-761]: https://wantedlab.atlassian.net/browse/WRP-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Figma 아이콘 동기화 워크플로우의 컴포넌트셋 설명 참조 방식을 수정하여 아이콘 설명 동기화 신뢰성 및 처리 정확도를 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wanteddev/montage-web/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->