### PR TITLE
fix(wds): pagination dot totalPages가 maxDotCount 이하일 때 scale 1 고정

### DIFF
--- a/packages/wds/src/components/pagination-dots/helpers.ts
+++ b/packages/wds/src/components/pagination-dots/helpers.ts
@@ -61,6 +61,10 @@ export const getPaginationDotScale = ({
     return 0;
   }
 
+  if (totalPages <= maxDotCount) {
+    return 1;
+  }
+
   // first
   if (
     (visibleArea[0] === 0 && Math.floor(maxDotCount / 2) > index) ||


### PR DESCRIPTION
## Summary

- `getPaginationDotScale`에서 `totalPages`가 `maxDotCount` 이하일 때 모든 dot의 scale을 `1`로 반환하도록 early return 추가
- dot 개수가 충분히 적어 축소가 불필요한 경우 currentPage 위치와 무관하게 일정한 크기를 보장

## Jira

[WRP-994](https://wantedlab.atlassian.net/browse/WRP-994) — [디자인시스템] pagination dot 컴포넌트 totalPage 5이하일때 dot 크기 조정

- Status: 열림
- Type: 작업

currentPage 1 기준 기대 동작:
- `totalPages: 4` → `1 1 1 1`
- `totalPages: 5` → `1 1 1 1 1`
- `totalPages: 6` → `1 1 1 1 0.8`
- `totalPages: 7` → `1 1 1 0.8 0.6`

## Test plan

- [ ] totalPages 4·5 (≤ maxDotCount)에서 모든 dot scale이 1인지 확인
- [ ] totalPages 6·7에서 기존 축소 로직(0.8 / 0.6)이 정상 동작하는지 회귀 확인

[WRP-994]: https://wantedlab.atlassian.net/browse/WRP-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 페이지네이션 점 렌더링이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->