### PR TITLE
ci: docs-sync workflow_call에 platform input 추가

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Create New PR
         if: steps.check-branch.outputs.branch_exists == 'false' && steps.commit.outputs.has_changes == 'true'
         run: |
-          gh pr create -B ${{ steps.extract-current-branch.outputs.base_branch }} -H ${{ steps.check-branch.outputs.branch }} --title "docs: sync from mobile document" --body "sync from mobile document"
+          gh pr create -B ${{ steps.extract-current-branch.outputs.base_branch }} -H ${{ steps.check-branch.outputs.branch }} --title "docs: sync from mobile document" --body "sync from mobile document" --label "ci: skip document deploy" --label "ci: skip test"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -206,7 +206,7 @@ jobs:
       - name: Create New PR
         if: steps.check-branch.outputs.branch_exists == 'false' && steps.commit.outputs.has_changes == 'true'
         run: |
-          gh pr create -B ${{ steps.extract-current-branch.outputs.base_branch }} -H ${{ steps.check-branch.outputs.branch }} --title "docs: sync from design document" --body "sync from design document"
+          gh pr create -B ${{ steps.extract-current-branch.outputs.base_branch }} -H ${{ steps.check-branch.outputs.branch }} --title "docs: sync from design document" --body "sync from design document" --label "ci: skip document deploy" --label "ci: skip test"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -11,6 +11,12 @@ on:
           - 'mobile'
           - 'design'
   workflow_call:
+    inputs:
+      platform:
+        description: Platform
+        required: false
+        default: 'mobile'
+        type: string
     outputs:
       branch:
         description: 'mobile docs sync로 생성/사용된 브랜치 이름'
@@ -24,7 +30,7 @@ env:
 
 jobs:
   sync-mobile-docs:
-    if: ${{ github.event_name == 'workflow_call' || inputs.platform == 'mobile' }}
+    if: ${{ inputs.platform == 'mobile' }}
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.check-branch.outputs.branch }}
@@ -116,7 +122,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
   sync-design-docs:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.platform == 'design' }}
+    if: ${{ inputs.platform == 'design' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token


### PR DESCRIPTION
## Summary

- `workflow_call` trigger에 `platform` input(required: false, default: `mobile`)을 추가
- `sync-mobile-docs` / `sync-design-docs` job의 `if` 조건을 `event_name` 분기 없이 `inputs.platform` 기준으로 단순화

## Test plan

- [ ] `workflow_dispatch`로 mobile/design 각각 실행했을 때 의도한 job만 실행되는지 확인
- [ ] 다른 워크플로우에서 `workflow_call`로 호출 시 mobile job이 기본 동작하는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 문서 동기화에서 플랫폼을 선택할 수 있어 모바일·디자인 문서를 선택적으로 동기화할 수 있습니다.
  * 플랫폼별 분기 처리로 필요에 따라 해당 문서군만 효율적으로 업데이트됩니다.
  * 모바일·디자인용 자동 생성 PR에 테스트 및 배포 관련 CI 건너뛰기 라벨이 자동으로 추가됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wanteddev/montage-web/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->