### PR TITLE
feat(core): button radius, dimension, spacing 토큰 적용

### DIFF
--- a/packages/core/src/components/button/style.ts
+++ b/packages/core/src/components/button/style.ts
@@ -49,7 +49,7 @@ export const buttonStyle =
     }
 
     ${buttonColorStyle(props, theme)}
-    ${buttonSizeStyle(props)}
+    ${buttonSizeStyle(props, theme)}
     ${props.fullWidth ? 'width: 100%;' : 'width: fit-content;'}
 
     ${createResponsiveStyle(
@@ -57,7 +57,7 @@ export const buttonStyle =
       theme,
     )(
       (params) => css`
-        ${buttonSizeStyle({ ...params, color: props.color })}
+        ${buttonSizeStyle({ ...params, color: props.color }, theme)}
         ${params?.fullWidth && 'width: 100%;'}
         ${params?.fullWidth === false && 'width: fit-content;'}
         ${params?.sx}
@@ -65,23 +65,26 @@ export const buttonStyle =
     )}
   `;
 
-const buttonSizeStyle = ({ size, iconOnly }: ButtonProps = {}) => {
+const buttonSizeStyle = (
+  { size, iconOnly }: ButtonProps = {},
+  theme: Theme,
+) => {
   switch (size) {
     case 'large':
       return css`
-        border-radius: 14px;
-        min-height: 48px;
-        padding: 13px 20px;
-        gap: 6px;
+        border-radius: ${theme.radius[14]};
+        min-height: ${theme.dimension[48]};
+        padding: 13px ${theme.spacing[20]};
+        gap: ${theme.spacing[6]};
 
         [data-role='button-loading'] {
-          width: 16px;
-          height: 16px;
+          width: ${theme.dimension[16]};
+          height: ${theme.dimension[16]};
         }
 
         ${iconOnly
           ? css`
-              padding: 14px;
+              padding: ${theme.spacing[14]};
               font-size: 20px;
 
               svg {
@@ -99,14 +102,14 @@ const buttonSizeStyle = ({ size, iconOnly }: ButtonProps = {}) => {
       `;
     case 'medium':
       return css`
-        border-radius: 12px;
-        min-height: 40px;
-        padding: 10px 16px;
-        gap: 4px;
+        border-radius: ${theme.radius[12]};
+        min-height: ${theme.dimension[40]};
+        padding: ${theme.spacing[10]} ${theme.spacing[16]};
+        gap: ${theme.spacing[4]};
 
         [data-role='button-loading'] {
-          width: 14px;
-          height: 14px;
+          width: ${theme.dimension[14]};
+          height: ${theme.dimension[14]};
         }
 
         ${iconOnly
@@ -129,19 +132,19 @@ const buttonSizeStyle = ({ size, iconOnly }: ButtonProps = {}) => {
       `;
     case 'small':
       return css`
-        border-radius: 10px;
-        min-height: 32px;
-        padding: 8px 12px;
-        gap: 4px;
+        border-radius: ${theme.radius[10]};
+        min-height: ${theme.dimension[32]};
+        padding: ${theme.spacing[8]} ${theme.spacing[12]};
+        gap: ${theme.spacing[4]};
 
         [data-role='button-loading'] {
-          width: 12px;
-          height: 12px;
+          width: ${theme.dimension[12]};
+          height: ${theme.dimension[12]};
         }
 
         ${iconOnly
           ? css`
-              padding: 8px;
+              padding: ${theme.spacing[8]};
               font-size: 16px;
 
               svg {
@@ -159,14 +162,14 @@ const buttonSizeStyle = ({ size, iconOnly }: ButtonProps = {}) => {
       `;
     case 'xsmall':
       return css`
-        border-radius: 8px;
-        min-height: 28px;
-        padding: 6px 10px;
-        gap: 4px;
+        border-radius: ${theme.radius[8]};
+        min-height: ${theme.dimension[28]};
+        padding: ${theme.spacing[6]} ${theme.spacing[10]};
+        gap: ${theme.spacing[4]};
 
         [data-role='button-loading'] {
-          width: 12px;
-          height: 12px;
+          width: ${theme.dimension[12]};
+          height: ${theme.dimension[12]};
         }
 
         ${iconOnly


### PR DESCRIPTION
## Summary

- `button/style.ts`의 사이즈별 정적 값을 `theme.radius` / `theme.dimension` / `theme.spacing` 토큰으로 치환
- `border-radius`, `min-height`, `padding`, `gap`, loading 인디케이터 크기에 토큰 적용
- Figma numeric variables(8/10/12/14/16/18/20/28/32/40/48)에 매칭되지 않는 파생 값(Large 세로 padding `13px`, Medium iconOnly `11px`, Xsmall iconOnly `7px`)은 raw 유지
- `font-size`는 typography line-height 기반으로 동작하므로 토큰 미적용 (raw 유지)
- `buttonSizeStyle` 시그니처에 `theme: Theme` 인자 추가, 호출부 2곳 함께 업데이트

## Jira

[WRP-861](https://wantedlab.atlassian.net/browse/WRP-861) — [WDS] Button 업데이트

- Status: 열림
- Type: 하위 작업
- Assignee: 김도은

Button의 속성 및 UI를 업데이트합니다.

## Test plan

- [ ] visual regression CI(`visual-test`) 통과 — 동일 픽셀이어야 함 (토큰 → 동일 값 1:1 치환)
- [ ] Large / Medium / Small / Xsmall × Solid·Outlined × Primary·Assistive·Negative × iconOnly on/off 렌더 확인

[WRP-861]: https://wantedlab.atlassian.net/browse/WRP-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 버튼의 크기, 간격, 로딩 상태 표시가 일관된 테마 기반으로 적용됩니다.

* **리팩토링**
  * 버튼 스타일 렌더링 로직이 테마 토큰을 활용하도록 업데이트되어, 반응형 디자인 지원이 강화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wanteddev/montage-web/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->