### PR TITLE
fix(ci): docs-sync에서 변경사항 없을 때 빈 브랜치/실패 방지

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -83,12 +83,21 @@ jobs:
       - run: git config user.email "${{ steps.app-user.outputs.email }}"
 
       - name: Commit and push to existing branch
+        id: commit
         run: |
-          git commit -am "docs: sync with mobile docs" --no-verify || echo "No changes to commit"
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "변경사항이 없어 push와 PR 생성을 건너뜁니다."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "docs: sync with mobile docs" --no-verify
           git push origin ${{ steps.check-branch.outputs.branch }}
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Create New PR
-        if: steps.check-branch.outputs.branch_exists == 'false'
+        if: steps.check-branch.outputs.branch_exists == 'false' && steps.commit.outputs.has_changes == 'true'
         run: |
           gh pr create -B ${{ steps.extract-current-branch.outputs.base_branch }} -H ${{ steps.check-branch.outputs.branch }} --title "docs: sync from mobile document" --body "sync from mobile document"
         env:
@@ -164,12 +173,21 @@ jobs:
       - run: git config user.email "${{ steps.app-user.outputs.email }}"
 
       - name: Commit and push to existing branch
+        id: commit
         run: |
-          git commit -am "docs: sync with design docs" --no-verify || echo "No changes to commit"
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "변경사항이 없어 push와 PR 생성을 건너뜁니다."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "docs: sync with design docs" --no-verify
           git push origin ${{ steps.check-branch.outputs.branch }}
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Create New PR
-        if: steps.check-branch.outputs.branch_exists == 'false'
+        if: steps.check-branch.outputs.branch_exists == 'false' && steps.commit.outputs.has_changes == 'true'
         run: |
           gh pr create -B ${{ steps.extract-current-branch.outputs.base_branch }} -H ${{ steps.check-branch.outputs.branch }} --title "docs: sync from design document" --body "sync from design document"
         env:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -10,14 +10,25 @@ on:
         options:
           - 'mobile'
           - 'design'
+  workflow_call:
+    outputs:
+      branch:
+        description: 'mobile docs sync로 생성/사용된 브랜치 이름'
+        value: ${{ jobs.sync-mobile-docs.outputs.branch }}
+      has_changes:
+        description: 'mobile docs sync에서 실제 변경사항이 push되었는지 여부 (true/false)'
+        value: ${{ jobs.sync-mobile-docs.outputs.has_changes }}
 
 env:
   FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
 
 jobs:
   sync-mobile-docs:
-    if: inputs.platform == 'mobile'
+    if: ${{ github.event_name == 'workflow_call' || inputs.platform == 'mobile' }}
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.check-branch.outputs.branch }}
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -105,7 +116,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
   sync-design-docs:
-    if: inputs.platform == 'design'
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.platform == 'design' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token


### PR DESCRIPTION
## Summary

- `docs-sync.yml`의 mobile/design 두 job 모두 변경사항이 없으면 commit/push/PR 생성을 skip하도록 수정
- 기존: 신규 sync 시나리오에서 generate 결과가 동일하면 base와 같은 SHA의 빈 브랜치가 remote에 push되고 `gh pr create`가 "No commits between" 에러로 실패
- 수정: `git diff --cached --quiet`로 변경 여부를 체크해 `has_changes` output을 출력, push와 PR 생성 step을 조건부로 실행

## Why

- 기존 sync PR이 열려있는 경우(`branch_exists=true`)는 `|| echo "No changes to commit"`로 조용히 no-op 처리되지만, 신규 sync 경로에서는 빈 브랜치 ref만 누적되고 워크플로우가 fail로 끝남
- 사용자가 매번 워크플로우 실패 알림을 받아야 하고, remote에 사용하지 않는 `feature/sync-docs/<run_id>` ref가 쌓이는 문제

## Test plan

- [ ] `Docs Sync` 워크플로우(platform=mobile)를 변경사항이 없는 상태에서 dispatch했을 때 워크플로우가 성공으로 종료되는지 확인
- [ ] 변경사항이 있는 상태에서 dispatch했을 때 기존대로 신규 PR이 생성되는지 확인
- [ ] (design platform도 동일) 두 케이스 모두 검증
- [ ] 기존 sync PR이 열려있는 상태에서 dispatch 시 변경사항 없으면 조용히 종료, 있으면 기존 PR 브랜치에 commit이 추가되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 문서 동기화 워크플로우 개선: 모바일 및 디자인 문서 동기화에서 변경 유무를 사전 검사해 변경이 없으면 조기 종료하도록 도입하여 불필요한 커밋/푸시 방지.
  * 워크플로 호출 시 주요 결과(branch, has_changes)를 외부로 노출하도록 출력 항목 추가.
  * Pull Request 생성 조건을 “브랜치 미존재 + 실제 변경 있음”으로 강화.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wanteddev/montage-web/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->