### PR TITLE
fix(wds): section header navigation 라인 색상 토큰 수정

### DIFF
--- a/packages/wds/src/components/section-header/style.ts
+++ b/packages/wds/src/components/section-header/style.ts
@@ -121,7 +121,7 @@ export const sectionHeaderNavigationStyle = (theme: Theme) => css`
   overflow: hidden;
   border-radius: 10px;
   height: 32px;
-  border: 1px solid ${theme.semantic.line.normal.normal};
+  border: 1px solid ${theme.semantic.line.normal.neutral};
 `;
 
 export const sectionHeaderNavigationButtonStyle = (theme: Theme) => css`


### PR DESCRIPTION
## Summary

- `sectionHeaderNavigationStyle`의 border 색상 토큰을 `line.normal.normal` → `line.normal.neutral`로 변경

## Jira

[WRP-997](https://wantedlab.atlassian.net/browse/WRP-997) — [디자인시스템] section header navigation 라인 색상 수정

- Status: 열림
- Type: 작업

## Test plan

- [ ] section header navigation 영역의 border 색상이 의도한 neutral 토큰으로 렌더되는지 확인

[WRP-997]: https://wantedlab.atlassian.net/browse/WRP-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 섹션 헤더의 테두리 색상이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->