### PR TITLE
ci: docs-sync에서 deploy까지 dispatch로 트리거

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -10,11 +10,8 @@ on:
       algolia:
         description: Run algolia crawler
         required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
+        default: false
+        type: boolean
       server_type:
         description: Server type
         required: false
@@ -40,6 +37,16 @@ on:
         required: false
         default: ''
         type: string
+      ref:
+        description: 'Branch/tag/sha to checkout. Defaults to the workflow ref.'
+        required: false
+        default: ''
+        type: string
+      algolia:
+        description: Run algolia crawler
+        required: false
+        default: false
+        type: boolean
 
 env:
   NODE_VERSION: 22.18.0
@@ -63,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set Environment Variable
         id: env-vars
@@ -110,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         uses: ./.github/actions/pnpm-install
@@ -217,7 +224,7 @@ jobs:
 
   algolia:
     needs: [deploy-docs]
-    if: ${{ inputs.algolia == 'true' && inputs.server_type == 'www' }}
+    if: ${{ inputs.algolia && inputs.server_type == 'www' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -10,20 +10,19 @@ on:
         options:
           - 'mobile'
           - 'design'
-  workflow_call:
-    inputs:
-      platform:
-        description: Platform
+      deploy:
+        description: Run docs deploy after sync (only when changes are pushed)
         required: false
-        default: 'mobile'
-        type: string
-    outputs:
-      branch:
-        description: 'mobile docs sync로 생성/사용된 브랜치 이름'
-        value: ${{ jobs.sync-mobile-docs.outputs.branch }}
-      has_changes:
-        description: 'mobile docs sync에서 실제 변경사항이 push되었는지 여부 (true/false)'
-        value: ${{ jobs.sync-mobile-docs.outputs.has_changes }}
+        default: false
+        type: boolean
+      server_type:
+        description: Server type for deploy
+        required: false
+        default: 'dev'
+        type: choice
+        options:
+          - 'dev'
+          - 'www'
 
 env:
   FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
@@ -124,6 +123,9 @@ jobs:
   sync-design-docs:
     if: ${{ inputs.platform == 'design' }}
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.check-branch.outputs.branch }}
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -210,3 +212,23 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
+
+  deploy-mobile-docs:
+    needs: sync-mobile-docs
+    if: ${{ inputs.deploy && needs.sync-mobile-docs.outputs.has_changes == 'true' }}
+    uses: ./.github/workflows/docs-deploy.yml
+    with:
+      server_type: ${{ inputs.server_type }}
+      ref: ${{ needs.sync-mobile-docs.outputs.branch }}
+      algolia: true
+    secrets: inherit
+
+  deploy-design-docs:
+    needs: sync-design-docs
+    if: ${{ inputs.deploy && needs.sync-design-docs.outputs.has_changes == 'true' }}
+    uses: ./.github/workflows/docs-deploy.yml
+    with:
+      server_type: ${{ inputs.server_type }}
+      ref: ${{ needs.sync-design-docs.outputs.branch }}
+      algolia: true
+    secrets: inherit


### PR DESCRIPTION
## Summary

- `docs-sync.yml`에서 `workflow_call` 제거 → `workflow_dispatch`만 유지하고 `deploy` / `server_type` input 추가
- platform별로 `sync-mobile-docs` / `sync-design-docs` 잡 뒤에 `deploy-mobile-docs` / `deploy-design-docs` 잡 추가 — `inputs.deploy && has_changes == 'true'`일 때만 sync로 만든/업데이트한 브랜치 ref로 `docs-deploy.yml`을 호출
- `docs-deploy.yml`의 `workflow_call`에 `ref` / `algolia` input 추가, `algolia`를 boolean으로 통일

## Why

montage-ios 등 외부 저장소에서 docs-sync를 reusable workflow로 호출하면 `actions/checkout`이 caller 저장소를 받아오기 때문에 `./.github/actions/pnpm-install` 같은 로컬 액션 경로를 찾지 못해 실패합니다. 이 PR은 `workflow_dispatch` 방식으로 전환해 montage-web 저장소 컨텍스트에서만 실행되도록 하고, deploy까지 한 번에 이어지도록 묶었습니다.

## 사용 예시 (외부 저장소)

```bash
gh workflow run docs-sync.yml \
  -R wanteddev/montage-web \
  -f platform=mobile \
  -f deploy=true \
  -f server_type=dev
```

## Test plan

- [ ] Actions UI에서 `Docs Sync`를 `platform=mobile`, `deploy=false`로 dispatch → 기존 동작 그대로 sync PR만 생성되는지
- [ ] `platform=mobile`, `deploy=true` (변경사항 있을 때) → `deploy-mobile-docs`가 sync된 브랜치 ref로 `docs-deploy.yml`을 호출하는지
- [ ] `platform=mobile`, `deploy=true` (변경사항 없을 때) → `deploy-mobile-docs`가 자연스럽게 skip되는지
- [ ] `platform=design`, `deploy=true` 동일 시나리오

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

이번 변경사항은 내부 배포 인프라 개선에 관한 것으로, 최종 사용자에게 직접적인 영향을 미치지 않습니다.

* **Chores**
  * 문서 배포 워크플로우 설정 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wanteddev/montage-web/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->