### PR TITLE
feat(core)!: wds 식별자 네이밍 변경

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -97,6 +97,44 @@ style={{ zIndex: `calc(${theme.zIndex.modal} + 1)` }}
 
 > **breakpoint 토큰은 var 변환에서 제외되었습니다.** `@media (min-width: ...)` 쿼리에는 CSS variable을 사용할 수 없기 때문입니다.
 
+### CSS Variable 네이밍 변경 (`--wds-` prefix 제거)
+
+컴포넌트 내부에서 사용하는 CSS 변수의 `--wds-` 브랜드 prefix가 제거되었습니다. 대부분 컴포넌트명으로 시작하므로 prefix만 떨어지며(`--wds-modal-translate` → `--modal-translate`), grid의 두 변수는 이름이 지나치게 일반적이어서 컴포넌트 스코프를 붙였습니다.
+
+| 기존                       | 변경                    |
+| -------------------------- | ----------------------- |
+| `--wds-modal-translate`    | `--modal-translate`     |
+| `--wds-switch-width`       | `--switch-width`        |
+| `--wds-table-border-color` | `--table-border-color`  |
+| _그 외 모든 `--wds-*`_     | _`--wds-` 제거_         |
+| `--wds-column-spacing`     | `--grid-column-spacing` |
+| `--wds-row-spacing`        | `--grid-row-spacing`    |
+
+이 변수들은 대부분 라이브러리 내부 전용(element-scoped)이지만, `css\`\``·인라인 style·scss에서 직접 참조하거나 오버라이드한 코드가 있다면 codemod로 자동 변환하세요:
+
+```sh
+npx @montage-ui/codemod@latest css-variable-migration src
+```
+
+codemod는 `.ts`/`.tsx`/`.js`/`.jsx`의 문자열·template literal과 `.css`/`.scss`/`.sass`/`.less` 스타일시트를 함께 변환합니다.
+
+### DOM 식별자(attribute / id) 변경
+
+컴포넌트 식별용 marker attribute와 portal container id가 변경되었습니다.
+
+| 기존                                                | 변경                               | 참조 케이스                    |
+| --------------------------------------------------- | ---------------------------------- | ------------------------------ |
+| `wds-component` (attribute)                         | `data-component`                   | `[wds-component="..."]` 셀렉터 |
+| `wds-ignore-first-focus` (attribute)                | `data-ignore-first-focus`          | focus 제어 attribute           |
+| `wds-ignore-dismissable-layer` (attribute)          | `data-ignore-dismissable-layer`    | dismiss 제어 attribute         |
+| `#wds-region-manager`, `#wds-region-manager-bottom` | `#montage-region-manager(-bottom)` | `querySelector` 참조           |
+
+`[wds-component="..."]` 셀렉터(css/scss), `querySelector('#wds-region-manager-bottom')`, `closest('[wds-ignore-dismissable-layer]')` 등을 직접 사용했다면 codemod로 자동 변환하세요:
+
+```sh
+npx @montage-ui/codemod@latest dom-identifier-migration src
+```
+
 ### Modal
 
 `variant="bottom"`, `handle={true}`의 기본 동작이 변경되었습니다.

--- a/docs/data/components/actions/action-area/web.mdx
+++ b/docs/data/components/actions/action-area/web.mdx
@@ -249,7 +249,7 @@ export default Demo;`}
 - buttonColor
 - textButtonColor
 
-내부 간격을 조정할 때는 `--wds-action-area-margin-x`, `--wds-action-area-margin-y` CSS Variable 을 사용합니다.
+내부 간격을 조정할 때는 `--action-area-margin-x`, `--action-area-margin-y` CSS Variable 을 사용합니다.
 
 <Demo code={`import { ActionArea, ActionAreaButton } from '@montage-ui/core';
 

--- a/docs/data/utilities/web-utility-components/animation-presence.mdx
+++ b/docs/data/utilities/web-utility-components/animation-presence.mdx
@@ -54,14 +54,14 @@ const mountAnimation = keyframes\`
     opacity: 0;
   }
   to {
-    height: var(--wds-accordion-height);
+    height: var(--accordion-height);
     opacity: 1;
   }
 \`;
 
 const unmountAnimation = keyframes\`
   from {
-    height: var(--wds-accordion-height);
+    height: var(--accordion-height);
     opacity: 1;
   }
   to {

--- a/docs/data/utilities/web-utility-components/dismissable-layer.mdx
+++ b/docs/data/utilities/web-utility-components/dismissable-layer.mdx
@@ -10,7 +10,7 @@ children 컴포넌트 외 다른 영역을 클릭, 포커스, 혹은 esc keydown
 일반적으로는 사용하지 않으며 시스템 컴포넌트를 직접 구현할 때 사용합니다.
 
 - `@radix-ui/react-dismissable-layer` 컴포넌트를 re-export 하여 제공하고 있습니다.
-- `wds-ignore-dismissable-layer="true"` 속성을 가진 요소는 pointerdown, focus 이벤트를 하더라도 Dismiss처리하지 않습니다.
+- `data-ignore-dismissable-layer="true"` 속성을 가진 요소는 pointerdown, focus 이벤트를 하더라도 Dismiss처리하지 않습니다.
 - 모든 이벤트는 `preventDefault()` 를 통해 막을 수 있습니다.
 
 ## API

--- a/docs/data/utilities/web-utility-components/focus-scope.mdx
+++ b/docs/data/utilities/web-utility-components/focus-scope.mdx
@@ -10,7 +10,7 @@ children 컴포넌트 외 다른 영역을 포커스 할 수 없고 자동으로
 일반적으로 사용하지 않으며 직접 시스템 컴포넌트를 구현할 때 사용합니다.
 
 - `@radix-ui/react-focus-scope` 컴포넌트를 재구성하여 제공하고 있습니다.
-- `wds-ignore-first-focus="true"` 속성을 가진 요소는 첫 번째 포커스 이벤트에서 제외됩니다.
+- `data-ignore-first-focus="true"` 속성을 가진 요소는 첫 번째 포커스 이벤트에서 제외됩니다.
 
 ## API
 

--- a/docs/src/features/docs/components/foundations/icons/collections/style.ts
+++ b/docs/src/features/docs/components/foundations/icons/collections/style.ts
@@ -32,7 +32,7 @@ export const iconItemStyle = (theme: Theme) => css`
     box-shadow: inset 0 0 0 1px
       ${addOpacity(theme.semantic.primary.normal, theme.opacity[16])};
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       background-color: ${theme.semantic.primary.normal};
       opacity: 0.06;
     }

--- a/docs/src/features/docs/components/getting-started/resources/github-modal/style.ts
+++ b/docs/src/features/docs/components/getting-started/resources/github-modal/style.ts
@@ -30,7 +30,7 @@ export const modalDimmerStyle = css`
 `;
 
 export const modalContainerStyle = css`
-  --wds-modal-popup-border-radius: 32px;
+  --modal-popup-border-radius: 32px;
   min-width: unset;
   animation: ${mountKeyframes} 0.3s cubic-bezier(0.2, 0, 0, 1);
 

--- a/docs/src/features/docs/components/lnb/group/item/style.ts
+++ b/docs/src/features/docs/components/lnb/group/item/style.ts
@@ -4,19 +4,19 @@ import type { Theme } from '@montage-ui/core';
 
 export const lnbItemStyle = (theme: Theme) => css`
   && {
-    --wds-list-cell-horizontal-padding: 0px;
-    --wds-list-cell-vertical-padding: 7px;
+    --list-cell-horizontal-padding: 0px;
+    --list-cell-vertical-padding: 7px;
   }
 
   &[data-depth='0'] {
     && {
-      --wds-list-cell-vertical-padding: 8px;
+      --list-cell-vertical-padding: 8px;
     }
   }
 
   border-radius: 12px;
 
-  & > [wds-component='with-interaction'] {
+  & > [data-component='with-interaction'] {
     width: calc(100% + var(--lnb-padding) * 2);
   }
 
@@ -40,7 +40,7 @@ export const lnbItemStyle = (theme: Theme) => css`
         transform: translateX(0px);
       }
 
-      &[aria-current='page'] > [wds-component='with-interaction'] {
+      &[aria-current='page'] > [data-component='with-interaction'] {
         opacity: ${theme.opacity[5]};
       }
     }
@@ -56,12 +56,12 @@ export const lnbItemStyle = (theme: Theme) => css`
       color: ${theme.semantic.label.normal};
     }
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       opacity: 0.02;
     }
 
     &:active {
-      & > [wds-component='with-interaction'] {
+      & > [data-component='with-interaction'] {
         opacity: ${theme.opacity[12]};
       }
     }

--- a/docs/src/features/docs/components/lnb/mobile/index.tsx
+++ b/docs/src/features/docs/components/lnb/mobile/index.tsx
@@ -159,9 +159,7 @@ const LnbMobile = () => {
             {sentenceCase(previousFocusedCategory ?? '')}
           </Typography>
         </ModalNavigation>
-        <ModalContent
-          sx={{ '--wds-modal-content-margin': '24px', paddingTop: 0 }}
-        >
+        <ModalContent sx={{ '--modal-content-margin': '24px', paddingTop: 0 }}>
           <ModalContentItem>
             {focusedCategory !== null && (
               <Typography

--- a/docs/src/features/docs/components/lnb/mobile/style.ts
+++ b/docs/src/features/docs/components/lnb/mobile/style.ts
@@ -82,7 +82,7 @@ export const wrapperStyle = css`
 `;
 
 export const navigationStyle = (theme: Theme) => css`
-  --wds-top-navigation-padding-x: 24px;
+  --top-navigation-padding-x: 24px;
   position: relative;
   background-color: transparent;
   backdrop-filter: none;

--- a/docs/src/features/docs/components/mdx/mdx-render/constants.tsx
+++ b/docs/src/features/docs/components/mdx/mdx-render/constants.tsx
@@ -133,7 +133,7 @@ export const MDX_COMPONENTS: { [key: string]: (props: any) => ReactNode } = {
       data-role="table"
       sx={(theme) => ({
         marginBottom: 40,
-        '--wds-table-border-color': theme.semantic.line.solid.alternative,
+        '--table-border-color': theme.semantic.line.solid.alternative,
       })}
     />
   ),

--- a/docs/src/features/docs/components/mdx/props-table/index.tsx
+++ b/docs/src/features/docs/components/mdx/props-table/index.tsx
@@ -35,7 +35,7 @@ const PropsTable = ({ component, fallback }: Props) => {
       aria-label={`${component} props`}
       sx={(theme) => ({
         marginBottom: 40,
-        '--wds-table-border-color': theme.semantic.line.normal.neutral,
+        '--table-border-color': theme.semantic.line.normal.neutral,
       })}
     >
       <colgroup>

--- a/docs/src/features/docs/components/mdx/section/variants/style.ts
+++ b/docs/src/features/docs/components/mdx/section/variants/style.ts
@@ -47,7 +47,7 @@ export const sectionVariantsControlMobileTriggerStyle = (theme: Theme) => css`
   z-index: 1;
 
   &[aria-expanded='true'] {
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       opacity: 0.0375;
     }
   }

--- a/docs/src/features/docs/components/route-tab/style.ts
+++ b/docs/src/features/docs/components/route-tab/style.ts
@@ -7,7 +7,7 @@ export const tabScrollStyle = css`
 `;
 
 export const tabStyle = (theme: Theme) => css`
-  --wds-tab-padding-y: 16px;
+  --tab-padding-y: 16px;
 
   margin-bottom: 48px;
   position: sticky;

--- a/docs/src/features/home/components/faq/style.ts
+++ b/docs/src/features/home/components/faq/style.ts
@@ -4,9 +4,9 @@ import type { Theme } from '@montage-ui/core';
 
 export const accordionSummaryStyle = (theme: Theme) => css`
   && {
-    --wds-list-cell-vertical-padding: 28px;
-    --wds-list-cell-horizontal-padding: 0px;
-    --wds-list-cell-interaction-padding: 12px;
+    --list-cell-vertical-padding: 28px;
+    --list-cell-horizontal-padding: 0px;
+    --list-cell-interaction-padding: 12px;
   }
 
   border-radius: 0px;
@@ -15,10 +15,10 @@ export const accordionSummaryStyle = (theme: Theme) => css`
   @media (pointer: fine) {
     &:hover {
       ${respondMore('500px')} {
-        --wds-list-cell-horizontal-padding: 10px;
+        --list-cell-horizontal-padding: 10px;
       }
 
-      [wds-component='list-cell-content'] {
+      [data-component='list-cell-content'] {
         color: ${theme.semantic.label.normal};
       }
     }
@@ -26,11 +26,11 @@ export const accordionSummaryStyle = (theme: Theme) => css`
 
   ${respondTo(theme.breakpoint.md)} {
     && {
-      --wds-list-cell-vertical-padding: 28px;
+      --list-cell-vertical-padding: 28px;
     }
   }
 
-  [wds-component='list-cell-content'] {
+  [data-component='list-cell-content'] {
     color: ${theme.semantic.label.assistive};
     transition: color 0.3s ease;
   }

--- a/docs/src/features/layout/components/gnb/search-modal/index.tsx
+++ b/docs/src/features/layout/components/gnb/search-modal/index.tsx
@@ -86,8 +86,8 @@ export const DocSearchModal = ({
         aria-haspopup="listbox"
         style={
           {
-            '--wds-modal-content-margin': '16px',
-            '--wds-action-area-margin-y': '16px',
+            '--modal-content-margin': '16px',
+            '--action-area-margin-y': '16px',
           } as CSSProperties
         }
       >

--- a/docs/src/features/layout/components/gnb/search-modal/results/option/hit/style.ts
+++ b/docs/src/features/layout/components/gnb/search-modal/results/option/hit/style.ts
@@ -6,13 +6,13 @@ export const wrapperStyle = css`
   position: relative;
 
   &:hover:not(:active):not([aria-selected='true']) {
-    & > a > [wds-component='with-interaction'] {
+    & > a > [data-component='with-interaction'] {
       opacity: 0;
     }
   }
 
   &[aria-selected='true']:not(:active) {
-    & > a > [wds-component='with-interaction'] {
+    & > a > [data-component='with-interaction'] {
       opacity: 0.05;
     }
   }

--- a/docs/src/features/layout/components/gnb/search-modal/styles.ts
+++ b/docs/src/features/layout/components/gnb/search-modal/styles.ts
@@ -22,15 +22,15 @@ export const modalContainerStyle = (theme: Theme) => css`
 `;
 
 export const modalNavigationStyle = (theme: Theme) => css`
-  --wds-top-navigation-padding-x: 16px;
-  --wds-top-navigation-padding-y: 16px;
+  --top-navigation-padding-x: 16px;
+  --top-navigation-padding-y: 16px;
 
   [data-role='top-navigation-wrapper'] {
     gap: 0px;
   }
 
   ${respondTo(theme.breakpoint.sm)} {
-    --wds-top-navigation-padding-y: 12px;
+    --top-navigation-padding-y: 12px;
   }
 `;
 
@@ -48,8 +48,8 @@ export const searchFieldStyle = (theme: Theme) => css`
 `;
 
 export const actionAreaStyle = (theme: Theme) => css`
-  --wds-action-area-margin-x: 16px;
-  --wds-action-area-margin-y: 16px;
+  --action-area-margin-x: 16px;
+  --action-area-margin-y: 16px;
 
   background-color: ${addOpacity(
     theme.semantic.background.normal.normal,
@@ -59,7 +59,7 @@ export const actionAreaStyle = (theme: Theme) => css`
   border-top: 1px solid ${theme.semantic.line.normal.alternative};
 
   ${respondTo(theme.breakpoint.sm)} {
-    --wds-action-area-margin-x: 20px;
+    --action-area-margin-x: 20px;
   }
 `;
 

--- a/docs/src/features/layout/components/gnb/style.ts
+++ b/docs/src/features/layout/components/gnb/style.ts
@@ -66,13 +66,13 @@ export const gnbActionsStyle = (theme: Theme) => css`
   font-size: 22px;
   color: ${theme.semantic.label.normal};
 
-  & > [wds-component='with-interaction'] {
+  & > [data-component='with-interaction'] {
     width: calc(100% + 16px);
     height: calc(100% + 16px);
   }
 
   &[aria-expanded='true'] {
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       opacity: ${theme.opacity[8]};
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,12 +64,7 @@ export default defineConfig(
       'react/no-unknown-property': [
         'error',
         {
-          ignore: [
-            'wds-component',
-            'wds-ignore-first-focus',
-            'wds-ignore-dismissable-layer',
-            'css',
-          ],
+          ignore: ['css'],
         },
       ],
 

--- a/packages/codemod/src/cli.ts
+++ b/packages/codemod/src/cli.ts
@@ -1,10 +1,23 @@
 import path from 'path';
+import fs from 'fs';
 
 import inquirer from 'inquirer';
 import meow from 'meow';
 import execa from 'execa';
 
 import { MIGRATION_TRANSFORMS } from './constants';
+import { renameWdsVariablesInString } from './transforms/v4/css-variable-map';
+import { renameWdsDomIdentifiersInString } from './transforms/v4/dom-identifier-map';
+
+/**
+ * Transforms that also need to rewrite stylesheets, which jscodeshift cannot
+ * parse. Keyed by transform name; the value is the text rename applied to
+ * .css/.scss/.sass/.less files.
+ */
+const STYLE_TEXT_TRANSFORMS: Record<string, (source: string) => string> = {
+  'css-variable-migration': renameWdsVariablesInString,
+  'dom-identifier-migration': renameWdsDomIdentifiersInString,
+};
 
 export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift');
 export const transformerDirectory = path.join(__dirname, 'transforms');
@@ -102,6 +115,66 @@ const run = () => {
     });
 };
 
+const STYLE_EXTENSIONS = ['.css', '.scss', '.sass', '.less'];
+const IGNORED_DIRECTORIES = new Set(['node_modules', '.next', 'dist']);
+
+/**
+ * jscodeshift only parses JS/TS, so stylesheets are handled with a plain text
+ * pass that reuses the same rename rules. Walks files/directories passed on the
+ * CLI and rewrites every `--wds-*` token it finds.
+ */
+const collectStyleFiles = (target: string): Array<string> => {
+  let stat;
+
+  try {
+    stat = fs.statSync(target);
+  } catch {
+    return [];
+  }
+
+  if (stat.isFile()) {
+    return STYLE_EXTENSIONS.includes(path.extname(target)) ? [target] : [];
+  }
+
+  if (!stat.isDirectory()) {
+    return [];
+  }
+
+  return fs.readdirSync(target, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.isDirectory()) {
+      return IGNORED_DIRECTORIES.has(entry.name)
+        ? []
+        : collectStyleFiles(path.join(target, entry.name));
+    }
+
+    return STYLE_EXTENSIONS.includes(path.extname(entry.name))
+      ? [path.join(target, entry.name)]
+      : [];
+  });
+};
+
+const runStyleTextTransform = (
+  files: string,
+  rename: (source: string) => string,
+) => {
+  const targets = files.split(/\s+/).filter(Boolean).flatMap(collectStyleFiles);
+
+  let changed = 0;
+
+  for (const file of new Set(targets)) {
+    const source = fs.readFileSync(file, 'utf8');
+    const next = rename(source);
+
+    if (next !== source) {
+      fs.writeFileSync(file, next);
+      changed += 1;
+      console.log(`stylesheet updated: ${file}`);
+    }
+  }
+
+  console.log(`\nStylesheets updated: ${changed}`);
+};
+
 const runTransform = ({
   files,
   transformer,
@@ -132,6 +205,16 @@ const runTransform = ({
 
   if (result.failed) {
     throw new Error(`jscodeshift exited with code ${result.exitCode}`);
+  }
+
+  // Some transforms also rewrite stylesheets, which jscodeshift cannot parse —
+  // run the matching text pass over .css/.scss/.sass/.less files.
+  const styleRename = Object.entries(STYLE_TEXT_TRANSFORMS).find(([name]) =>
+    transformer.endsWith(name),
+  )?.[1];
+
+  if (styleRename) {
+    runStyleTextTransform(files, styleRename);
   }
 };
 

--- a/packages/codemod/src/constants.ts
+++ b/packages/codemod/src/constants.ts
@@ -44,5 +44,7 @@ export const MIGRATION_TRANSFORMS = {
   },
   v4: {
     'package-name-migration': 'Package Name Migration',
+    'css-variable-migration': 'CSS Variable Migration',
+    'dom-identifier-migration': 'DOM Identifier Migration',
   },
 };

--- a/packages/codemod/src/transforms/v4/css-variable-map.ts
+++ b/packages/codemod/src/transforms/v4/css-variable-map.ts
@@ -1,0 +1,128 @@
+/**
+ * Single source of truth for the `--wds-*` → unprefixed CSS variable rename
+ * shipped in Montage 4.0.0.
+ *
+ * The library (`@montage-ui/core`) and this codemod share these rules so the
+ * renamed variables stay in sync. The same map is also used to generate the
+ * one-off `sed` rules that rewrite the library source.
+ *
+ * Rename rule:
+ * - Default: strip the `--wds-` brand prefix (`--wds-modal-translate` → `--modal-translate`).
+ *   Every variable already carries its component name, so the result stays scoped.
+ * - Exceptions: a handful of variables whose names become too generic once the
+ *   prefix is stripped (and would collide with user-defined variables). These get
+ *   an explicit component-scoped name instead.
+ */
+
+/**
+ * Variables whose stripped name would be too generic and risk colliding with a
+ * consumer's own CSS variables. Renamed with an explicit component scope.
+ */
+export const CSS_VARIABLE_EXCEPTIONS: Record<string, string> = {
+  '--wds-column-spacing': '--grid-column-spacing',
+  '--wds-row-spacing': '--grid-row-spacing',
+};
+
+/**
+ * All `--wds-*` CSS variables exposed by the library as of 3.x. Used to validate
+ * the rename map and to document the migration surface. Keep in sync with the
+ * library source.
+ */
+export const KNOWN_WDS_VARIABLES: ReadonlyArray<string> = [
+  '--wds-accordion-height',
+  '--wds-accordion-overflow',
+  '--wds-action-area-extra-content-margin',
+  '--wds-action-area-margin',
+  '--wds-action-area-margin-x',
+  '--wds-action-area-margin-y',
+  '--wds-card-content-item-bottom-position-margin-top',
+  '--wds-card-content-item-top-position-margin-bottom',
+  '--wds-card-content-item-top-position-margin-top',
+  '--wds-card-thumbnail-content-z-index',
+  '--wds-card-thumbnail-overlay-z-index',
+  '--wds-category-icon-button-padding',
+  '--wds-category-list-padding',
+  '--wds-column-spacing',
+  '--wds-fallback-view-bottom-space',
+  '--wds-framed-style-border-radius',
+  '--wds-framed-style-horizontal-padding',
+  '--wds-framed-style-vertical-padding',
+  '--wds-icon-button-inset',
+  '--wds-list-cell-horizontal-padding',
+  '--wds-list-cell-interaction-display',
+  '--wds-list-cell-interaction-padding',
+  '--wds-list-cell-vertical-padding',
+  '--wds-modal-content-margin',
+  '--wds-modal-default-max-height',
+  '--wds-modal-grabber-height-guard',
+  '--wds-modal-max-height',
+  '--wds-modal-popup-border-radius',
+  '--wds-modal-translate',
+  '--wds-pagination-dot-border-color',
+  '--wds-pagination-dot-size',
+  '--wds-progress-indicator-transform',
+  '--wds-push-badge-offset-x',
+  '--wds-push-badge-offset-y',
+  '--wds-region-viewport-bottom',
+  '--wds-region-viewport-max-width',
+  '--wds-row-spacing',
+  '--wds-snackbar-animation-height',
+  '--wds-snackbar-animation-margin-top',
+  '--wds-switch-padding',
+  '--wds-switch-thumb-size',
+  '--wds-switch-width',
+  '--wds-tab-icon-button-padding',
+  '--wds-tab-list-active-divider-color',
+  '--wds-tab-list-disabled-divider-color',
+  '--wds-tab-list-divider-color',
+  '--wds-tab-list-item-flex',
+  '--wds-tab-list-item-overflow',
+  '--wds-tab-list-item-text-align',
+  '--wds-tab-list-item-text-display',
+  '--wds-tab-list-padding',
+  '--wds-tab-padding-x',
+  '--wds-tab-padding-y',
+  '--wds-table-border-color',
+  '--wds-table-cell-min-height',
+  '--wds-table-cell-padding-x',
+  '--wds-table-cell-padding-y',
+  '--wds-table-head-cell-min-height',
+  '--wds-table-head-cell-padding-x',
+  '--wds-table-head-cell-padding-y',
+  '--wds-text-area-height',
+  '--wds-text-area-scroll-height',
+  '--wds-toast-animation-height',
+  '--wds-toast-animation-margin-top',
+  '--wds-top-navigation-min-height',
+  '--wds-top-navigation-padding',
+  '--wds-top-navigation-padding-x',
+  '--wds-top-navigation-padding-y',
+  '--wds-top-navigation-title-width',
+];
+
+/** Matches a single `--wds-*` CSS custom property token. */
+export const WDS_VARIABLE_PATTERN = /--wds-[a-z0-9-]+/g;
+
+/** Renames a single `--wds-*` token to its 4.0 name. */
+export const renameWdsVariable = (token: string): string => {
+  return CSS_VARIABLE_EXCEPTIONS[token] ?? token.replace(/^--wds-/, '--');
+};
+
+/**
+ * Rewrites every `--wds-*` token inside an arbitrary string (CSS text, a
+ * `var(...)` reference, an inline-style key, etc.). Returns the input unchanged
+ * when no token is present.
+ */
+export const renameWdsVariablesInString = (input: string): string => {
+  return input.replace(WDS_VARIABLE_PATTERN, (token) =>
+    renameWdsVariable(token),
+  );
+};
+
+/**
+ * Fully expanded old → new map for the known 3.x variables. Useful for
+ * validation, documentation, and generating the library `sed` rules.
+ */
+export const CSS_VARIABLE_MAP: Record<string, string> = Object.fromEntries(
+  KNOWN_WDS_VARIABLES.map((name) => [name, renameWdsVariable(name)]),
+);

--- a/packages/codemod/src/transforms/v4/css-variable-migration.ts
+++ b/packages/codemod/src/transforms/v4/css-variable-migration.ts
@@ -1,0 +1,76 @@
+import {
+  WDS_VARIABLE_PATTERN,
+  renameWdsVariablesInString,
+} from './css-variable-map';
+
+import type { API, FileInfo, Options } from 'jscodeshift';
+
+const hasWdsVariable = (value: string) => {
+  WDS_VARIABLE_PATTERN.lastIndex = 0;
+  return WDS_VARIABLE_PATTERN.test(value);
+};
+
+/**
+ * Renames every `--wds-*` CSS variable to its Montage 4.0 name across:
+ * - string literals: inline-style keys (`'--wds-x'`), `var(--wds-x)` values,
+ *   and any other string carrying the token
+ * - template literals: `css\`\`` / `styled\`\`` blocks and dynamic style strings
+ *
+ * The token is matched by the `--wds-` prefix, so the transform is independent
+ * of how the string is used and never touches non-Montage variables.
+ */
+const transformer = (file: FileInfo, api: API, options: Options) => {
+  const j = api.jscodeshift.withParser('tsx');
+  const root = j(file.source);
+
+  let hasChanges = false;
+
+  // String literals — inline style keys/values, `var(...)` refs, etc.
+  root.find(j.StringLiteral).forEach((path) => {
+    const { value } = path.node;
+
+    if (typeof value === 'string' && hasWdsVariable(value)) {
+      const next = renameWdsVariablesInString(value);
+
+      if (next !== value) {
+        path.node.value = next;
+        // Drop the cached raw source so the printer regenerates the literal
+        // from `value` (otherwise the stale raw is emitted unchanged).
+        delete (path.node as { extra?: unknown }).extra;
+        hasChanges = true;
+      }
+    }
+  });
+
+  // Template literal chunks — `css\`\`` / `styled\`\`` and dynamic style strings.
+  root.find(j.TemplateElement).forEach((path) => {
+    const { raw, cooked } = path.node.value;
+
+    if (typeof raw === 'string' && hasWdsVariable(raw)) {
+      const nextRaw = renameWdsVariablesInString(raw);
+
+      if (nextRaw !== raw) {
+        path.node.value.raw = nextRaw;
+
+        if (typeof cooked === 'string') {
+          path.node.value.cooked = renameWdsVariablesInString(cooked);
+        }
+
+        hasChanges = true;
+      }
+    }
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!hasChanges) {
+    return file.source;
+  }
+
+  // Reprinted literals pick recast's quote option. Use 'auto' so each literal
+  // keeps the quote style needing the least escaping — selector strings like
+  // `'[data-component="x"]'` must stay single-quoted instead of being reprinted
+  // as `"[data-component=\"x\"]"`.
+  return root.toSource({ quote: 'auto', ...options });
+};
+
+export default transformer;

--- a/packages/codemod/src/transforms/v4/dom-identifier-map.ts
+++ b/packages/codemod/src/transforms/v4/dom-identifier-map.ts
@@ -1,0 +1,44 @@
+/**
+ * Single source of truth for the `wds-*` DOM identifier renames shipped in
+ * Montage 4.0.0 — marker attributes and portal container ids that consumers may
+ * reference via CSS attribute selectors, `querySelector`, or `closest`.
+ *
+ * Rename strategy:
+ * - Marker / behavior-control attributes are normalized to the standard `data-`
+ *   prefix.
+ * - Global element ids keep a brand prefix (`montage-`) to avoid collisions.
+ *
+ * Note: `wds-pagination-dot` is intentionally omitted — it is an internal React
+ * `key`, never rendered to the DOM, so it is not part of the consumer surface.
+ */
+export const DOM_IDENTIFIER_MAP: Record<string, string> = {
+  'wds-component': 'data-component',
+  'wds-ignore-first-focus': 'data-ignore-first-focus',
+  'wds-ignore-dismissable-layer': 'data-ignore-dismissable-layer',
+  // Covers `wds-region-manager` and `wds-region-manager-bottom`.
+  'wds-region-manager': 'montage-region-manager',
+};
+
+/** Matches any `wds-*` DOM identifier token handled by the map. */
+export const WDS_DOM_IDENTIFIER_PATTERN = new RegExp(
+  Object.keys(DOM_IDENTIFIER_MAP).join('|'),
+);
+
+/**
+ * Rewrites every known `wds-*` DOM identifier inside an arbitrary string —
+ * attribute selectors (`[wds-component='x']`), id selectors
+ * (`#wds-region-manager-bottom`), and raw attribute names. Returns the input
+ * unchanged when no identifier is present.
+ *
+ * The map keys all start with `wds-` and the replacements never do, so applying
+ * the substitutions in sequence is safe and idempotent.
+ */
+export const renameWdsDomIdentifiersInString = (input: string): string => {
+  let output = input;
+
+  for (const [oldId, newId] of Object.entries(DOM_IDENTIFIER_MAP)) {
+    output = output.split(oldId).join(newId);
+  }
+
+  return output;
+};

--- a/packages/codemod/src/transforms/v4/dom-identifier-migration.ts
+++ b/packages/codemod/src/transforms/v4/dom-identifier-migration.ts
@@ -1,0 +1,86 @@
+import {
+  DOM_IDENTIFIER_MAP,
+  WDS_DOM_IDENTIFIER_PATTERN,
+  renameWdsDomIdentifiersInString,
+} from './dom-identifier-map';
+
+import type { API, FileInfo, Options } from 'jscodeshift';
+
+const hasDomIdentifier = (value: string) =>
+  WDS_DOM_IDENTIFIER_PATTERN.test(value);
+
+/**
+ * Renames `wds-*` DOM identifiers to their Montage 4.0 names across:
+ * - string literals: CSS attribute/id selectors passed to `styled`/`querySelector`,
+ *   `closest`, `classList`, etc.
+ * - template literals: `css\`\`` / `styled\`\`` selector blocks
+ * - JSX attribute names: the rare case a consumer sets `wds-component` directly
+ *
+ * Stylesheets (.css/.scss/...) are handled separately by the CLI text pass.
+ */
+const transformer = (file: FileInfo, api: API, options: Options) => {
+  const j = api.jscodeshift.withParser('tsx');
+  const root = j(file.source);
+
+  let hasChanges = false;
+
+  // String literals — selectors in querySelector/closest/styled, etc.
+  root.find(j.StringLiteral).forEach((path) => {
+    const { value } = path.node;
+
+    if (typeof value === 'string' && hasDomIdentifier(value)) {
+      const next = renameWdsDomIdentifiersInString(value);
+
+      if (next !== value) {
+        path.node.value = next;
+        delete (path.node as { extra?: unknown }).extra;
+        hasChanges = true;
+      }
+    }
+  });
+
+  // Template literal chunks — selector blocks in `css\`\``/`styled\`\``.
+  root.find(j.TemplateElement).forEach((path) => {
+    const { raw, cooked } = path.node.value;
+
+    if (typeof raw === 'string' && hasDomIdentifier(raw)) {
+      const nextRaw = renameWdsDomIdentifiersInString(raw);
+
+      if (nextRaw !== raw) {
+        path.node.value.raw = nextRaw;
+
+        if (typeof cooked === 'string') {
+          path.node.value.cooked = renameWdsDomIdentifiersInString(cooked);
+        }
+
+        hasChanges = true;
+      }
+    }
+  });
+
+  // JSX attribute names — e.g. `<div wds-component="x" />`.
+  root.find(j.JSXAttribute).forEach((path) => {
+    const { name } = path.node;
+
+    if (
+      name.type === 'JSXIdentifier' &&
+      Object.prototype.hasOwnProperty.call(DOM_IDENTIFIER_MAP, name.name)
+    ) {
+      name.name = DOM_IDENTIFIER_MAP[name.name]!;
+      hasChanges = true;
+    }
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!hasChanges) {
+    return file.source;
+  }
+
+  // Reprinted literals pick recast's quote option. Use 'auto' so each literal
+  // keeps the quote style needing the least escaping — selector strings like
+  // `'[data-component="x"]'` must stay single-quoted instead of being reprinted
+  // as `"[data-component=\"x\"]"`.
+  return root.toSource({ quote: 'auto', ...options });
+};
+
+export default transformer;

--- a/packages/core/src/components/accordion/index.tsx
+++ b/packages/core/src/components/accordion/index.tsx
@@ -141,7 +141,7 @@ const AccordionSummary = forwardRef<
     return (
       <ListCell
         ref={ref}
-        wds-component="accordion-summary"
+        data-component="accordion-summary"
         as="div"
         role="button"
         verticalPadding={verticalPadding}
@@ -258,7 +258,7 @@ const AccordionDetails = forwardRef(
           const currentTabIndex = elm.getAttribute('tabindex');
           const prevTabIndex = elm.getAttribute('data-prev-tabindex');
 
-          const details = elm.closest('[wds-component="accordion-details"]');
+          const details = elm.closest('[data-component="accordion-details"]');
 
           if (details !== ref.current) {
             return;
@@ -288,7 +288,7 @@ const AccordionDetails = forwardRef(
       <AnimationPresence present={expanded || forceMount}>
         <Box
           ref={composedRefs}
-          wds-component="accordion-details"
+          data-component="accordion-details"
           aria-labelledby={summaryId}
           aria-hidden={!expanded}
           id={detailsId}
@@ -303,7 +303,7 @@ const AccordionDetails = forwardRef(
           ]}
           style={
             {
-              '--wds-accordion-height': `${height}px`,
+              '--accordion-height': `${height}px`,
               ...props.style,
             } as CSSProperties
           }
@@ -348,7 +348,7 @@ const AccordionContent = forwardRef(
   ) => {
     return (
       <Box
-        wds-component="accordion-content"
+        data-component="accordion-content"
         ref={ref}
         {...props}
         sx={[accordionContentStyle, sx]}

--- a/packages/core/src/components/accordion/style.ts
+++ b/packages/core/src/components/accordion/style.ts
@@ -88,7 +88,7 @@ export const accordionSummaryContentStyle = ({
     }
   `}
 
-  [wds-component='icon-button'] {
+  [data-component='icon-button'] {
     width: 100%;
     height: 100%;
   }
@@ -116,15 +116,15 @@ const mountKeyframes = keyframes`
     overflow: hidden;
   }
   to {
-    height: var(--wds-accordion-height);
-    overflow: var(--wds-accordion-overflow);
+    height: var(--accordion-height);
+    overflow: var(--accordion-overflow);
   }
 `;
 
 const unmountKeyframes = keyframes`
   from {
-    height: var(--wds-accordion-height);
-    overflow: var(--wds-accordion-overflow);
+    height: var(--accordion-height);
+    overflow: var(--accordion-overflow);
   }
 
   to {
@@ -163,10 +163,10 @@ export const accordionDetailsStyle = ({
 
 export const accordionDetailsWrapperStyle = css`
   flex-direction: column;
-  padding-top: calc(16px - var(--wds-list-cell-vertical-padding, 16px));
-  padding-bottom: var(--wds-list-cell-vertical-padding, 16px);
-  padding-left: calc(var(--wds-list-cell-horizontal-padding, 0px));
-  padding-right: calc(var(--wds-list-cell-horizontal-padding, 0px));
+  padding-top: calc(16px - var(--list-cell-vertical-padding, 16px));
+  padding-bottom: var(--list-cell-vertical-padding, 16px);
+  padding-left: calc(var(--list-cell-horizontal-padding, 0px));
+  padding-right: calc(var(--list-cell-horizontal-padding, 0px));
 `;
 
 export const accordionDividerStyle = ({
@@ -175,7 +175,7 @@ export const accordionDividerStyle = ({
   disableAnimation: boolean;
 }) => css`
   margin: 0 auto;
-  width: calc(100% - (var(--wds-list-cell-horizontal-padding, 0px) * 2));
+  width: calc(100% - (var(--list-cell-horizontal-padding, 0px) * 2));
   will-change: opacity;
 
   ${!disableAnimation &&
@@ -185,5 +185,5 @@ export const accordionDividerStyle = ({
 `;
 
 export const accordionContentStyle = css`
-  margin-top: var(--wds-list-cell-vertical-padding, 16px);
+  margin-top: var(--list-cell-vertical-padding, 16px);
 `;

--- a/packages/core/src/components/action-area/index.tsx
+++ b/packages/core/src/components/action-area/index.tsx
@@ -44,7 +44,7 @@ const ActionArea = forwardRef<
     return (
       <ActionAreaProvider variant={variant}>
         <FlexBox
-          wds-component="action-area"
+          data-component="action-area"
           ref={ref}
           flexShrink={0}
           flexDirection="column"
@@ -65,8 +65,7 @@ const ActionArea = forwardRef<
               alignItems="center"
               data-role="action-area-extra-content"
               sx={{
-                marginBottom:
-                  'calc(4px + var(--wds-action-area-margin-y, 20px))',
+                marginBottom: 'calc(4px + var(--action-area-margin-y, 20px))',
               }}
             >
               {extraContent}

--- a/packages/core/src/components/action-area/style.ts
+++ b/packages/core/src/components/action-area/style.ts
@@ -9,8 +9,7 @@ export const actionAreaStyle =
   ({ divider, background, extra }: ActionAreaProps) =>
   (theme: Theme) => css`
     width: 100%;
-    padding: var(--wds-action-area-margin-y, 20px)
-      var(--wds-action-area-margin-x, 20px);
+    padding: var(--action-area-margin-y, 20px) var(--action-area-margin-x, 20px);
     position: relative;
 
     ${actionAreaBackgroundStyle({ divider, background, extra }, theme)}
@@ -39,10 +38,10 @@ const actionAreaBackgroundStyle = (
                 ${gradient(
                   theme.semantic.background.elevated.normal,
                   'top',
-                  'calc(var(--wds-action-area-margin-y, 20px) * 2)',
+                  'calc(var(--action-area-margin-y, 20px) * 2)',
                   'mask',
                 )}
-                height: calc(100% + var(--wds-action-area-margin-y, 20px));
+                height: calc(100% + var(--action-area-margin-y, 20px));
                 content: '';
                 z-index: 0;
                 position: absolute;

--- a/packages/core/src/components/alert/index.tsx
+++ b/packages/core/src/components/alert/index.tsx
@@ -112,7 +112,7 @@ const AlertDimmer = forwardRef(
         ref={composeRefs(ref, dimmerRef as ForwardedRef<T>)}
         as={(as || 'div') as T}
         {...props}
-        wds-ignore-dismissable-layer="true"
+        data-ignore-dismissable-layer="true"
         data-role="alert-dimmer"
         data-status={open ? 'open' : 'close'}
         onClick={composeEventHandlers(
@@ -227,7 +227,7 @@ const AlertContainer = forwardRef(
           <FlexBox
             {...wrapperProps}
             sx={[alertWrapperStyle, wrapperProps?.sx]}
-            wds-ignore-dismissable-layer="true"
+            data-ignore-dismissable-layer="true"
           >
             {dimmer}
 
@@ -318,7 +318,7 @@ const AlertHeading = forwardRef<
 
   return (
     <Typography
-      wds-component="alert-title"
+      data-component="alert-title"
       variant="headline1"
       weight="bold"
       color="semantic.label.normal"
@@ -345,7 +345,7 @@ const AlertDescription = forwardRef<
       variant="body2"
       weight="regular"
       color="semantic.label.alternative"
-      wds-component="alert-description"
+      data-component="alert-description"
       ref={ref}
       as="p"
       id={descriptionId}
@@ -373,7 +373,7 @@ const AlertActionArea = forwardRef<
     <FlexBox
       flexDirection="row"
       alignItems="center"
-      wds-component="alert-action-area"
+      data-component="alert-action-area"
       justifyContent="flex-end"
       gap="24px"
       ref={ref}
@@ -411,7 +411,7 @@ const AlertActionAreaButton = forwardRef(
             ? [
                 (theme) => ({
                   color: getColorByToken(theme, 'semantic.status.negative'),
-                  ['[wds-component="with-interaction"]']: {
+                  ['[data-component="with-interaction"]']: {
                     backgroundColor: getColorByToken(
                       theme,
                       'semantic.status.negative',

--- a/packages/core/src/components/autocomplete/style.ts
+++ b/packages/core/src/components/autocomplete/style.ts
@@ -46,11 +46,11 @@ export const autocompleteOptionStyle = (theme: Theme) => css`
     color: ${theme.semantic.primary.normal};
   }
 
-  &[data-focus='true'] > [wds-component='with-interaction'] {
+  &[data-focus='true'] > [data-component='with-interaction'] {
     opacity: ${theme.opacity[0]};
   }
 
-  &[data-focus-visible='true'] > [wds-component='with-interaction'] {
+  &[data-focus-visible='true'] > [data-component='with-interaction'] {
     opacity: 0.06;
   }
 `;

--- a/packages/core/src/components/avatar-button/style.ts
+++ b/packages/core/src/components/avatar-button/style.ts
@@ -16,7 +16,7 @@ export const avatarButtonStyle = (theme: Theme) => css`
   &:focus-visible {
     outline: none;
 
-    [wds-component='avatar'] {
+    [data-component='avatar'] {
       &::before {
         content: '';
         position: absolute;
@@ -35,7 +35,7 @@ export const avatarButtonStyle = (theme: Theme) => css`
   }
 
   &[aria-expanded='true'] {
-    [wds-component='with-interaction'] {
+    [data-component='with-interaction'] {
       ${activeInteractionStyle(theme)}
     }
   }

--- a/packages/core/src/components/avatar-group/style.ts
+++ b/packages/core/src/components/avatar-group/style.ts
@@ -16,7 +16,7 @@ export const avatarGroupStyle =
 
     ${avatarGroupSizeStyle(size)}
 
-    [wds-component='avatar'] {
+    [data-component='avatar'] {
       flex-shrink: 0;
       position: relative;
 
@@ -50,7 +50,7 @@ const avatarGroupSizeStyle = (size: AvatarGroupProps['size']) => {
     case 'small':
       return css`
         gap: 10px;
-        [wds-component='avatar'] {
+        [data-component='avatar'] {
           margin-left: -8px;
 
           &:last-child {
@@ -61,7 +61,7 @@ const avatarGroupSizeStyle = (size: AvatarGroupProps['size']) => {
     case 'xsmall':
       return css`
         gap: 8px;
-        [wds-component='avatar'] {
+        [data-component='avatar'] {
           margin-left: -6px;
 
           &:last-child {

--- a/packages/core/src/components/avatar/index.test.tsx
+++ b/packages/core/src/components/avatar/index.test.tsx
@@ -13,7 +13,7 @@ describe('when given avatar component', () => {
   it('should render fallback when src is absent and render image after src is provided', () => {
     const { container, rerender } = render(<Avatar />);
 
-    const root = container.querySelector('[wds-component="avatar"]')!;
+    const root = container.querySelector('[data-component="avatar"]')!;
     expect(root).toHaveAttribute('data-state', 'idle');
     expect(container.querySelector('img')).not.toBeInTheDocument();
     expect(
@@ -47,7 +47,7 @@ describe('when given avatar component', () => {
 
     const { container, rerender } = render(<Avatar src="/broken.png" />);
 
-    const root = container.querySelector('[wds-component="avatar"]')!;
+    const root = container.querySelector('[data-component="avatar"]')!;
 
     // img first, then effect rejects and Avatar switches to fallback
     expect(container.querySelector('img')).toBeInTheDocument();

--- a/packages/core/src/components/avatar/index.tsx
+++ b/packages/core/src/components/avatar/index.tsx
@@ -59,7 +59,7 @@ const Avatar = forwardRef<
       <Box
         ref={ref}
         className={className}
-        wds-component="avatar"
+        data-component="avatar"
         sx={[avatarWrapperStyle({ size, variant, xs, sm, md, lg, xl }), sx]}
         data-state={imageLoadingStatus}
         style={style}

--- a/packages/core/src/components/avatar/style.ts
+++ b/packages/core/src/components/avatar/style.ts
@@ -82,8 +82,8 @@ const avatarSizeStyle = (
         return css`
           border-radius: 9999px;
 
-          & > [wds-component='with-interaction'],
-          & + [wds-component='with-interaction'] {
+          & > [data-component='with-interaction'],
+          & + [data-component='with-interaction'] {
             border-radius: 9999px;
           }
         `;
@@ -92,8 +92,8 @@ const avatarSizeStyle = (
         return css`
           border-radius: ${rounded}px;
 
-          & > [wds-component='with-interaction'],
-          & + [wds-component='with-interaction'] {
+          & > [data-component='with-interaction'],
+          & + [data-component='with-interaction'] {
             border-radius: ${rounded + 8}px;
           }
 

--- a/packages/core/src/components/bottom-navigation/index.tsx
+++ b/packages/core/src/components/bottom-navigation/index.tsx
@@ -69,7 +69,7 @@ const BottomNavigation = forwardRef(
           ref={ref}
           alignItems="center"
           {...props}
-          wds-component="bottom-navigation"
+          data-component="bottom-navigation"
           data-scroll-end={scrollEnd}
           sx={[bottomNavigationStyle, props.sx]}
         >
@@ -109,7 +109,7 @@ const BottomNavigationItem = forwardRef<any, BottomNavigationItemProps>(
           alignItems="center"
           justifyContent="center"
           flexDirection="column"
-          wds-component="bottom-navigation-item"
+          data-component="bottom-navigation-item"
           aria-current={isActive ? 'page' : undefined}
           aria-labelledby={id}
           sx={[bottomNavigationItemStyle, props.sx]}

--- a/packages/core/src/components/button/style.ts
+++ b/packages/core/src/components/button/style.ts
@@ -36,7 +36,7 @@ export const buttonStyle =
       cursor: wait;
       &
         > *:not([data-role='button-loading']):not(
-          [wds-component='with-interaction']
+          [data-component='with-interaction']
         ) {
         visibility: hidden;
       }

--- a/packages/core/src/components/card-list/style.ts
+++ b/packages/core/src/components/card-list/style.ts
@@ -17,15 +17,15 @@ const cardListPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
         gap: 16px;
 
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 120px;
         }
         // text
-        [wds-component='card-title'] {
+        [data-component='card-title'] {
           ${typographyStyle('body1', 'bold')}
         }
-        [wds-component='card-caption'] {
+        [data-component='card-caption'] {
           ${typographyStyle('label2', 'medium')}
         }
       `;
@@ -34,15 +34,15 @@ const cardListPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
         gap: 12px;
 
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 96px;
         }
         // text
-        [wds-component='card-title'] {
+        [data-component='card-title'] {
           ${typographyStyle('body2', 'bold')}
         }
-        [wds-component='card-caption'] {
+        [data-component='card-caption'] {
           ${typographyStyle('label2', 'medium')}
         }
       `;
@@ -57,21 +57,21 @@ export const cardListStyle =
     ${cardListPlatformStyle({ platform })}
 
     &:hover {
-      [wds-component='thumbnail'] img {
+      [data-component='thumbnail'] img {
         transform: scale(1.025);
       }
     }
 
     // thumbnail
-    [wds-component='thumbnail'],
-    [wds-component='thumbnail-skeleton'] {
+    [data-component='thumbnail'],
+    [data-component='thumbnail-skeleton'] {
       aspect-ratio: 3 / 2;
     }
     // text
-    [wds-component='card-title'] {
+    [data-component='card-title'] {
       ${ellipsisTypographyStyle(1)}
     }
-    [wds-component='card-caption'] {
+    [data-component='card-caption'] {
       ${ellipsisTypographyStyle(1)}
     }
 
@@ -112,12 +112,12 @@ const cardListSkeletonPlatformStyle = ({
         padding-right: ${hasTrailingContent ? '40px' : '0'};
 
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 120px;
         }
         // skeleton
-        [wds-component='card-title-skeleton'] {
+        [data-component='card-title-skeleton'] {
           width: 75%;
           height: 24px;
         }
@@ -129,12 +129,12 @@ const cardListSkeletonPlatformStyle = ({
         padding-right: ${hasTrailingContent ? '36px' : '0'};
 
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 96px;
         }
         // skeleton
-        [wds-component='card-title-skeleton'] {
+        [data-component='card-title-skeleton'] {
           width: 75%;
           height: 22px;
         }
@@ -165,7 +165,7 @@ export const cardListSkeletonStyle =
     })}
 
     // thumbnail
-    [wds-component='thumbnail'], [wds-component='thumbnail-skeleton'] {
+    [data-component='thumbnail'], [data-component='thumbnail-skeleton'] {
       aspect-ratio: 3 / 2;
     }
 

--- a/packages/core/src/components/card/index.tsx
+++ b/packages/core/src/components/card/index.tsx
@@ -194,7 +194,7 @@ const CardContent = forwardRef(
   ) => {
     return (
       <FlexBox
-        wds-component="card-content"
+        data-component="card-content"
         ref={ref}
         flexDirection="column"
         flex="1"
@@ -221,7 +221,7 @@ const CardContentItem = forwardRef(
     return (
       <FlexBox
         ref={ref}
-        wds-component="card-content-item"
+        data-component="card-content-item"
         {...props}
         sx={[cardContentItemStyle({ position, variant }), sx]}
       />
@@ -251,7 +251,7 @@ const CardTitle = forwardRef(
       <Typography
         as={as ?? 'p'}
         ref={ref}
-        wds-component="card-title"
+        data-component="card-title"
         {...props}
         sx={[
           cardTitleStyle({ variant, weight, color, xs, sm, md, lg, xl }),
@@ -284,7 +284,7 @@ const CardCaption = forwardRef(
       <Typography
         ref={ref}
         as={as ?? 'p'}
-        wds-component="card-caption"
+        data-component="card-caption"
         {...props}
         sx={[
           cardCaptionStyle({ variant, weight, color, xs, sm, md, lg, xl }),
@@ -364,7 +364,7 @@ const CardContentItemSkeleton = forwardRef(
     return (
       <Skeleton
         ref={ref}
-        wds-component="card-content-item-skeleton"
+        data-component="card-content-item-skeleton"
         variant="rectangle"
         radius="3px"
         width={width}
@@ -394,7 +394,7 @@ const CardTitleSkeleton = forwardRef(
     return (
       <Skeleton
         ref={ref}
-        wds-component="card-title-skeleton"
+        data-component="card-title-skeleton"
         {...props}
         sx={[
           cardTitleSkeletonStyle({ width, height, xs, sm, md, lg, xl }),
@@ -436,7 +436,7 @@ const CardCaptionSkeleton = forwardRef(
       <Skeleton
         ref={ref}
         data-type={type}
-        wds-component="card-caption-skeleton"
+        data-component="card-caption-skeleton"
         width={width}
         height={height}
         {...props}

--- a/packages/core/src/components/card/style.ts
+++ b/packages/core/src/components/card/style.ts
@@ -25,13 +25,13 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
     case 'desktop':
       return css`
         gap: 8px;
-        --wds-card-content-item-top-position-margin-top: 2px;
-        --wds-card-content-item-top-position-margin-bottom: 4px;
+        --card-content-item-top-position-margin-top: 2px;
+        --card-content-item-top-position-margin-bottom: 4px;
 
-        --wds-card-content-item-bottom-position-margin-top: 8px;
+        --card-content-item-bottom-position-margin-top: 8px;
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 100%;
           aspect-ratio: 3 / 2;
         }
@@ -50,14 +50,14 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
           }
         }
         // content
-        [wds-component='card-content'] {
+        [data-component='card-content'] {
           padding: 0 6px;
         }
         // text
-        [wds-component='card-title'] {
+        [data-component='card-title'] {
           ${typographyStyle('body1', 'bold')}
         }
-        [wds-component='card-caption'] {
+        [data-component='card-caption'] {
           ${typographyStyle('label2', 'medium')}
         }
       `;
@@ -66,13 +66,13 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
       return css`
         gap: 6px;
 
-        --wds-card-content-item-top-position-margin-top: 2px;
-        --wds-card-content-item-top-position-margin-bottom: 4px;
+        --card-content-item-top-position-margin-top: 2px;
+        --card-content-item-top-position-margin-bottom: 4px;
 
-        --wds-card-content-item-bottom-position-margin-top: 6px;
+        --card-content-item-bottom-position-margin-top: 6px;
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 100%;
           aspect-ratio: 4 / 3;
         }
@@ -91,14 +91,14 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
           }
         }
         // content
-        [wds-component='card-content'] {
+        [data-component='card-content'] {
           padding: 0 2px;
         }
         // text
-        [wds-component='card-title'] {
+        [data-component='card-title'] {
           ${typographyStyle('body2', 'bold')}
         }
-        [wds-component='card-caption'] {
+        [data-component='card-caption'] {
           ${typographyStyle('label2', 'medium')}
         }
       `;
@@ -108,21 +108,21 @@ const cardPlatformStyle = ({ platform }: Pick<CardProps, 'platform'>) => {
 export const cardStyle =
   ({ xs, sm, md, lg, xl, width, platform }: CardProps) =>
   (theme: Theme) => css`
-    --wds-card-thumbnail-overlay-z-index: 1;
-    --wds-card-thumbnail-content-z-index: 2;
+    --card-thumbnail-overlay-z-index: 1;
+    --card-thumbnail-content-z-index: 2;
 
     width: ${toCssValue(width) ?? '100%'};
     ${cardPlatformStyle({ platform })}
 
     &:hover {
-      [wds-component='thumbnail'] img {
+      [data-component='thumbnail'] img {
         transform: scale(1.025);
       }
     }
 
     // thumbnail
-    [wds-component='thumbnail'],
-    [wds-component='thumbnail-skeleton'] {
+    [data-component='thumbnail'],
+    [data-component='thumbnail-skeleton'] {
       width: 100%;
     }
 
@@ -152,8 +152,8 @@ const cardThumbnailRatioStyle = ({
   const parsedRatio = `${width} / ${height}`;
 
   return css`
-    & [wds-component='thumbnail'],
-    &[wds-component='thumbnail-skeleton'] {
+    & [data-component='thumbnail'],
+    &[data-component='thumbnail-skeleton'] {
       aspect-ratio: ${parsedRatio};
     }
   `;
@@ -171,7 +171,7 @@ export const cardThumbnailStyle =
   (theme: Theme) => css`
     position: relative;
 
-    [wds-component='thumbnail'] {
+    [data-component='thumbnail'] {
       overflow: hidden;
 
       img {
@@ -215,7 +215,7 @@ export const cardThumbnailContentWrapperStyle = (theme: Theme) => css`
   width: 100%;
 
   > * {
-    z-index: var(--wds-card-thumbnail-content-z-index);
+    z-index: var(--card-thumbnail-content-z-index);
   }
 
   // overlay
@@ -229,7 +229,7 @@ export const cardThumbnailContentWrapperStyle = (theme: Theme) => css`
     height: 100%;
     border-radius: 12px;
     opacity: ${theme.opacity[35]};
-    z-index: var(--wds-card-thumbnail-overlay-z-index);
+    z-index: var(--card-thumbnail-overlay-z-index);
   }
 `;
 
@@ -246,7 +246,7 @@ export const cardThumbnailContentToggleIconStyle = (theme: Theme) => css`
 export const cardTitleStyle = (props: CardTitleProps) => (theme: Theme) => css`
   ${ellipsisTypographyStyle(2)}
 
-  &[wds-component='card-title'] {
+  &[data-component='card-title'] {
     ${cardTypographyStyle(props, 'bold')(theme)}
   }
 `;
@@ -255,7 +255,7 @@ export const cardCaptionStyle =
   (props: TypographyProps) => (theme: Theme) => css`
     ${ellipsisTypographyStyle()}
 
-    &[wds-component='card-caption'] {
+    &[data-component='card-caption'] {
       ${cardTypographyStyle(props, 'medium')(theme)}
     }
   `;
@@ -305,8 +305,8 @@ export const cardTypographyStyle =
 export const cardContentStyle = css`
   overflow: hidden;
 
-  [wds-component='card-title'],
-  [wds-component='card-title-skeleton'] {
+  [data-component='card-title'],
+  [data-component='card-title-skeleton'] {
     margin-bottom: 2px;
   }
 `;
@@ -321,14 +321,12 @@ export const cardContentItemStyle = ({
     switch (position) {
       case 'top':
         return css`
-          margin-top: var(--wds-card-content-item-top-position-margin-top);
-          margin-bottom: var(
-            --wds-card-content-item-top-position-margin-bottom
-          );
+          margin-top: var(--card-content-item-top-position-margin-top);
+          margin-bottom: var(--card-content-item-top-position-margin-bottom);
         `;
       case 'bottom':
         return css`
-          margin-top: var(--wds-card-content-item-bottom-position-margin-top);
+          margin-top: var(--card-content-item-bottom-position-margin-top);
         `;
     }
   })()};
@@ -341,23 +339,23 @@ const cardSkeletonPlatformStyle = ({
     case 'desktop':
       return css`
         gap: 8px;
-        --wds-card-content-item-top-position-margin-top: 4px;
-        --wds-card-content-item-top-position-margin-bottom: 4px;
+        --card-content-item-top-position-margin-top: 4px;
+        --card-content-item-top-position-margin-bottom: 4px;
 
-        --wds-card-content-item-bottom-position-margin-top: 8px;
+        --card-content-item-bottom-position-margin-top: 8px;
 
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 100%;
           aspect-ratio: 3 / 2;
         }
         // content
-        [wds-component='card-content'] {
+        [data-component='card-content'] {
           padding: 0 6px;
         }
         // skeleton
-        [wds-component='card-title-skeleton'] {
+        [data-component='card-title-skeleton'] {
           width: 100%;
           height: 24px;
         }
@@ -366,23 +364,23 @@ const cardSkeletonPlatformStyle = ({
     case 'mobile':
       return css`
         gap: 6px;
-        --wds-card-content-item-top-position-margin-top: 2px;
-        --wds-card-content-item-top-position-margin-bottom: 4px;
+        --card-content-item-top-position-margin-top: 2px;
+        --card-content-item-top-position-margin-bottom: 4px;
 
-        --wds-card-content-item-bottom-position-margin-top: 6px;
+        --card-content-item-bottom-position-margin-top: 6px;
 
         // thumbnail
-        [wds-component='thumbnail'],
-        [wds-component='thumbnail-skeleton'] {
+        [data-component='thumbnail'],
+        [data-component='thumbnail-skeleton'] {
           width: 100%;
           aspect-ratio: 4 / 3;
         }
         // content
-        [wds-component='card-content'] {
+        [data-component='card-content'] {
           padding: 0 2px;
         }
         // skeleton
-        [wds-component='card-title-skeleton'] {
+        [data-component='card-title-skeleton'] {
           width: 100%;
           height: 22px;
         }
@@ -397,8 +395,8 @@ export const cardSkeletonStyle =
     ${cardSkeletonPlatformStyle({ platform })}
 
     // thumbnail
-    [wds-component='thumbnail'],
-    [wds-component='thumbnail-skeleton'] {
+    [data-component='thumbnail'],
+    [data-component='thumbnail-skeleton'] {
       width: 100%;
     }
 
@@ -419,7 +417,7 @@ export const cardSkeletonStyle =
 
 export const cardTitleSkeletonStyle =
   (props: CardTitleSkeletonProps) => (theme: Theme) => css`
-    &[wds-component='card-title-skeleton'] {
+    &[data-component='card-title-skeleton'] {
       ${cardSkeletonWidthStyle(props)(theme)}
     }
   `;

--- a/packages/core/src/components/category/index.tsx
+++ b/packages/core/src/components/category/index.tsx
@@ -171,7 +171,7 @@ const CategoryList = forwardRef<
       >
         <RovingFocusGroup.Root asChild orientation="horizontal" loop dir="ltr">
           <FlexBox
-            wds-component="category-list"
+            data-component="category-list"
             role="tablist"
             ref={composedRef}
             dir={dir || 'ltr'}
@@ -324,7 +324,7 @@ const CategoryListItem = forwardRef<any, CategoryListItemProps>(
           role="tab"
           ref={composedRefs}
           aria-pressed={undefined}
-          wds-component="category-list-item"
+          data-component="category-list-item"
           aria-selected={isActive}
           aria-disabled={disabled}
           data-value={value}
@@ -421,7 +421,7 @@ const CategoryPanel = forwardRef<
     <Box
       {...props}
       ref={ref}
-      wds-component="category-panel"
+      data-component="category-panel"
       id={`${context.id}-${value}-panel`}
       aria-labelledby={`${context.id}-${value}`}
       role="tabpanel"

--- a/packages/core/src/components/category/style.ts
+++ b/packages/core/src/components/category/style.ts
@@ -98,12 +98,12 @@ const categoryPaddingStyle = ({
 
         &:not(:has([data-role='category-list-icon-button']))
           [data-radix-scroll-area-content] {
-          padding: 0px var(--wds-category-list-padding, 20px);
+          padding: 0px var(--category-list-padding, 20px);
         }
 
         &:has([data-role='category-list-icon-button'])
           [data-radix-scroll-area-content] {
-          padding: 0px 0px 0px var(--wds-category-list-padding, 20px);
+          padding: 0px 0px 0px var(--category-list-padding, 20px);
         }
 
         ${isScrollableRight
@@ -127,8 +127,8 @@ const categoryPaddingStyle = ({
               }
             `}
 
-        --wds-category-icon-button-padding: 0px
-          calc(var(--wds-category-list-padding, 20px) - 4px) 0px 0px;
+        --category-icon-button-padding: 0px
+          calc(var(--category-list-padding, 20px) - 4px) 0px 0px;
       `;
     case false:
       return css`
@@ -169,7 +169,7 @@ const categoryPaddingStyle = ({
               }
             `}
 
-        --wds-category-icon-button-padding: 0px;
+        --category-icon-button-padding: 0px;
       `;
   }
 };
@@ -355,5 +355,5 @@ export const stickyButtonStyle = css`
   right: 0px;
   height: 100%;
   flex-shrink: 0;
-  padding: var(--wds-category-icon-button-padding, 0px);
+  padding: var(--category-icon-button-padding, 0px);
 `;

--- a/packages/core/src/components/check-mark/index.tsx
+++ b/packages/core/src/components/check-mark/index.tsx
@@ -11,7 +11,7 @@ const CheckMark = forwardRef<HTMLButtonElement, CheckMarkProps>(
     return (
       <Checkbox
         ref={ref}
-        wds-component="check-mark"
+        data-component="check-mark"
         tight={false}
         {...props}
         sx={[

--- a/packages/core/src/components/check-mark/style.ts
+++ b/packages/core/src/components/check-mark/style.ts
@@ -91,7 +91,7 @@ const checkMarkSizeStyle = ({
             margin: 0 auto;
           }
 
-          [wds-component='with-interaction'] {
+          [data-component='with-interaction'] {
             width: calc(100% + 12px);
           }
         `}
@@ -116,7 +116,7 @@ const checkMarkSizeStyle = ({
             margin: 0 auto;
           }
 
-          [wds-component='with-interaction'] {
+          [data-component='with-interaction'] {
             width: calc(100% + 12px);
           }
         `}

--- a/packages/core/src/components/checkbox/index.tsx
+++ b/packages/core/src/components/checkbox/index.tsx
@@ -104,7 +104,7 @@ const Checkbox = forwardRef<
             aria-required={required}
             ref={composedRefs}
             data-tight={tight}
-            wds-component="checkbox"
+            data-component="checkbox"
             {...props}
             sx={[
               checkboxStyle({

--- a/packages/core/src/components/checkbox/style.ts
+++ b/packages/core/src/components/checkbox/style.ts
@@ -39,7 +39,7 @@ export const checkboxStyle =
       cursor: pointer;
     }
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       border-radius: 9999px;
     }
 
@@ -176,7 +176,7 @@ const checkboxSizeStyle = ({
           padding-right: 1px;
           width: 20px;
 
-          [wds-component='with-interaction'] {
+          [data-component='with-interaction'] {
             width: calc(100% + 12px);
           }
         `}
@@ -199,7 +199,7 @@ const checkboxSizeStyle = ({
           padding-right: 0px;
           width: 16px;
 
-          [wds-component='with-interaction'] {
+          [data-component='with-interaction'] {
             width: calc(100% + 12px);
           }
         `}

--- a/packages/core/src/components/date-calendar/index.tsx
+++ b/packages/core/src/components/date-calendar/index.tsx
@@ -202,7 +202,7 @@ const DateCalendar = forwardRef<
       >
         <FlexBox
           ref={composedRefs}
-          wds-component="date-calendar"
+          data-component="date-calendar"
           flexDirection="column"
           alignItems="flex-start"
           {...props}
@@ -223,7 +223,7 @@ const DateCalendar = forwardRef<
                 <FlexBox sx={dateCalendarHeaderStyle} alignItems="center">
                   <FlexBox sx={dateCalendarHeaderLabelStyle} flex="1">
                     <TextButton
-                      wds-ignore-first-focus="true"
+                      data-ignore-first-focus="true"
                       onClick={() => {
                         if (isOnlySelectDay || isOnlySelectMonth) return;
 
@@ -264,7 +264,7 @@ const DateCalendar = forwardRef<
                     {views.includes('day') && (
                       <>
                         <IconButton
-                          wds-ignore-first-focus="true"
+                          data-ignore-first-focus="true"
                           size={18}
                           aria-label="Previous month"
                           disabled={
@@ -293,7 +293,7 @@ const DateCalendar = forwardRef<
                         </IconButton>
 
                         <IconButton
-                          wds-ignore-first-focus="true"
+                          data-ignore-first-focus="true"
                           size={18}
                           aria-label="Next month"
                           disabled={

--- a/packages/core/src/components/date-calendar/style.ts
+++ b/packages/core/src/components/date-calendar/style.ts
@@ -38,7 +38,7 @@ export const dateCalendarHeaderLabelButtonStyle = (theme: Theme) => css`
   padding-top: 0px;
   padding-bottom: 0px;
 
-  & > [wds-component='with-interaction'] {
+  & > [data-component='with-interaction'] {
     height: calc(100% + 8px);
   }
 `;
@@ -117,14 +117,14 @@ export const dayItemButtonStyle = (theme: Theme) => css`
     }
   }
 
-  &:not(:hover):not(:active) > [wds-component='with-interaction'] {
+  &:not(:hover):not(:active) > [data-component='with-interaction'] {
     transition: none;
   }
 
   &:focus-visible {
     outline: none;
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       transition: none;
       opacity: 0.06;
     }

--- a/packages/core/src/components/date-range-calendar/index.tsx
+++ b/packages/core/src/components/date-range-calendar/index.tsx
@@ -175,7 +175,7 @@ const DateRangeCalendar = forwardRef<
       >
         <FlexBox
           ref={composedRefs}
-          wds-component="date-range-calendar"
+          data-component="date-range-calendar"
           sx={[rangeCalendarContainerStyle, props.sx]}
           onMouseLeave={() => {
             if (!disabled && !readOnly) setHoveredDate(null);
@@ -239,7 +239,7 @@ const RangeDayPanel = memo(({ panelIndex }: RangeDayPanelProps) => {
   const prevArrow = useMemo(() => {
     return (
       <IconButton
-        wds-ignore-first-focus="true"
+        data-ignore-first-focus="true"
         size={18}
         aria-label="Previous month"
         disabled={
@@ -269,7 +269,7 @@ const RangeDayPanel = memo(({ panelIndex }: RangeDayPanelProps) => {
   const nextArrow = useMemo(() => {
     return (
       <IconButton
-        wds-ignore-first-focus="true"
+        data-ignore-first-focus="true"
         size={18}
         aria-label="Next month"
         disabled={
@@ -1018,7 +1018,7 @@ const RangeMonthPanel = memo(() => {
             </FlexBox>
             <FlexBox gap="18px" sx={rangePanelHeaderNavigationStyle}>
               <IconButton
-                wds-ignore-first-focus="true"
+                data-ignore-first-focus="true"
                 size={18}
                 aria-label="Previous year"
                 disabled={
@@ -1041,7 +1041,7 @@ const RangeMonthPanel = memo(() => {
                 <IconChevronLeftSmall />
               </IconButton>
               <IconButton
-                wds-ignore-first-focus="true"
+                data-ignore-first-focus="true"
                 size={18}
                 aria-label="Next year"
                 disabled={

--- a/packages/core/src/components/date-range-calendar/style.ts
+++ b/packages/core/src/components/date-range-calendar/style.ts
@@ -151,14 +151,14 @@ export const rangeDayItemStyle = (theme: Theme) => css`
     }
   }
 
-  &:not(:hover):not(:active) > [wds-component='with-interaction'] {
+  &:not(:hover):not(:active) > [data-component='with-interaction'] {
     transition: none;
   }
 
   &:focus-visible {
     outline: none;
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       transition: none;
       opacity: 0.06;
     }

--- a/packages/core/src/components/dismissable-layer/index.tsx
+++ b/packages/core/src/components/dismissable-layer/index.tsx
@@ -17,7 +17,7 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
       (e: PointerDownOutsideEvent | FocusOutsideEvent) => {
         const target = e.target as HTMLElement;
 
-        if (target.closest('[wds-ignore-dismissable-layer="true"]')) {
+        if (target.closest('[data-ignore-dismissable-layer="true"]')) {
           e.preventDefault();
         }
       },

--- a/packages/core/src/components/fallback-view/index.tsx
+++ b/packages/core/src/components/fallback-view/index.tsx
@@ -94,7 +94,7 @@ const FallbackViewImage = forwardRef(
     return (
       <FlexBox
         ref={ref}
-        wds-component="fallback-view-image"
+        data-component="fallback-view-image"
         justifyContent="center"
         alignItems="center"
         {...props}
@@ -116,7 +116,7 @@ const FallbackViewContent = forwardRef(
     return (
       <FlexBox
         ref={ref}
-        wds-component="fallback-view-content"
+        data-component="fallback-view-content"
         flexDirection="column"
         alignItems="center"
         gap="24px"
@@ -165,7 +165,7 @@ const FallbackViewButton = forwardRef(
       <Button
         as={(as || 'button') as ElementType}
         ref={ref}
-        wds-component="fallback-view-button"
+        data-component="fallback-view-button"
         variant="outlined"
         color="assistive"
         {...props}

--- a/packages/core/src/components/fallback-view/style.ts
+++ b/packages/core/src/components/fallback-view/style.ts
@@ -14,11 +14,11 @@ export const fallbackViewStyle =
     width: ${toCssValue(width)};
     ${fallbackViewPlatformStyle({ platform })}
     ${fallbackViewPaddingStyle({ padding })}
-    --wds-fallback-view-bottom-space: 0px;
+    --fallback-view-bottom-space: 0px;
 
-    &:has([wds-component='fallback-view-image'])
-      [wds-component='fallback-view-content'] {
-      --wds-fallback-view-bottom-space: 20px;
+    &:has([data-component='fallback-view-image'])
+      [data-component='fallback-view-content'] {
+      --fallback-view-bottom-space: 20px;
     }
 
     [data-role='fallback-view-text-title'] {
@@ -162,12 +162,12 @@ const fallbackViewContentPlatformStyle = ({
     case 'mobile':
       return css`
         padding-top: 8px;
-        padding-bottom: calc(8px + var(--wds-fallback-view-bottom-space));
+        padding-bottom: calc(8px + var(--fallback-view-bottom-space));
       `;
     case 'desktop':
       return css`
         padding-top: 12px;
-        padding-bottom: calc(12px + var(--wds-fallback-view-bottom-space));
+        padding-bottom: calc(12px + var(--fallback-view-bottom-space));
       `;
   }
 };

--- a/packages/core/src/components/focus-scope/helpers.ts
+++ b/packages/core/src/components/focus-scope/helpers.ts
@@ -64,9 +64,9 @@ export const getTabbableCandidates = (container: HTMLElement) => {
 export const getTabbableForFirstFocus = (nodes: Array<HTMLElement>) => {
   return nodes.sort((a, b) => {
     const aIgnoreFirstFocus =
-      a.getAttribute('wds-ignore-first-focus') === 'true';
+      a.getAttribute('data-ignore-first-focus') === 'true';
     const bIgnoreFirstFocus =
-      b.getAttribute('wds-ignore-first-focus') === 'true';
+      b.getAttribute('data-ignore-first-focus') === 'true';
 
     if (aIgnoreFirstFocus && !bIgnoreFirstFocus) {
       return 1;

--- a/packages/core/src/components/focus-scope/index.tsx
+++ b/packages/core/src/components/focus-scope/index.tsx
@@ -267,7 +267,7 @@ const FocusScopeWrapper = forwardRef<
           onKeyDown={composeEventHandlers(props.onKeyDown, handleKeyDown)}
         />
         <span
-          wds-component="focus-guard"
+          data-component="focus-guard"
           tabIndex={trapped ? 0 : -1}
           style={{
             outline: 'none',

--- a/packages/core/src/components/grid-item/style.ts
+++ b/packages/core/src/components/grid-item/style.ts
@@ -8,8 +8,8 @@ import type { GridItemProps } from './types';
 export const gridItemStyle =
   ({ xs, sm, md, lg, xl, ...props }: GridItemProps) =>
   (theme: Theme) => css`
-    padding-top: calc(var(--wds-column-spacing));
-    padding-left: calc(var(--wds-row-spacing));
+    padding-top: calc(var(--grid-column-spacing));
+    padding-left: calc(var(--grid-row-spacing));
 
     ${gridItemAlignStyle(props)}
 

--- a/packages/core/src/components/grid/style.ts
+++ b/packages/core/src/components/grid/style.ts
@@ -59,16 +59,16 @@ const gridSpacingStyle = (
 
   if (typeof spacing === 'number') {
     return css`
-      --wds-${type}-spacing: ${theme.spacing[spacing]};
+      --${type}-spacing: ${theme.spacing[spacing]};
 
       ${
         type === 'column'
           ? css`
-              margin-top: calc(var(--wds-${type}-spacing) * -1);
+              margin-top: calc(var(--${type}-spacing) * -1);
             `
           : css`
-              width: calc(100% + var(--wds-${type}-spacing));
-              margin-left: calc(var(--wds-${type}-spacing) * -1);
+              width: calc(100% + var(--${type}-spacing));
+              margin-left: calc(var(--${type}-spacing) * -1);
             `
       }
     `;

--- a/packages/core/src/components/grid/style.ts
+++ b/packages/core/src/components/grid/style.ts
@@ -59,16 +59,16 @@ const gridSpacingStyle = (
 
   if (typeof spacing === 'number') {
     return css`
-      --${type}-spacing: ${theme.spacing[spacing]};
+      --grid-${type}-spacing: ${theme.spacing[spacing]};
 
       ${
         type === 'column'
           ? css`
-              margin-top: calc(var(--${type}-spacing) * -1);
+              margin-top: calc(var(--grid-${type}-spacing) * -1);
             `
           : css`
-              width: calc(100% + var(--${type}-spacing));
-              margin-left: calc(var(--${type}-spacing) * -1);
+              width: calc(100% + var(--grid-${type}-spacing));
+              margin-left: calc(var(--grid-${type}-spacing) * -1);
             `
       }
     `;

--- a/packages/core/src/components/icon-button/index.test.tsx
+++ b/packages/core/src/components/icon-button/index.test.tsx
@@ -4,7 +4,7 @@ import { theme } from '@montage-ui/engine';
 import { IconButton } from '.';
 
 const getButton = (container: HTMLElement) =>
-  container.querySelector('[wds-component="icon-button"]') as HTMLElement;
+  container.querySelector('[data-component="icon-button"]') as HTMLElement;
 
 const getSvg = (container: HTMLElement) =>
   container.querySelector('svg') as unknown as HTMLElement;

--- a/packages/core/src/components/icon-button/index.tsx
+++ b/packages/core/src/components/icon-button/index.tsx
@@ -93,7 +93,7 @@ const IconButton = forwardRef(
         <Box
           as={(as || 'button') as ElementType}
           ref={ref}
-          wds-component="icon-button"
+          data-component="icon-button"
           data-variant={variant}
           disabled={disabled}
           type="button"

--- a/packages/core/src/components/icon-button/style.ts
+++ b/packages/core/src/components/icon-button/style.ts
@@ -36,7 +36,7 @@ export const iconButtonStyle =
       cursor: not-allowed;
     }
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       width: auto;
       aspect-ratio: 1 / 1;
     }
@@ -59,13 +59,13 @@ export const iconButtonStyle =
   `;
 
 // Exposes the gap between the box edge and the icon edge as
-// `--wds-icon-button-inset` on the adjacent PushBadge sibling so it can align to
+// `--icon-button-inset` on the adjacent PushBadge sibling so it can align to
 // the icon edge (not the chrome edge). Only normal variant has invisible chrome,
 // so this compensation is scoped to 'normal' — other variants keep the badge at
 // the visible chrome corner.
 const badgeInsetStyle = (inset: string) => css`
-  & + [wds-component='push-badge'] {
-    --wds-icon-button-inset: ${inset};
+  & + [data-component='push-badge'] {
+    --icon-button-inset: ${inset};
   }
 `;
 
@@ -179,7 +179,7 @@ const iconButtonColorStyle = (
 
         ${Boolean(interactionColor) &&
         css`
-          & > [wds-component='with-interaction'] {
+          & > [data-component='with-interaction'] {
             background-color: ${getColorByToken(theme, interactionColor!)};
           }
         `}

--- a/packages/core/src/components/list/index.tsx
+++ b/packages/core/src/components/list/index.tsx
@@ -141,7 +141,7 @@ const ListCell = forwardRef(
             data-disable-interaction={
               disabled || disableInteraction || verticalPadding === 'none'
             }
-            wds-component="list-cell"
+            data-component="list-cell"
             {...props}
             onKeyDown={composeEventHandlers(props.onKeyDown, (e) => {
               if (
@@ -229,7 +229,7 @@ const ListCellContent = forwardRef<
     case 'large-icon':
       return (
         <FlexBox
-          wds-component="list-cell-content"
+          data-component="list-cell-content"
           alignItems={alignItems}
           ref={ref}
           {...props}
@@ -242,7 +242,7 @@ const ListCellContent = forwardRef<
     case 'button':
       return (
         <FlexBox
-          wds-component="list-cell-content"
+          data-component="list-cell-content"
           alignItems={alignItems}
           ref={ref}
           {...props}
@@ -257,7 +257,7 @@ const ListCellContent = forwardRef<
     case 'icon-button':
       return (
         <FlexBox
-          wds-component="list-cell-content"
+          data-component="list-cell-content"
           alignItems={alignItems}
           ref={ref}
           {...props}
@@ -274,7 +274,7 @@ const ListCellContent = forwardRef<
         <FlexBox
           role="button"
           alignItems={alignItems}
-          wds-component="list-cell-content"
+          data-component="list-cell-content"
           gap="8px"
           ref={ref}
           tabIndex={props.onClick ? 0 : -1}
@@ -308,7 +308,7 @@ const ListCellContent = forwardRef<
       return (
         <CheckboxProvider tight>
           <FlexBox
-            wds-component="list-cell-content"
+            data-component="list-cell-content"
             alignItems={alignItems}
             ref={ref}
             {...props}
@@ -322,7 +322,7 @@ const ListCellContent = forwardRef<
       return (
         <RadioProvider tight>
           <FlexBox
-            wds-component="list-cell-content"
+            data-component="list-cell-content"
             alignItems={alignItems}
             ref={ref}
             {...props}
@@ -342,7 +342,7 @@ const ListCellContent = forwardRef<
     default:
       return (
         <FlexBox
-          wds-component="list-cell-content"
+          data-component="list-cell-content"
           alignItems={alignItems}
           ref={ref}
           {...props}

--- a/packages/core/src/components/list/style.ts
+++ b/packages/core/src/components/list/style.ts
@@ -32,10 +32,10 @@ export const listCellStyle =
   }: ListCellProps) =>
   (theme: Theme) => css`
     width: 100%;
-    padding-top: var(--wds-list-cell-vertical-padding);
-    padding-bottom: var(--wds-list-cell-vertical-padding);
-    padding-left: var(--wds-list-cell-horizontal-padding);
-    padding-right: var(--wds-list-cell-horizontal-padding);
+    padding-top: var(--list-cell-vertical-padding);
+    padding-bottom: var(--list-cell-vertical-padding);
+    padding-left: var(--list-cell-horizontal-padding);
+    padding-right: var(--list-cell-horizontal-padding);
 
     ${disabled
       ? css`
@@ -75,9 +75,9 @@ export const listCellStyle =
     ${listCellFillWidthStyle({ fillWidth })}
     ${listCellInteractionPaddingStyle({ fillWidth, interactionPadding })}
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       border-radius: inherit;
-      display: var(--wds-list-cell-interaction-display, block);
+      display: var(--list-cell-interaction-display, block);
     }
 
     ${createResponsiveStyle(
@@ -138,17 +138,17 @@ const listCellInteractionPaddingStyle = ({
 }: Pick<ListCellProps, 'fillWidth' | 'interactionPadding'>) => {
   if (fillWidth) {
     return css`
-      & > [wds-component='with-interaction'] {
+      & > [data-component='with-interaction'] {
         width: 100%;
       }
     `;
   }
   return css`
-    --wds-list-cell-interaction-padding: ${toCssValue(interactionPadding) ??
+    --list-cell-interaction-padding: ${toCssValue(interactionPadding) ??
     '12px'};
 
-    & > [wds-component='with-interaction'] {
-      width: calc(100% + (var(--wds-list-cell-interaction-padding, 0px) * 2));
+    & > [data-component='with-interaction'] {
+      width: calc(100% + (var(--list-cell-interaction-padding, 0px) * 2));
     }
   `;
 };
@@ -157,29 +157,29 @@ const listCellPaddingStyle = ({
   verticalPadding,
 }: Pick<ListCellProps, 'verticalPadding'>) => css`
   &,
-  & ~ [wds-component='accordion-details'] {
+  & ~ [data-component='accordion-details'] {
     ${(() => {
       switch (verticalPadding) {
         case 'none':
           return css`
-            --wds-list-cell-vertical-padding: 0px;
-            --wds-list-cell-interaction-display: none;
+            --list-cell-vertical-padding: 0px;
+            --list-cell-interaction-display: none;
           `;
 
         case 'small':
           return css`
-            --wds-list-cell-vertical-padding: 8px;
-            --wds-list-cell-interaction-display: block;
+            --list-cell-vertical-padding: 8px;
+            --list-cell-interaction-display: block;
           `;
         case 'large':
           return css`
-            --wds-list-cell-vertical-padding: 16px;
-            --wds-list-cell-interaction-display: block;
+            --list-cell-vertical-padding: 16px;
+            --list-cell-interaction-display: block;
           `;
         case 'medium':
           return css`
-            --wds-list-cell-vertical-padding: 12px;
-            --wds-list-cell-interaction-display: block;
+            --list-cell-vertical-padding: 12px;
+            --list-cell-interaction-display: block;
           `;
       }
     })()}
@@ -193,17 +193,17 @@ const listCellFillWidthStyle = ({
     case true:
       return css`
         &,
-        & ~ [wds-component='accordion-details'],
+        & ~ [data-component='accordion-details'],
         & ~ [data-role='accordion-divider'] {
-          --wds-list-cell-horizontal-padding: 20px;
+          --list-cell-horizontal-padding: 20px;
         }
       `;
     case false:
       return css`
         &,
-        & ~ [wds-component='accordion-details'],
+        & ~ [data-component='accordion-details'],
         & ~ [data-role='accordion-divider'] {
-          --wds-list-cell-horizontal-padding: 0px;
+          --list-cell-horizontal-padding: 0px;
         }
         border-radius: 12px;
       `;
@@ -216,7 +216,7 @@ export const listCellDividerStyle = css`
   left: 50%;
   transform: translate(-50%, 0px);
   transition: opacity 0.15s ease;
-  width: calc(100% - (var(--wds-list-cell-horizontal-padding) * 2));
+  width: calc(100% - (var(--list-cell-horizontal-padding) * 2));
 `;
 
 const listCellContentVariantStyle =
@@ -267,7 +267,7 @@ const listCellContentVariantStyle =
       case 'checkbox':
         return css`
           &:not([data-role='list-item-trailing-content']):has(
-              [wds-component='checkbox'][data-tight='true']
+              [data-component='checkbox'][data-tight='true']
             ) {
             padding-right: 2px;
           }
@@ -275,7 +275,7 @@ const listCellContentVariantStyle =
       case 'radio':
         return css`
           &:not([data-role='list-item-trailing-content']):has(
-              [wds-component='radio'][data-tight='true']
+              [data-component='radio'][data-tight='true']
             ) {
             padding-right: 2px;
           }
@@ -293,7 +293,7 @@ export const listCellContentStyle =
       justify-content: flex-end;
     }
 
-    [wds-component='with-interaction'] {
+    [data-component='with-interaction'] {
       z-index: 1;
     }
 

--- a/packages/core/src/components/menu/index.tsx
+++ b/packages/core/src/components/menu/index.tsx
@@ -429,7 +429,7 @@ const MenuActionAreaContent = forwardRef<
     case 'icon':
       return (
         <FlexBox
-          wds-component="menu-action-area-content"
+          data-component="menu-action-area-content"
           ref={ref}
           {...props}
           sx={[
@@ -451,7 +451,7 @@ const MenuActionAreaContent = forwardRef<
     case 'chip-filter':
       return (
         <FlexBox
-          wds-component="menu-bottom-content"
+          data-component="menu-bottom-content"
           ref={ref}
           {...props}
           sx={[menuActionAreaContentStyle(variant), sx]}
@@ -465,7 +465,7 @@ const MenuActionAreaContent = forwardRef<
     default:
       return (
         <FlexBox
-          wds-component="menu-bottom-content"
+          data-component="menu-bottom-content"
           ref={ref}
           {...props}
           sx={[menuActionAreaContentStyle(variant), sx]}

--- a/packages/core/src/components/menu/style.ts
+++ b/packages/core/src/components/menu/style.ts
@@ -51,7 +51,7 @@ export const menuItemStyle = (theme: Theme) => css`
   &:focus-visible {
     outline: none;
 
-    > [wds-component='with-interaction'] {
+    > [data-component='with-interaction'] {
       opacity: 0.06;
     }
   }

--- a/packages/core/src/components/modal/constants.ts
+++ b/packages/core/src/components/modal/constants.ts
@@ -12,7 +12,7 @@ export const BOTTOM_SHEET_PEEK_PADDING = 12;
 
 /**
  * Top inset (px) reserved above the sheet at its full snap. Mirrors the `- 40px`
- * in the `--wds-modal-default-max-height` CSS calc — keep in sync with style.ts.
+ * in the `--modal-default-max-height` CSS calc — keep in sync with style.ts.
  */
 export const BOTTOM_SHEET_TOP_INSET_PX = 40;
 

--- a/packages/core/src/components/modal/helpers.ts
+++ b/packages/core/src/components/modal/helpers.ts
@@ -101,7 +101,7 @@ type ApplySnapOptions = {
  * drag cycle.
  *
  * - `peek`: keeps the sheet at its natural (full) height and slides the whole
- *   thing down via `--wds-modal-translate: calc(100% - peekHeight)`, leaving
+ *   thing down via `--modal-translate: calc(100% - peekHeight)`, leaving
  *   exactly `peekHeight` visible at the bottom. Holding height steady avoids
  *   reflowing the content (and resetting scroll position) every time peek
  *   toggles.
@@ -126,17 +126,17 @@ export const applySnap = (
   // order would let the CSS transition catch the handoff frame and animate
   // the drag→CSS jump even when the values are visually identical.
   container.style.removeProperty('box-shadow');
-  container.style.removeProperty('--wds-modal-max-height');
+  container.style.removeProperty('--modal-max-height');
 
   dimmer?.style.removeProperty('opacity');
 
   if (snap === 'peek') {
     container.style.setProperty(
-      '--wds-modal-translate',
+      '--modal-translate',
       `calc(100% - ${peekHeight}px)`,
     );
   } else {
-    container.style.removeProperty('--wds-modal-translate');
+    container.style.removeProperty('--modal-translate');
   }
 
   container.style.removeProperty('transition');
@@ -228,7 +228,7 @@ export const rubberBand = (
  * Resolve the sheet's **snap-independent** full max-height — i.e. what the
  * sheet's height would be at `data-snap='full'` regardless of the current snap.
  *
- * Mirrors the CSS `--wds-modal-default-max-height` calc directly:
+ * Mirrors the CSS `--modal-default-max-height` calc directly:
  *   `100% (≈ viewport) - safe-area-inset-top - 40px`
  *
  * Computing this in JS instead of probing the DOM avoids the cascade /
@@ -258,7 +258,7 @@ export const computeFullMaxHeight = (): number => {
 /**
  * Pick which visual technique drives the in-flight drag.
  *
- * - `translate`: only `--wds-modal-translate` is updated; the sheet slides
+ * - `translate`: only `--modal-translate` is updated; the sheet slides
  *   downward as a whole while its `height` stays fixed.
  * - `height`: inline `height` is updated, growing or shrinking the sheet
  *   from its top edge.
@@ -477,9 +477,9 @@ export const resolveNonFlexibleReleaseSnap = ({
  * Compute the inline style values needed to render the in-flight drag.
  *
  * Returns one of:
- * - `mode='height'`: set `--wds-modal-max-height` to `height`, clear translate.
- * - `mode='translate'`: set `--wds-modal-translate` to `translate` (and
- *   optionally fix `--wds-modal-max-height` so the sheet doesn't reflow as it
+ * - `mode='height'`: set `--modal-max-height` to `height`, clear translate.
+ * - `mode='translate'`: set `--modal-translate` to `translate` (and
+ *   optionally fix `--modal-max-height` so the sheet doesn't reflow as it
  *   slides). `peek` start derives translate from the live `visualHeight` so
  *   re-grabs mid-settle pick up at the actual current visible position.
  */

--- a/packages/core/src/components/modal/hooks.ts
+++ b/packages/core/src/components/modal/hooks.ts
@@ -335,7 +335,7 @@ export const useSnapLifecycle = ({
     if (isOpen) return;
 
     container.style.removeProperty('transition');
-    container.style.removeProperty('--wds-modal-translate');
+    container.style.removeProperty('--modal-translate');
     dimmerRef.current?.style.removeProperty('transition');
     dimmerRef.current?.style.removeProperty('opacity');
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -397,7 +397,7 @@ export const useDraggable = ({
   const isDragging = useRef(false);
   const startedY = useRef(0);
   const startedVisualHeight = useRef(0);
-  // Resolved px value of `--wds-modal-max-height`, captured once at drag start
+  // Resolved px value of `--modal-max-height`, captured once at drag start
   // so per-frame height calculations don't trigger reflows from getComputedStyle.
   const startedMaxHeight = useRef(0);
   // Snap-INDEPENDENT full max-height — what max-height would be in
@@ -494,15 +494,15 @@ export const useDraggable = ({
     if (dragStyle.mode === 'translate') {
       if (dragStyle.fixedHeight) {
         container.style.setProperty(
-          '--wds-modal-max-height',
+          '--modal-max-height',
           `${dragStyle.fixedHeight}px`,
         );
       }
-      container.style.setProperty('--wds-modal-translate', dragStyle.translate);
+      container.style.setProperty('--modal-translate', dragStyle.translate);
     } else {
-      container.style.removeProperty('--wds-modal-translate');
+      container.style.removeProperty('--modal-translate');
       container.style.setProperty(
-        '--wds-modal-max-height',
+        '--modal-max-height',
         `${dragStyle.height}px`,
       );
     }
@@ -514,10 +514,7 @@ export const useDraggable = ({
     // straight into the CSS variable so the lifted height rule can grow the
     // element past its natural size, matching the flexible feel.
     if (!isFlexible && visualHeight > fullMax) {
-      container.style.setProperty(
-        '--wds-modal-max-height',
-        `${visualHeight}px`,
-      );
+      container.style.setProperty('--modal-max-height', `${visualHeight}px`);
     }
 
     const opacity = computeDimmerOpacityDuringDrag({
@@ -718,7 +715,7 @@ export const useDraggable = ({
     // - flexible: half/peek CSS pins the element height to `default × 0.5`,
     //   so `startedMaxHeight` would under-cap the spring's `to` and projection
     //   candidates. Derive the would-be full height from viewport + safe-area
-    //   directly — same formula as the CSS `--wds-modal-default-max-height`
+    //   directly — same formula as the CSS `--modal-default-max-height`
     //   calc, but computed in JS so we don't depend on data-snap cascade or
     //   in-flight height transitions reporting interpolated values.
     // - non-flexible (hug/fixed/fill): the element has no per-snap height rule
@@ -734,13 +731,13 @@ export const useDraggable = ({
 
     container.style.setProperty('transition', 'none');
     container.style.setProperty(
-      '--wds-modal-max-height',
+      '--modal-max-height',
       `${startedMaxHeight.current}px`,
     );
     dimmerRef.current?.style.setProperty('transition', 'none');
 
     if (startedSnap.current !== 'peek') {
-      container.style.removeProperty('--wds-modal-translate');
+      container.style.removeProperty('--modal-translate');
     }
 
     startedVisualHeight.current = readVisualHeight(container);
@@ -996,7 +993,7 @@ export const useDraggable = ({
       let visualHeight = Math.max(0, startedVisualHeight.current - diffY);
 
       // Top-edge rubber-band — applied universally. `applyDragStyles` will
-      // push the rubber-banded `visualHeight` into `--wds-modal-max-height`
+      // push the rubber-banded `visualHeight` into `--modal-max-height`
       // (and for non-flexible variants override the translate-mode
       // `fixedHeight`) so the lifted CSS `height` rule grows the element
       // past its natural full size.

--- a/packages/core/src/components/modal/index.tsx
+++ b/packages/core/src/components/modal/index.tsx
@@ -256,13 +256,13 @@ const ModalContainer = forwardRef(
     const topNavigationHeight =
       useSize(
         containerRef.current?.querySelector(
-          '[wds-component="top-navigation"]',
+          '[data-component="top-navigation"]',
         ) ?? null,
       )?.height ?? 0;
 
     const actionAreaHeight =
       useSize(
-        containerRef.current?.querySelector('[wds-component="action-area"]') ??
+        containerRef.current?.querySelector('[data-component="action-area"]') ??
           null,
       )?.height ?? 0;
 
@@ -391,7 +391,7 @@ const ModalContainer = forwardRef(
                   aria-describedby={`${context.descriptionId} ${context.summaryId}`}
                   aria-labelledby={`${context.titleId} ${context.headingId}`}
                   {...props}
-                  wds-ignore-dismissable-layer="true"
+                  data-ignore-dismissable-layer="true"
                   data-snap={snap}
                   data-largest-undimmed-snap={largestUndimmedSnap}
                   data-status={open ? 'open' : 'close'}
@@ -438,10 +438,9 @@ const ModalContainer = forwardRef(
                       flex="1"
                       data-role="modal-container-wrapper"
                       sx={{
-                        '--wds-modal-grabber-height-guard': `${grabberHeightGuard}px`,
+                        '--modal-grabber-height-guard': `${grabberHeightGuard}px`,
                         ['&:has([data-role="modal-container-grabber"])']: {
-                          paddingTop:
-                            'var(--wds-modal-grabber-height-guard, 0px)',
+                          paddingTop: 'var(--modal-grabber-height-guard, 0px)',
                         },
                       }}
                       {...dragProps}
@@ -501,7 +500,7 @@ const ModalDimmer = forwardRef(
         }
         as={as || 'div'}
         {...props}
-        wds-ignore-dismissable-layer="true"
+        data-ignore-dismissable-layer="true"
         ref={useComposedRefs(ref, dimmerRef as ForwardedRef<T>)}
         onPointerDown={composeEventHandlers(
           props.onPointerDown,
@@ -670,7 +669,7 @@ const ModalContent = forwardRef<
 >(
   (
     {
-      gap = 'calc(var(--wds-modal-content-margin, 20px))',
+      gap = 'calc(var(--modal-content-margin, 20px))',
       xs,
       sm,
       md,
@@ -691,7 +690,7 @@ const ModalContent = forwardRef<
         <FlexBox
           ref={ref}
           as="div"
-          wds-component="modal-content"
+          data-component="modal-content"
           flexDirection="column"
           {...props}
           sx={[

--- a/packages/core/src/components/modal/style.ts
+++ b/packages/core/src/components/modal/style.ts
@@ -102,7 +102,7 @@ const modalContainerWrapperVariant = (
         }
 
         [data-role='modal-container-scroll-area']:has(
-          [wds-component='top-navigation'][data-variant='floating']
+          [data-component='top-navigation'][data-variant='floating']
         ) {
           background: initial;
           will-change: unset;
@@ -121,7 +121,7 @@ const modalContainerWrapperVariant = (
         }
 
         [data-role='modal-container-scroll-area']:has(
-          [wds-component='top-navigation'][data-variant='floating']
+          [data-component='top-navigation'][data-variant='floating']
         ) {
           background: initial;
           will-change: unset;
@@ -140,7 +140,7 @@ const modalContainerWrapperVariant = (
         }
 
         [data-role='modal-container-scroll-area']:has(
-          [wds-component='top-navigation'][data-variant='floating']
+          [data-component='top-navigation'][data-variant='floating']
         ) {
           background: inherit;
           will-change: backdrop-filter;
@@ -154,7 +154,7 @@ const modalBottomMountKeyframes = keyframes`
     transform: translateY(100%);
   }
   100% {
-    transform: translateY(var(--wds-modal-translate, 0px));
+    transform: translateY(var(--modal-translate, 0px));
   }
 `;
 
@@ -167,14 +167,14 @@ export const modalContainerStyle =
     outline: none;
     background-color: ${theme.semantic.background.elevated.normal};
 
-    [wds-component='top-navigation'] {
+    [data-component='top-navigation'] {
       z-index: 5;
       position: sticky;
-      top: var(--wds-modal-grabber-height-guard, 0px);
+      top: var(--modal-grabber-height-guard, 0px);
       left: 0px;
     }
 
-    [wds-component='action-area'] {
+    [data-component='action-area'] {
       position: sticky;
       z-index: 5;
       bottom: 0;
@@ -248,25 +248,25 @@ const modalContainerSize = (
           height: 400px;
         `}
 
-        --wds-modal-popup-border-radius: 12px;
-        --wds-modal-content-margin: 20px;
-        --wds-top-navigation-padding-x: 16px;
-        --wds-top-navigation-padding-y: 16px;
-        --wds-top-navigation-padding: var(--wds-top-navigation-padding-y)
-          var(--wds-top-navigation-padding-x);
-        --wds-top-navigation-min-height: 56px;
-        --wds-action-area-margin-x: var(--wds-modal-content-margin);
-        --wds-action-area-margin-y: var(--wds-modal-content-margin);
+        --modal-popup-border-radius: 12px;
+        --modal-content-margin: 20px;
+        --top-navigation-padding-x: 16px;
+        --top-navigation-padding-y: 16px;
+        --top-navigation-padding: var(--top-navigation-padding-y)
+          var(--top-navigation-padding-x);
+        --top-navigation-min-height: 56px;
+        --action-area-margin-x: var(--modal-content-margin);
+        --action-area-margin-y: var(--modal-content-margin);
 
-        [wds-component='top-navigation'] {
-          --wds-tab-list-padding: var(--wds-modal-content-margin);
+        [data-component='top-navigation'] {
+          --tab-list-padding: var(--modal-content-margin);
         }
 
         [data-role='action-area-extra-content'] {
           margin-top: calc(
-            var(--wds-action-area-margin-x) - var(--wds-action-area-margin-y)
+            var(--action-area-margin-x) - var(--action-area-margin-y)
           );
-          margin-bottom: calc(4px + var(--wds-action-area-margin-y, 20px));
+          margin-bottom: calc(4px + var(--action-area-margin-y, 20px));
         }
 
         [data-role='navigation-title'] {
@@ -286,25 +286,25 @@ const modalContainerSize = (
           height: 480px;
         `}
 
-        --wds-modal-popup-border-radius: 12px;
-        --wds-modal-content-margin: 20px;
-        --wds-top-navigation-padding-x: 16px;
-        --wds-top-navigation-padding-y: 20px;
-        --wds-top-navigation-padding: var(--wds-top-navigation-padding-y)
-          var(--wds-top-navigation-padding-x);
-        --wds-top-navigation-min-height: 64px;
-        --wds-action-area-margin-x: var(--wds-modal-content-margin);
-        --wds-action-area-margin-y: var(--wds-modal-content-margin);
+        --modal-popup-border-radius: 12px;
+        --modal-content-margin: 20px;
+        --top-navigation-padding-x: 16px;
+        --top-navigation-padding-y: 20px;
+        --top-navigation-padding: var(--top-navigation-padding-y)
+          var(--top-navigation-padding-x);
+        --top-navigation-min-height: 64px;
+        --action-area-margin-x: var(--modal-content-margin);
+        --action-area-margin-y: var(--modal-content-margin);
 
-        [wds-component='top-navigation'] {
-          --wds-tab-list-padding: var(--wds-modal-content-margin);
+        [data-component='top-navigation'] {
+          --tab-list-padding: var(--modal-content-margin);
         }
 
         [data-role='action-area-extra-content'] {
           margin-top: calc(
-            var(--wds-action-area-margin-x) - var(--wds-action-area-margin-y)
+            var(--action-area-margin-x) - var(--action-area-margin-y)
           );
-          margin-bottom: calc(4px + var(--wds-action-area-margin-y, 20px));
+          margin-bottom: calc(4px + var(--action-area-margin-y, 20px));
         }
 
         [data-role='navigation-title'] {
@@ -324,25 +324,25 @@ const modalContainerSize = (
           height: 560px;
         `}
 
-        --wds-modal-popup-border-radius: 20px;
-        --wds-modal-content-margin: 24px;
-        --wds-top-navigation-padding-x: 20px;
-        --wds-top-navigation-padding-y: 20px;
-        --wds-top-navigation-padding: var(--wds-top-navigation-padding-y)
-          var(--wds-top-navigation-padding-x);
-        --wds-top-navigation-min-height: 64px;
-        --wds-action-area-margin-x: var(--wds-modal-content-margin);
-        --wds-action-area-margin-y: var(--wds-modal-content-margin);
+        --modal-popup-border-radius: 20px;
+        --modal-content-margin: 24px;
+        --top-navigation-padding-x: 20px;
+        --top-navigation-padding-y: 20px;
+        --top-navigation-padding: var(--top-navigation-padding-y)
+          var(--top-navigation-padding-x);
+        --top-navigation-min-height: 64px;
+        --action-area-margin-x: var(--modal-content-margin);
+        --action-area-margin-y: var(--modal-content-margin);
 
-        [wds-component='top-navigation'] {
-          --wds-tab-list-padding: var(--wds-modal-content-margin);
+        [data-component='top-navigation'] {
+          --tab-list-padding: var(--modal-content-margin);
         }
 
         [data-role='action-area-extra-content'] {
           margin-top: calc(
-            var(--wds-action-area-margin-x) - var(--wds-action-area-margin-y)
+            var(--action-area-margin-x) - var(--action-area-margin-y)
           );
-          margin-bottom: var(--wds-action-area-margin-y);
+          margin-bottom: var(--action-area-margin-y);
         }
 
         [data-role='navigation-title'] {
@@ -362,29 +362,26 @@ const modalContainerSize = (
           height: 640px;
         `}
 
-        --wds-modal-popup-border-radius: 20px;
-        --wds-modal-content-margin: 32px;
-        --wds-top-navigation-padding-x: 28px;
-        --wds-top-navigation-padding-y: 24px;
-        --wds-top-navigation-padding: var(--wds-top-navigation-padding-y)
-          var(--wds-top-navigation-padding-x);
-        --wds-top-navigation-min-height: 72px;
-        --wds-action-area-margin-x: var(--wds-modal-content-margin);
-        --wds-action-area-margin-y: 24px;
-        --wds-action-area-extra-content-margin: var(
-          --wds-action-area-margin,
-          20px
-        );
+        --modal-popup-border-radius: 20px;
+        --modal-content-margin: 32px;
+        --top-navigation-padding-x: 28px;
+        --top-navigation-padding-y: 24px;
+        --top-navigation-padding: var(--top-navigation-padding-y)
+          var(--top-navigation-padding-x);
+        --top-navigation-min-height: 72px;
+        --action-area-margin-x: var(--modal-content-margin);
+        --action-area-margin-y: 24px;
+        --action-area-extra-content-margin: var(--action-area-margin, 20px);
 
-        [wds-component='top-navigation'] {
-          --wds-tab-list-padding: var(--wds-modal-content-margin);
+        [data-component='top-navigation'] {
+          --tab-list-padding: var(--modal-content-margin);
         }
 
         [data-role='action-area-extra-content'] {
           margin-top: calc(
-            var(--wds-action-area-margin-x) - var(--wds-action-area-margin-y)
+            var(--action-area-margin-x) - var(--action-area-margin-y)
           );
-          margin-bottom: var(--wds-action-area-margin-y);
+          margin-bottom: var(--action-area-margin-y);
         }
 
         [data-role='navigation-title'] {
@@ -434,7 +431,7 @@ const modalContainerVariant = (variant: ModalContainerProps['variant']) => {
       `;
     case 'popup':
       return css`
-        border-radius: var(--wds-modal-popup-border-radius, 12px);
+        border-radius: var(--modal-popup-border-radius, 12px);
         animation: none;
         max-height: min(760px, 100%);
         padding: initial;
@@ -466,15 +463,12 @@ const modalContainerVariant = (variant: ModalContainerProps['variant']) => {
       `;
     case 'bottom':
       return css`
-        --wds-modal-default-max-height: calc(
+        --modal-default-max-height: calc(
           100% - env(safe-area-inset-top, 0px) - 40px
         );
         padding: 0px 0px env(safe-area-inset-bottom, 0px) 0px;
-        height: var(--wds-modal-max-height, auto);
-        max-height: var(
-          --wds-modal-max-height,
-          var(--wds-modal-default-max-height)
-        );
+        height: var(--modal-max-height, auto);
+        max-height: var(--modal-max-height, var(--modal-default-max-height));
         border-radius: 12px 12px 0px 0px;
         max-width: 480px;
         width: 100%;
@@ -484,12 +478,12 @@ const modalContainerVariant = (variant: ModalContainerProps['variant']) => {
           transform ${BOTTOM_SHEET_SETTLE_TRANSITION},
           box-shadow ${BOTTOM_SHEET_SETTLE_TRANSITION};
         pointer-events: auto;
-        transform: translateY(var(--wds-modal-translate, 0px));
+        transform: translateY(var(--modal-translate, 0px));
         animation: ${BOTTOM_SHEET_SETTLE_DURATION_MS}ms ease
           ${modalBottomMountKeyframes};
 
         &[data-status='open'] {
-          transform: translateY(var(--wds-modal-translate, 0px));
+          transform: translateY(var(--modal-translate, 0px));
         }
 
         &[data-status='close'] {
@@ -524,10 +518,7 @@ const modalContainerBottomResize = (
   switch (resize) {
     case 'fill':
       return css`
-        height: var(
-          --wds-modal-max-height,
-          var(--wds-modal-default-max-height)
-        );
+        height: var(--modal-max-height, var(--modal-default-max-height));
       `;
     case 'flexible':
       /**
@@ -550,17 +541,14 @@ const modalContainerBottomResize = (
           box-shadow ${BOTTOM_SHEET_SETTLE_TRANSITION};
 
         &[data-snap='full'] {
-          height: var(
-            --wds-modal-max-height,
-            var(--wds-modal-default-max-height)
-          );
+          height: var(--modal-max-height, var(--modal-default-max-height));
         }
 
         &[data-snap='half'],
         &[data-snap='peek'] {
           height: var(
-            --wds-modal-max-height,
-            calc(var(--wds-modal-default-max-height) * 0.5)
+            --modal-max-height,
+            calc(var(--modal-default-max-height) * 0.5)
           );
         }
       `;
@@ -576,9 +564,9 @@ export const modalNavigationStyle = ({ variant }: ModalNavigationProps) => {
     case 'emphasized':
       return css`
         [data-role='top-navigation-wrapper'] {
-          padding: var(--wds-top-navigation-padding-y, 16px)
-            var(--wds-top-navigation-padding-x, 16px);
-          min-height: var(--wds-top-navigation-min-height, 64px);
+          padding: var(--top-navigation-padding-y, 16px)
+            var(--top-navigation-padding-x, 16px);
+          min-height: var(--top-navigation-min-height, 64px);
           gap: 16px;
           width: 100%;
           justify-content: initial;
@@ -650,12 +638,12 @@ export const modalContentStyle =
   ({ gap, xs, sm, md, lg, xl }: ModalContentProps) =>
   (theme: Theme) => css`
     width: 100%;
-    padding-top: var(--wds-modal-content-margin, 20px);
-    padding-bottom: var(--wds-modal-content-margin, 20px);
+    padding-top: var(--modal-content-margin, 20px);
+    padding-bottom: var(--modal-content-margin, 20px);
 
     ${gap !== undefined
       ? css`
-          gap: calc(var(--wds-modal-content-margin, 20px));
+          gap: calc(var(--modal-content-margin, 20px));
         `
       : css`
           gap: ${toCssValue(gap)};
@@ -676,5 +664,5 @@ export const modalContentStyle =
   `;
 
 export const modalContentItemStyle = () => css`
-  padding: 0px calc(var(--wds-modal-content-margin, 20px));
+  padding: 0px calc(var(--modal-content-margin, 20px));
 `;

--- a/packages/core/src/components/pagination-dots/index.tsx
+++ b/packages/core/src/components/pagination-dots/index.tsx
@@ -96,7 +96,7 @@ const PaginationDots = forwardRef<
 
             return (
               <RovingFocusGroupItem
-                key={`wds-pagination-dot-${i}`}
+                key={`montage-pagination-dot-${i}`}
                 active={isActive}
                 focusable
                 asChild

--- a/packages/core/src/components/pagination-dots/style.ts
+++ b/packages/core/src/components/pagination-dots/style.ts
@@ -43,13 +43,12 @@ export const paginationDotsWrapperStyle =
 
     &:hover, &:has(*:focus-visible) {
       [data-role='pagination-dot-button'] {
-        width: var(--wds-pagination-dot-size, 10px);
-        height: var(--wds-pagination-dot-size, 10px);
-        margin-left: var(--wds-pagination-dot-size, 10px);
+        width: var(--pagination-dot-size, 10px);
+        height: var(--pagination-dot-size, 10px);
+        margin-left: var(--pagination-dot-size, 10px);
 
         &::after {
-          --wds-pagination-dot-border-color: ${theme.semantic.line.normal
-            .neutral};
+          --pagination-dot-border-color: ${theme.semantic.line.normal.neutral};
         }
 
         &:first-of-type {
@@ -113,7 +112,7 @@ const paginationDotsWrapperColorStyle = (
               opacity ease 0.2s;
             border: 1px solid
               var(
-                --wds-pagination-dot-border-color,
+                --pagination-dot-border-color,
                 ${theme.semantic.line.normal.neutral}
               );
           }
@@ -137,21 +136,21 @@ const paginationDotsWrapperSizeStyle = ({
       return css`
         height: 10px;
 
-        --wds-pagination-dot-size: 10px;
+        --pagination-dot-size: 10px;
       `;
     case 'small':
       return css`
         height: 8px;
 
-        --wds-pagination-dot-size: 8px;
+        --pagination-dot-size: 8px;
       `;
   }
 };
 
 export const paginationDotsStyle = (scale: number, isFirst: boolean) => css`
   transition: all ease 0.2s;
-  width: calc(var(--wds-pagination-dot-size, 10px) * ${scale});
-  height: calc(var(--wds-pagination-dot-size, 10px) * ${scale});
+  width: calc(var(--pagination-dot-size, 10px) * ${scale});
+  height: calc(var(--pagination-dot-size, 10px) * ${scale});
   margin: 0px;
   padding: 0px;
   border-radius: 1000px;
@@ -159,11 +158,11 @@ export const paginationDotsStyle = (scale: number, isFirst: boolean) => css`
   ${scale === 0 &&
   css`
     &::after {
-      --wds-pagination-dot-border-color: transparent;
+      --pagination-dot-border-color: transparent;
     }
   `}
 
   margin-left: ${scale === 0 || isFirst
     ? 0
-    : 'var(--wds-pagination-dot-size, 10px)'};
+    : 'var(--pagination-dot-size, 10px)'};
 `;

--- a/packages/core/src/components/pagination/index.tsx
+++ b/packages/core/src/components/pagination/index.tsx
@@ -373,7 +373,7 @@ const PaginationField = forwardRef<
   } = usePaginationContext(PAGINATION_FIELD_NAME);
 
   return (
-    <FlexBox wds-component="pagination-field" alignItems="center" gap="8px">
+    <FlexBox data-component="pagination-field" alignItems="center" gap="8px">
       <Label
         variant="label2"
         weight="medium"

--- a/packages/core/src/components/pagination/style.ts
+++ b/packages/core/src/components/pagination/style.ts
@@ -32,7 +32,7 @@ export const pageButtonStyle = (theme: Theme) => css`
   }
 
   // TextButton Interaction
-  [wds-component='with-interaction'] {
+  [data-component='with-interaction'] {
     width: calc(100% + 10px);
   }
 
@@ -47,7 +47,7 @@ export const pageButtonStyle = (theme: Theme) => css`
         color: ${theme.semantic.label.normal};
       }
 
-      [wds-component='with-interaction'] {
+      [data-component='with-interaction'] {
         ${activeInteractionStyle(theme, 'light')}
       }
     }

--- a/packages/core/src/components/picker-action-area/style.ts
+++ b/packages/core/src/components/picker-action-area/style.ts
@@ -3,8 +3,8 @@ import { css } from '@montage-ui/engine';
 import type { Theme } from '@montage-ui/engine';
 
 export const pickerActionAreaStyle = (theme: Theme) => css`
-  --wds-action-area-margin-x: 12px;
-  --wds-action-area-margin-y: 10px;
+  --action-area-margin-x: 12px;
+  --action-area-margin-y: 10px;
 
   border-top: 1px solid ${theme.semantic.line.solid.alternative};
   background-color: ${theme.semantic.background.elevated.normal};

--- a/packages/core/src/components/popper/index.tsx
+++ b/packages/core/src/components/popper/index.tsx
@@ -112,7 +112,7 @@ const PopperArrow = forwardRef<
   return (
     <FlexBox
       ref={composedRef}
-      wds-component="popper-arrow"
+      data-component="popper-arrow"
       aria-hidden
       {...props}
       sx={[{ width: 'fit-content', height: 'fit-content' }, props.sx]}
@@ -255,7 +255,7 @@ const PopperContent = forwardRef<
     return (
       <PortalOrFragment disablePortal={disablePortal} container={container}>
         <Box
-          wds-ignore-dismissable-layer="true"
+          data-ignore-dismissable-layer="true"
           ref={refs.setFloating}
           {...wrapperProps}
           data-side={side}

--- a/packages/core/src/components/progress-indicator/index.tsx
+++ b/packages/core/src/components/progress-indicator/index.tsx
@@ -13,7 +13,7 @@ const ProgressIndicator = forwardRef<
 >(({ percent = 0, ...props }, ref) => {
   return (
     <Box
-      wds-component="progress-indicator"
+      data-component="progress-indicator"
       role="progressbar"
       aria-valuemax={100}
       aria-valuemin={0}
@@ -26,7 +26,7 @@ const ProgressIndicator = forwardRef<
       style={
         {
           ...props.style,
-          '--wds-progress-indicator-transform': `translateX(${-100 + percent}%)`,
+          '--progress-indicator-transform': `translateX(${-100 + percent}%)`,
         } as CSSProperties
       }
     />

--- a/packages/core/src/components/progress-indicator/style.ts
+++ b/packages/core/src/components/progress-indicator/style.ts
@@ -15,7 +15,7 @@ export const progressIndicatorStyle = (theme: Theme) => css`
     inset: 0;
     width: 100%;
     height: 100%;
-    transform: var(--wds-progress-indicator-transform);
+    transform: var(--progress-indicator-transform);
     transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
     background-color: ${theme.semantic.primary.normal};
   }

--- a/packages/core/src/components/progress-step-indicator/index.tsx
+++ b/packages/core/src/components/progress-step-indicator/index.tsx
@@ -76,7 +76,7 @@ const ProgressStepIndicator = forwardRef<
         )}
       >
         <Box
-          wds-component="progress-step-indicator"
+          data-component="progress-step-indicator"
           aria-label="progress"
           ref={ref}
           {...props}
@@ -119,7 +119,7 @@ const ProgressStepIndicatorItem = forwardRef<
     <Box
       as="li"
       ref={ref}
-      wds-component="progress-step-indicator-item"
+      data-component="progress-step-indicator-item"
       aria-label={`Step ${index}`}
       {...props}
       data-is-completed={isCompleted}

--- a/packages/core/src/components/progress-tracker/index.tsx
+++ b/packages/core/src/components/progress-tracker/index.tsx
@@ -72,7 +72,7 @@ const ProgressTracker = forwardRef<
         )}
       >
         <FlexBox
-          wds-component="progress-tracker"
+          data-component="progress-tracker"
           aria-label="progress"
           as="ol"
           ref={ref}
@@ -137,7 +137,7 @@ const ProgressTrackerItemVertical = forwardRef<
     <FlexBox
       as="li"
       ref={ref}
-      wds-component="progress-tracker-item"
+      data-component="progress-tracker-item"
       aria-current={isActive ? 'step' : undefined}
       aria-label={`Step ${index}`}
       gap="20px"
@@ -255,7 +255,7 @@ const ProgressTrackerItemHorizontal = forwardRef<
     <FlexBox
       as="li"
       ref={ref}
-      wds-component="progress-tracker-item"
+      data-component="progress-tracker-item"
       aria-current={isActive ? 'step' : undefined}
       aria-label={`Step ${index}`}
       flexDirection="column"
@@ -371,7 +371,7 @@ const ProgressTrackerLabelContent = forwardRef<
     case 'badge':
       return (
         <FlexBox
-          wds-component="progress-tracker-label-content"
+          data-component="progress-tracker-label-content"
           ref={ref}
           alignItems="center"
           gap="4px"
@@ -382,7 +382,7 @@ const ProgressTrackerLabelContent = forwardRef<
     case 'caption':
       return (
         <FlexBox
-          wds-component="progress-tracker-label-content"
+          data-component="progress-tracker-label-content"
           ref={ref}
           alignItems="center"
           justifyContent="flex-end"
@@ -403,7 +403,7 @@ const ProgressTrackerLabelContent = forwardRef<
     case 'custom':
       return (
         <FlexBox
-          wds-component="progress-tracker-label-content"
+          data-component="progress-tracker-label-content"
           ref={ref}
           flex="1"
           {...props}

--- a/packages/core/src/components/push-badge/index.tsx
+++ b/packages/core/src/components/push-badge/index.tsx
@@ -76,7 +76,7 @@ const PushBadge = forwardRef<
 
         <Box
           as="span"
-          wds-component="push-badge"
+          data-component="push-badge"
           data-variant={variant}
           sx={pushBadgeStyle({ variant, invisible, position })}
         >

--- a/packages/core/src/components/push-badge/style.ts
+++ b/packages/core/src/components/push-badge/style.ts
@@ -16,10 +16,10 @@ export const pushBadgeWrapperStyle =
     position: relative;
     border-radius: inherit;
 
-    --wds-push-badge-offset-x: ${offsetX ?? '0px'};
-    --wds-push-badge-offset-y: ${offsetY ?? '0px'};
+    --push-badge-offset-x: ${offsetX ?? '0px'};
+    --push-badge-offset-y: ${offsetY ?? '0px'};
 
-    & > [wds-component='push-badge'] {
+    & > [data-component='push-badge'] {
       ${pushBadgeSizeStyle({ variant, size })}
     }
 
@@ -30,18 +30,18 @@ export const pushBadgeWrapperStyle =
       (params) => css`
         ${params?.size &&
         css`
-          & > [wds-component='push-badge'] {
+          & > [data-component='push-badge'] {
             ${pushBadgeSizeStyle({ variant, size })}
           }
         `}
 
         ${params?.offsetX !== undefined &&
         css`
-          --wds-push-badge-offset-x: ${params.offsetX};
+          --push-badge-offset-x: ${params.offsetX};
         `}
           ${params?.offsetY !== undefined &&
         css`
-          --wds-push-badge-offset-y: ${params.offsetY};
+          --push-badge-offset-y: ${params.offsetY};
         `}
         ${params?.sx}
       `,
@@ -60,10 +60,10 @@ export const pushBadgeStyle =
     ${pushBadgeVariantStyle({ variant }, theme)}
   `;
 
-// Adjacent sibling can expose `--wds-icon-button-inset` to pull the badge
+// Adjacent sibling can expose `--icon-button-inset` to pull the badge
 // inward by that amount (e.g. IconButton normal variant aligning badge to the
 // icon edge instead of the padded chrome edge). Defaults to 0px → no effect.
-const INSET = 'var(--wds-icon-button-inset, 0px)';
+const INSET = 'var(--icon-button-inset, 0px)';
 
 const pushBadgePositionStyle = ({ position, invisible }: PushBadgeProps) => {
   const transform = `${invisible ? 'scale(0)' : 'scale(1)'} translate(-50%, -50%)`;
@@ -71,58 +71,58 @@ const pushBadgePositionStyle = ({ position, invisible }: PushBadgeProps) => {
   switch (position) {
     case 'top-left':
       return css`
-        top: calc(0px + var(--wds-push-badge-offset-y) + ${INSET});
-        left: calc(0px + var(--wds-push-badge-offset-x) + ${INSET});
+        top: calc(0px + var(--push-badge-offset-y) + ${INSET});
+        left: calc(0px + var(--push-badge-offset-x) + ${INSET});
         transform: ${transform};
       `;
     case 'top-center':
       return css`
-        top: calc(0px + var(--wds-push-badge-offset-y) + ${INSET});
-        left: calc(50% + var(--wds-push-badge-offset-x));
+        top: calc(0px + var(--push-badge-offset-y) + ${INSET});
+        left: calc(50% + var(--push-badge-offset-x));
         transform: ${transform};
       `;
     case 'top-right':
       return css`
-        top: calc(0px + var(--wds-push-badge-offset-y) + ${INSET});
-        left: calc(100% + var(--wds-push-badge-offset-x) - ${INSET});
+        top: calc(0px + var(--push-badge-offset-y) + ${INSET});
+        left: calc(100% + var(--push-badge-offset-x) - ${INSET});
         transform: ${transform};
       `;
 
     case 'middle-left':
       return css`
-        top: calc(50% + var(--wds-push-badge-offset-y));
-        left: calc(0px + var(--wds-push-badge-offset-x) + ${INSET});
+        top: calc(50% + var(--push-badge-offset-y));
+        left: calc(0px + var(--push-badge-offset-x) + ${INSET});
         transform: ${transform};
       `;
     case 'middle-center':
       return css`
-        top: calc(50% + var(--wds-push-badge-offset-y));
-        left: calc(50% + var(--wds-push-badge-offset-x));
+        top: calc(50% + var(--push-badge-offset-y));
+        left: calc(50% + var(--push-badge-offset-x));
         transform: ${transform};
       `;
     case 'middle-right':
       return css`
-        top: calc(50% + var(--wds-push-badge-offset-y));
-        left: calc(100% + var(--wds-push-badge-offset-x) - ${INSET});
+        top: calc(50% + var(--push-badge-offset-y));
+        left: calc(100% + var(--push-badge-offset-x) - ${INSET});
         transform: ${transform};
       `;
 
     case 'bottom-left':
       return css`
-        top: calc(100% + var(--wds-push-badge-offset-y) - ${INSET});
-        left: calc(0px + var(--wds-push-badge-offset-x) + ${INSET});
+        top: calc(100% + var(--push-badge-offset-y) - ${INSET});
+        left: calc(0px + var(--push-badge-offset-x) + ${INSET});
         transform: ${transform};
       `;
     case 'bottom-center':
       return css`
-        top: calc(100% + var(--wds-push-badge-offset-y) - ${INSET});
-        left: calc(50% + var(--wds-push-badge-offset-x));
+        top: calc(100% + var(--push-badge-offset-y) - ${INSET});
+        left: calc(50% + var(--push-badge-offset-x));
         transform: ${transform};
       `;
     case 'bottom-right':
       return css`
-        top: calc(100% + var(--wds-push-badge-offset-y) - ${INSET});
-        left: calc(100% + var(--wds-push-badge-offset-x) - ${INSET});
+        top: calc(100% + var(--push-badge-offset-y) - ${INSET});
+        left: calc(100% + var(--push-badge-offset-x) - ${INSET});
         transform: ${transform};
       `;
   }

--- a/packages/core/src/components/radio/index.tsx
+++ b/packages/core/src/components/radio/index.tsx
@@ -77,7 +77,7 @@ const Radio = forwardRef<
             value={value}
             ref={composedRefs}
             data-tight={tight}
-            wds-component="radio"
+            data-component="radio"
             {...props}
             sx={[
               radioStyle({

--- a/packages/core/src/components/radio/style.ts
+++ b/packages/core/src/components/radio/style.ts
@@ -140,7 +140,7 @@ const radioSizeStyle = (
         css`
           width: 20px;
 
-          [wds-component='with-interaction'] {
+          [data-component='with-interaction'] {
             width: calc(100% + 12px);
           }
         `}
@@ -165,7 +165,7 @@ const radioSizeStyle = (
         css`
           width: 16px;
 
-          [wds-component='with-interaction'] {
+          [data-component='with-interaction'] {
             width: calc(100% + 12px);
           }
         `}

--- a/packages/core/src/components/round-checkbox/index.tsx
+++ b/packages/core/src/components/round-checkbox/index.tsx
@@ -17,7 +17,7 @@ const RoundCheckbox = forwardRef<
   return (
     <Checkbox
       ref={ref}
-      wds-component="round-checkbox"
+      data-component="round-checkbox"
       tight={false}
       {...props}
       sx={[roundCheckboxStyle(props), props.sx]}

--- a/packages/core/src/components/scroll-area/style.ts
+++ b/packages/core/src/components/scroll-area/style.ts
@@ -112,7 +112,7 @@ export const scrollBarThumbStyle = (theme: Theme) => css`
   border-radius: 10px;
   background-color: ${theme.semantic.fill.strong};
 
-  & > [wds-component='with-interaction'] {
+  & > [data-component='with-interaction'] {
     transition: opacity 0.2s ease;
   }
 `;

--- a/packages/core/src/components/search-field/index.tsx
+++ b/packages/core/src/components/search-field/index.tsx
@@ -66,7 +66,7 @@ const SearchField = forwardRef<
       <Box
         className={className}
         style={style}
-        wds-component="search-field"
+        data-component="search-field"
         ref={useComposedRefs(parentRef, wrapperRef)}
         sx={[
           searchFieldWrapperStyle({

--- a/packages/core/src/components/section-header/style.ts
+++ b/packages/core/src/components/section-header/style.ts
@@ -21,9 +21,9 @@ export const sectionHeaderStyle =
     }
 
     [data-role='section-header-trailing-content']
-      [wds-component='icon-button'][data-variant='normal'],
+      [data-component='icon-button'][data-variant='normal'],
     [data-role='section-header-heading-content']
-      [wds-component='icon-button'][data-variant='normal'] {
+      [data-component='icon-button'][data-variant='normal'] {
       color: ${theme.semantic.label.assistive};
     }
 

--- a/packages/core/src/components/segmented-control/index.test.tsx
+++ b/packages/core/src/components/segmented-control/index.test.tsx
@@ -16,7 +16,7 @@ describe('when given segmented control component', () => {
 
   function getItem(container: HTMLElement, value: string) {
     return container.querySelector(
-      `[wds-component="segmented-control-item"][data-value="${value}"]`,
+      `[data-component="segmented-control-item"][data-value="${value}"]`,
     );
   }
 

--- a/packages/core/src/components/segmented-control/index.tsx
+++ b/packages/core/src/components/segmented-control/index.tsx
@@ -91,10 +91,10 @@ const SegmentedControl = forwardRef<
       const targetElement = motionThumbRef.current;
 
       const currentElement = parentElement?.querySelector<HTMLDivElement>(
-        `[wds-component="segmented-control-item"][data-value="${prevValue}"]`,
+        `[data-component="segmented-control-item"][data-value="${prevValue}"]`,
       );
       const nextElement = parentElement?.querySelector<HTMLDivElement>(
-        `[wds-component="segmented-control-item"][data-value="${value}"]`,
+        `[data-component="segmented-control-item"][data-value="${value}"]`,
       );
 
       if (variant === 'outlined') {
@@ -162,7 +162,7 @@ const SegmentedControl = forwardRef<
             alignItems="stretch"
             role="radiogroup"
             {...props}
-            wds-component="segmented-control"
+            data-component="segmented-control"
             sx={[
               segmentedControlStyle({ variant, size, xs, sm, md, lg, xl }),
               props.sx,
@@ -248,7 +248,7 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
           aria-labelledby={id}
           {...props}
           disabled={disabled}
-          wds-component="segmented-control-item"
+          data-component="segmented-control-item"
           data-active={active}
           data-ssr-motion={active}
           sx={[

--- a/packages/core/src/components/snackbar/index.tsx
+++ b/packages/core/src/components/snackbar/index.tsx
@@ -115,7 +115,9 @@ const Snackbar = forwardRef(
           container={
             container ??
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            globalThis?.document?.querySelector('#wds-region-manager-bottom')
+            globalThis?.document?.querySelector(
+              '#montage-region-manager-bottom',
+            )
           }
         >
           <Box

--- a/packages/core/src/components/snackbar/style.ts
+++ b/packages/core/src/components/snackbar/style.ts
@@ -18,16 +18,16 @@ const mountKeyframes = keyframes`
   }
   to {
     opacity: 1;
-    height: var(--wds-snackbar-animation-height);
-    margin-top: var(--wds-snackbar-animation-margin-top);
+    height: var(--snackbar-animation-height);
+    margin-top: var(--snackbar-animation-margin-top);
   }
 `;
 
 const unmountKeyframes = keyframes`
   from {
     opacity: 1;
-    height: var(--wds-snackbar-animation-height);
-    margin-top: var(--wds-snackbar-animation-margin-top);
+    height: var(--snackbar-animation-height);
+    margin-top: var(--snackbar-animation-margin-top);
   }
   to {
     opacity: 0;
@@ -42,7 +42,7 @@ export const wrapperStyle =
     backdrop-filter: blur(32px);
     will-change: backdrop-filter;
     border-radius: 12px;
-    margin-top: var(--wds-snackbar-animation-margin-top);
+    margin-top: var(--snackbar-animation-margin-top);
     max-width: 100%;
 
     ${respondMore(theme.breakpoint.sm)} {
@@ -115,7 +115,7 @@ export const snackbarActionStyle = (theme: Theme) => css`
     ${typographyStyle('body2', 'bold')}
   }
 
-  & [wds-component='with-interaction'] {
+  & [data-component='with-interaction'] {
     background-color: ${theme.semantic.background.normal.normal};
   }
 `;
@@ -140,7 +140,7 @@ export const snackbarCloseButtonStyle = (theme: Theme) => css`
     opacity: ${theme.opacity[61]};
   }
 
-  & [wds-component='with-interaction'] {
+  & [data-component='with-interaction'] {
     background-color: ${theme.semantic.background.normal.normal};
   }
 `;

--- a/packages/core/src/components/stepper/index.tsx
+++ b/packages/core/src/components/stepper/index.tsx
@@ -57,7 +57,7 @@ const Stepper = forwardRef<
         )}
       >
         <FlexBox
-          wds-component="stepper"
+          data-component="stepper"
           aria-label="progress"
           ref={ref}
           {...props}
@@ -101,7 +101,7 @@ const StepperItem = forwardRef<
       <FlexBox
         as="li"
         ref={ref}
-        wds-component="stepper-item"
+        data-component="stepper-item"
         aria-current={isActive ? 'step' : undefined}
         aria-label={`Step ${index}`}
         alignItems="center"

--- a/packages/core/src/components/switch/style.ts
+++ b/packages/core/src/components/switch/style.ts
@@ -18,17 +18,17 @@ export const switchStyle =
     cursor: pointer;
     height: fit-content;
     flex-shrink: 0;
-    padding: var(--wds-switch-padding, 4px);
-    width: var(--wds-switch-width, 52px);
+    padding: var(--switch-padding, 4px);
+    width: var(--switch-width, 52px);
     transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1);
 
-    & > [wds-component='with-interaction'] {
+    & > [data-component='with-interaction'] {
       transition:
         opacity 200ms cubic-bezier(0.4, 0, 0.2, 1),
         background-color 200ms cubic-bezier(0.4, 0, 0.2, 1);
     }
 
-    &:active > [wds-component='with-interaction'] {
+    &:active > [data-component='with-interaction'] {
       ${hoverInteractionStyle(theme, 'normal')}
     }
 
@@ -43,8 +43,8 @@ export const switchStyle =
         width 200ms cubic-bezier(0.4, 0, 0.2, 1);
       display: block;
       transform-origin: 100%;
-      width: var(--wds-switch-thumb-size, 24px);
-      height: var(--wds-switch-thumb-size, 24px);
+      width: var(--switch-thumb-size, 24px);
+      height: var(--switch-thumb-size, 24px);
       margin-left: 0px;
     }
 
@@ -53,7 +53,7 @@ export const switchStyle =
     &:hover:active {
       span {
         width: calc(
-          var(--wds-switch-thumb-size, 24px) + var(--wds-switch-padding, 4px)
+          var(--switch-thumb-size, 24px) + var(--switch-padding, 4px)
         );
       }
     }
@@ -64,19 +64,19 @@ export const switchStyle =
 
       span {
         margin-left: calc(
-          var(--wds-switch-width, 52px) - var(--wds-switch-thumb-size, 24px) -
-            (var(--wds-switch-padding, 4px) * 2)
+          var(--switch-width, 52px) - var(--switch-thumb-size, 24px) -
+            (var(--switch-padding, 4px) * 2)
         );
       }
 
       &:hover:active {
         span {
           width: calc(
-            var(--wds-switch-thumb-size, 24px) + var(--wds-switch-padding, 4px)
+            var(--switch-thumb-size, 24px) + var(--switch-padding, 4px)
           );
           margin-left: calc(
-            var(--wds-switch-width, 52px) - var(--wds-switch-thumb-size, 24px) -
-              (var(--wds-switch-padding, 4px) * 3)
+            var(--switch-width, 52px) - var(--switch-thumb-size, 24px) -
+              (var(--switch-padding, 4px) * 3)
           );
         }
       }
@@ -107,18 +107,18 @@ const switchSizeStyle = ({ size }: Pick<SwitchProps, 'size'>) => {
       return css`
         border-radius: 100px;
 
-        --wds-switch-width: 52px;
-        --wds-switch-padding: 4px;
-        --wds-switch-thumb-size: 24px;
+        --switch-width: 52px;
+        --switch-padding: 4px;
+        --switch-thumb-size: 24px;
       `;
 
     case 'small':
       return css`
         border-radius: 75px;
 
-        --wds-switch-width: 39px;
-        --wds-switch-padding: 3px;
-        --wds-switch-thumb-size: 18px;
+        --switch-width: 39px;
+        --switch-padding: 3px;
+        --switch-thumb-size: 18px;
       `;
   }
 };

--- a/packages/core/src/components/tab/index.tsx
+++ b/packages/core/src/components/tab/index.tsx
@@ -172,10 +172,10 @@ const TabList = forwardRef<
       const motionElement = motionDividerRef.current;
 
       const currentElement = target.querySelector<HTMLDivElement>(
-        `[wds-component="tab-list-item"][data-value="${prevValue}"]`,
+        `[data-component="tab-list-item"][data-value="${prevValue}"]`,
       );
       const nextElement = target.querySelector<HTMLDivElement>(
-        `[wds-component="tab-list-item"][data-value="${context.value}"]`,
+        `[data-component="tab-list-item"][data-value="${context.value}"]`,
       );
 
       const nextTextElement = nextElement?.querySelector<HTMLSpanElement>(
@@ -212,7 +212,7 @@ const TabList = forwardRef<
     return (
       <RovingFocusGroup.Root asChild orientation="horizontal" loop dir="ltr">
         <FlexBox
-          wds-component="tab-list"
+          data-component="tab-list"
           role="tablist"
           ref={composedRef}
           dir={dir || 'ltr'}
@@ -363,7 +363,7 @@ const TabListItem = forwardRef<any, TabListItemProps>(
           role="tab"
           ref={composedRefs}
           {...props}
-          wds-component="tab-list-item"
+          data-component="tab-list-item"
           disabled={disabled}
           aria-selected={isActive}
           aria-labelledby={`${context.id}-${value}`}
@@ -468,7 +468,7 @@ const TabPanel = forwardRef<
     <Box
       {...props}
       ref={ref}
-      wds-component="tab-panel"
+      data-component="tab-panel"
       id={`${context.id}-${value}-panel`}
       aria-labelledby={`${context.id}-${value}`}
       role="tabpanel"

--- a/packages/core/src/components/tab/style.ts
+++ b/packages/core/src/components/tab/style.ts
@@ -49,7 +49,7 @@ export const tabListStyle =
     ${tabSizeStyle({ size, resize })}
 
     [data-role="tab-list-wrapper"] {
-      gap: calc(var(--wds-tab-padding-x) * 2);
+      gap: calc(var(--tab-padding-x) * 2);
     }
 
     &::after {
@@ -132,11 +132,11 @@ const tabPaddingStyle = ({
         display: none;
       }
 
-      --wds-tab-list-item-flex: 1 1 0;
-      --wds-tab-list-item-overflow: hidden;
-      --wds-tab-list-item-text-display: block;
-      --wds-tab-list-item-text-align: center;
-      --wds-tab-icon-button-padding: 0px;
+      --tab-list-item-flex: 1 1 0;
+      --tab-list-item-overflow: hidden;
+      --tab-list-item-text-display: block;
+      --tab-list-item-text-align: center;
+      --tab-icon-button-padding: 0px;
     `;
   }
 
@@ -149,12 +149,12 @@ const tabPaddingStyle = ({
 
         &:not(:has([data-role='tab-list-icon-button']))
           [data-radix-scroll-area-content] {
-          padding: 0px var(--wds-tab-list-padding, 20px);
+          padding: 0px var(--tab-list-padding, 20px);
         }
 
         &:has([data-role='tab-list-icon-button'])
           [data-radix-scroll-area-content] {
-          padding: 0px 0px 0px var(--wds-tab-list-padding, 20px);
+          padding: 0px 0px 0px var(--tab-list-padding, 20px);
         }
 
         ${isScrollableRight
@@ -178,12 +178,12 @@ const tabPaddingStyle = ({
               }
             `}
 
-        --wds-tab-list-item-flex: initial;
-        --wds-tab-list-item-overflow: initial;
-        --wds-tab-list-item-text-display: block;
-        --wds-tab-list-item-text-align: initial;
-        --wds-tab-icon-button-padding: 0px
-          calc(var(--wds-tab-list-padding, 20px) - 4px) 0px 0px;
+        --tab-list-item-flex: initial;
+        --tab-list-item-overflow: initial;
+        --tab-list-item-text-display: block;
+        --tab-list-item-text-align: initial;
+        --tab-icon-button-padding: 0px calc(var(--tab-list-padding, 20px) - 4px)
+          0px 0px;
       `;
     case false:
       return css`
@@ -224,11 +224,11 @@ const tabPaddingStyle = ({
               }
             `}
 
-        --wds-tab-list-item-flex: initial;
-        --wds-tab-list-item-overflow: initial;
-        --wds-tab-list-item-text-display: block;
-        --wds-tab-list-item-text-align: initial;
-        --wds-tab-icon-button-padding: 0px;
+        --tab-list-item-flex: initial;
+        --tab-list-item-overflow: initial;
+        --tab-list-item-text-display: block;
+        --tab-list-item-text-align: initial;
+        --tab-icon-button-padding: 0px;
       `;
   }
 };
@@ -237,28 +237,28 @@ const tabSizeStyle = ({ size, resize }: TabListProps) => {
   switch (size) {
     case 'small':
       return css`
-        --wds-tab-padding-x: ${resize === 'fill' ? '0px' : '12px'};
-        --wds-tab-padding-y: 9px;
+        --tab-padding-x: ${resize === 'fill' ? '0px' : '12px'};
+        --tab-padding-y: 9px;
 
-        [wds-component='tab-list-item'] {
+        [data-component='tab-list-item'] {
           ${typographyStyle('body2', 'bold')}
         }
       `;
     case 'medium':
       return css`
-        --wds-tab-padding-x: ${resize === 'fill' ? '0px' : '12px'};
-        --wds-tab-padding-y: 12px;
+        --tab-padding-x: ${resize === 'fill' ? '0px' : '12px'};
+        --tab-padding-y: 12px;
 
-        [wds-component='tab-list-item'] {
+        [data-component='tab-list-item'] {
           ${typographyStyle('headline2', 'bold')}
         }
       `;
     case 'large':
       return css`
-        --wds-tab-padding-x: ${resize === 'fill' ? '0px' : '12px'};
-        --wds-tab-padding-y: 14px;
+        --tab-padding-x: ${resize === 'fill' ? '0px' : '12px'};
+        --tab-padding-y: 14px;
 
-        [wds-component='tab-list-item'] {
+        [data-component='tab-list-item'] {
           ${typographyStyle('headline2', 'bold')}
         }
       `;
@@ -286,20 +286,20 @@ export const scrollWrapperStyle = css`
 export const tabListWrapperStyle = (theme: Theme) => css`
   position: relative;
 
-  --wds-tab-list-active-divider-color: ${theme.semantic.label.strong};
-  --wds-tab-list-disabled-divider-color: ${theme.semantic.fill.alternative};
+  --tab-list-active-divider-color: ${theme.semantic.label.strong};
+  --tab-list-disabled-divider-color: ${theme.semantic.fill.alternative};
 
-  --wds-tab-list-divider-color: var(--wds-tab-list-active-divider-color);
+  --tab-list-divider-color: var(--tab-list-active-divider-color);
 
   &:has([aria-selected='true'][aria-disabled='true']) {
-    --wds-tab-list-divider-color: var(--wds-tab-list-disabled-divider-color);
+    --tab-list-divider-color: var(--tab-list-disabled-divider-color);
   }
 `;
 
 export const motionDividerStyle = css`
   position: absolute;
   height: 2px;
-  background-color: var(--wds-tab-list-divider-color);
+  background-color: var(--tab-list-divider-color);
   transition: background-color 0.2s ease;
   display: none;
 `;
@@ -307,10 +307,10 @@ export const motionDividerStyle = css`
 export const tabListItemStyle =
   ({ disabled }: { disabled?: boolean }) =>
   (theme: Theme) => css`
-    padding: var(--wds-tab-padding-y) 0px;
+    padding: var(--tab-padding-y) 0px;
     scroll-margin-inline: 25px;
-    flex: var(--wds-tab-list-item-flex, initial);
-    overflow: var(--wds-tab-list-item-overflow, initial);
+    flex: var(--tab-list-item-flex, initial);
+    overflow: var(--tab-list-item-overflow, initial);
     position: relative;
     cursor: pointer;
 
@@ -324,15 +324,15 @@ export const tabListItemStyle =
     [data-role='tab-list-item-text'] {
       white-space: nowrap;
       transition: color 0.2s ease;
-      display: var(--wds-tab-list-item-text-display, block);
-      text-align: var(--wds-tab-list-item-text-align, initial);
+      display: var(--tab-list-item-text-display, block);
+      text-align: var(--tab-list-item-text-align, initial);
     }
 
     [data-role='tab-list-item-divider'] {
       position: absolute;
       left: 0;
       transition: background-color 0.2s ease;
-      bottom: calc(var(--wds-tab-padding-y) * -1);
+      bottom: calc(var(--tab-padding-y) * -1);
       max-height: 0px;
       height: 2px;
       width: 100%;
@@ -354,7 +354,7 @@ export const tabListItemStyle =
           &[data-ssr-motion='true'] {
             [data-role='tab-list-item-divider'] {
               max-height: 2px;
-              background-color: var(--wds-tab-list-disabled-divider-color);
+              background-color: var(--tab-list-disabled-divider-color);
             }
           }
         `
@@ -378,7 +378,7 @@ export const tabListItemStyle =
             &[data-ssr-motion='true'] {
               [data-role='tab-list-item-divider'] {
                 max-height: 2px;
-                background-color: var(--wds-tab-list-active-divider-color);
+                background-color: var(--tab-list-active-divider-color);
               }
             }
           }
@@ -391,7 +391,7 @@ export const tabListItemStyle =
 
 export const tabListItemInteractionStyle = css`
   position: absolute;
-  width: calc(100% + (var(--wds-tab-padding-x) * 2));
+  width: calc(100% + (var(--tab-padding-x) * 2));
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
@@ -403,5 +403,5 @@ export const stickyButtonStyle = css`
   right: 0px;
   height: 100%;
   flex-shrink: 0;
-  padding: var(--wds-tab-icon-button-padding, 0px);
+  padding: var(--tab-icon-button-padding, 0px);
 `;

--- a/packages/core/src/components/table/style.ts
+++ b/packages/core/src/components/table/style.ts
@@ -8,19 +8,19 @@ import {
 import type { Theme } from '@montage-ui/engine';
 
 export const tableStyle = (theme: Theme) => css`
-  --wds-table-head-cell-padding-x: 20px;
-  --wds-table-head-cell-padding-y: 8px;
-  --wds-table-head-cell-min-height: 44px;
+  --table-head-cell-padding-x: 20px;
+  --table-head-cell-padding-y: 8px;
+  --table-head-cell-min-height: 44px;
 
-  --wds-table-cell-padding-x: 20px;
-  --wds-table-cell-padding-y: 16px;
-  --wds-table-cell-min-height: 44px;
+  --table-cell-padding-x: 20px;
+  --table-cell-padding-y: 16px;
+  --table-cell-min-height: 44px;
 
-  --wds-table-border-color: ${theme.semantic.line.solid.neutral};
+  --table-border-color: ${theme.semantic.line.solid.neutral};
 
   border-radius: 12px;
   overflow: hidden;
-  border: 1px solid var(--wds-table-border-color);
+  border: 1px solid var(--table-border-color);
 
   table {
     display: table;
@@ -55,24 +55,23 @@ export const scrollAreaStyle = css`
 `;
 
 export const tableHeadCellStyle = css`
-  padding: var(--wds-table-head-cell-padding-y, 8px) 0px
-    var(--wds-table-head-cell-padding-y, 8px)
-    var(--wds-table-head-cell-padding-x, 20px);
-  height: var(--wds-table-head-cell-min-height, 44px);
+  padding: var(--table-head-cell-padding-y, 8px) 0px
+    var(--table-head-cell-padding-y, 8px) var(--table-head-cell-padding-x, 20px);
+  height: var(--table-head-cell-min-height, 44px);
   vertical-align: middle;
   display: table-cell;
   border: none;
-  border-bottom: 1px solid var(--wds-table-border-color);
+  border-bottom: 1px solid var(--table-border-color);
 `;
 
 export const tableCellStyle = css`
-  padding: var(--wds-table-cell-padding-y, 16px) 0px
-    var(--wds-table-cell-padding-y, 16px) var(--wds-table-cell-padding-x, 20px);
+  padding: var(--table-cell-padding-y, 16px) 0px
+    var(--table-cell-padding-y, 16px) var(--table-cell-padding-x, 20px);
   vertical-align: middle;
   display: table-cell;
   border: none;
-  height: var(--wds-table-cell-min-height, 44px);
-  border-bottom: 1px solid var(--wds-table-border-color);
+  height: var(--table-cell-min-height, 44px);
+  border-bottom: 1px solid var(--table-border-color);
 `;
 
 export const tableRowStyle = (interaction?: boolean) => (theme: Theme) => css`
@@ -83,10 +82,10 @@ export const tableRowStyle = (interaction?: boolean) => (theme: Theme) => css`
   border: none;
 
   td:last-child {
-    padding-right: var(--wds-table-head-cell-padding-x, 20px);
+    padding-right: var(--table-head-cell-padding-x, 20px);
   }
   th:last-child {
-    padding-right: var(--wds-table-head-cell-padding-x, 20px);
+    padding-right: var(--table-head-cell-padding-x, 20px);
   }
 
   ${interaction &&
@@ -161,7 +160,6 @@ export const tableFootStyle = css`
 `;
 
 export const paginationWrapperStyle = css`
-  padding: var(--wds-table-cell-padding-y, 16px)
-    var(--wds-table-cell-padding-x, 20px);
-  border-top: 1px solid var(--wds-table-border-color);
+  padding: var(--table-cell-padding-y, 16px) var(--table-cell-padding-x, 20px);
+  border-top: 1px solid var(--table-border-color);
 `;

--- a/packages/core/src/components/text-area/helpers.ts
+++ b/packages/core/src/components/text-area/helpers.ts
@@ -8,7 +8,7 @@ export const getTextAreaDefaultHeight = ({
   minRows = 2,
 }: Pick<TextAreaProps, 'minRows'>) => {
   return {
-    '--wds-text-area-scroll-height': `${minRows * DEFAULT_LINE_HEIGHT}px`,
-    '--wds-text-area-height': `${minRows * DEFAULT_LINE_HEIGHT}px`,
+    '--text-area-scroll-height': `${minRows * DEFAULT_LINE_HEIGHT}px`,
+    '--text-area-height': `${minRows * DEFAULT_LINE_HEIGHT}px`,
   } as CSSProperties;
 };

--- a/packages/core/src/components/text-area/index.tsx
+++ b/packages/core/src/components/text-area/index.tsx
@@ -113,7 +113,7 @@ const TextArea = forwardRef<
           outerHeight,
         );
 
-        parent.style.setProperty('--wds-text-area-height', outerHeight + 'px');
+        parent.style.setProperty('--text-area-height', outerHeight + 'px');
       }
 
       outerHeight = maxRows
@@ -126,10 +126,7 @@ const TextArea = forwardRef<
           )
         : outerHeight;
 
-      parent.style.setProperty(
-        '--wds-text-area-scroll-height',
-        `${outerHeight}px`,
-      );
+      parent.style.setProperty('--text-area-scroll-height', `${outerHeight}px`);
     }, [maxRows, minRows, props.placeholder]);
 
     useResizeObserver(textAreaRef.current, syncTextAreaHeight);
@@ -182,7 +179,7 @@ const TextArea = forwardRef<
         <FlexBox
           ref={parentRef}
           flexDirection="column"
-          wds-component="text-area"
+          data-component="text-area"
           className={className}
           style={{
             ...getTextAreaDefaultHeight({ minRows }),
@@ -299,7 +296,7 @@ const TextAreaContent = forwardRef<
       return (
         <Typography
           as="div"
-          wds-component="text-area-content"
+          data-component="text-area-content"
           variant="label2"
           weight="medium"
           ref={ref}
@@ -322,7 +319,7 @@ const TextAreaContent = forwardRef<
     case 'badge':
       return (
         <FlexBox
-          wds-component="text-area-content"
+          data-component="text-area-content"
           ref={ref}
           sx={[textAreaContentStyle, sx]}
           {...props}
@@ -333,7 +330,7 @@ const TextAreaContent = forwardRef<
     case 'button':
       return (
         <FlexBox
-          wds-component="text-area-content"
+          data-component="text-area-content"
           ref={ref}
           alignItems="center"
           sx={[
@@ -349,7 +346,7 @@ const TextAreaContent = forwardRef<
     case 'icon':
       return (
         <FlexBox
-          wds-component="text-area-content"
+          data-component="text-area-content"
           ref={ref}
           sx={[
             textAreaContentStyle,
@@ -368,7 +365,7 @@ const TextAreaContent = forwardRef<
     case 'icon-button':
       return (
         <FlexBox
-          wds-component="text-area-content"
+          data-component="text-area-content"
           ref={ref}
           sx={[textAreaContentStyle, sx]}
           {...props}
@@ -382,7 +379,7 @@ const TextAreaContent = forwardRef<
     default:
       return (
         <FlexBox
-          wds-component="text-area-content"
+          data-component="text-area-content"
           ref={ref}
           sx={[textAreaContentStyle, sx]}
           {...props}

--- a/packages/core/src/components/text-area/style.ts
+++ b/packages/core/src/components/text-area/style.ts
@@ -108,7 +108,7 @@ export const textAreaWrapperStyle =
     }
 
     [data-radix-scroll-area-viewport] {
-      height: var(--wds-text-area-scroll-height);
+      height: var(--text-area-scroll-height);
     }
 
     ${createResponsiveStyle(
@@ -127,7 +127,7 @@ export const textAreaWrapperStyle =
 export const textAreaStyle =
   ({ xs, sm, md, lg, xl }: TextAreaProps) =>
   (theme: Theme) => css`
-    height: var(--wds-text-area-height);
+    height: var(--text-area-height);
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/packages/core/src/components/text-button/index.tsx
+++ b/packages/core/src/components/text-button/index.tsx
@@ -64,7 +64,7 @@ const TextButton = forwardRef(
       >
         <Box
           as={(as || 'button') as T}
-          wds-component="text-button"
+          data-component="text-button"
           data-color={color}
           aria-labelledby={id}
           ref={ref}

--- a/packages/core/src/components/text-button/style.ts
+++ b/packages/core/src/components/text-button/style.ts
@@ -39,7 +39,7 @@ export const textButtonStyle =
       cursor: wait;
       &
         > *:not([data-role='text-button-loading']):not(
-          [wds-component='with-interaction']
+          [data-component='with-interaction']
         ) {
         visibility: hidden;
       }
@@ -123,7 +123,7 @@ const textButtonSizeStyle = ({ size }: TextButtonProps, theme: Theme) => {
           height: ${theme.dimension[14]};
         }
 
-        & > [wds-component='with-interaction'] {
+        & > [data-component='with-interaction'] {
           width: calc(100% + (${theme.spacing[8]} * 2));
           height: 100%;
         }
@@ -147,7 +147,7 @@ const textButtonSizeStyle = ({ size }: TextButtonProps, theme: Theme) => {
           height: ${theme.dimension[12]};
         }
 
-        & > [wds-component='with-interaction'] {
+        & > [data-component='with-interaction'] {
           width: calc(100% + (${theme.spacing[6]} * 2));
           height: 100%;
         }

--- a/packages/core/src/components/text-field/index.test.tsx
+++ b/packages/core/src/components/text-field/index.test.tsx
@@ -20,7 +20,7 @@ describe('when given text field component', () => {
     const { container } = render(<TextField data-testid="text-field" />);
 
     const wrapper = container.querySelector<HTMLElement>(
-      '[wds-component="text-field"]',
+      '[data-component="text-field"]',
     )!;
 
     fireEvent.click(wrapper);

--- a/packages/core/src/components/text-field/index.tsx
+++ b/packages/core/src/components/text-field/index.tsx
@@ -94,7 +94,7 @@ const TextField = forwardRef<
       <Box
         className={className}
         style={style}
-        wds-component="text-field"
+        data-component="text-field"
         ref={useComposedRefs(parentRef, wrapperRef)}
         sx={[
           textFieldWrapperStyle({
@@ -211,7 +211,7 @@ const TextFieldContent = forwardRef<
       return (
         <Typography
           as="div"
-          wds-component="text-field-content"
+          data-component="text-field-content"
           variant="body1"
           weight="medium"
           ref={ref}
@@ -225,7 +225,7 @@ const TextFieldContent = forwardRef<
     case 'badge':
       return (
         <FlexBox
-          wds-component="text-field-content"
+          data-component="text-field-content"
           ref={ref}
           sx={[textFieldContentStyle, sx]}
           {...props}
@@ -239,7 +239,7 @@ const TextFieldContent = forwardRef<
           as="div"
           variant="label1"
           weight="bold"
-          wds-component="text-field-content"
+          data-component="text-field-content"
           ref={ref}
           sx={[textFieldContentStyle, { padding: '2px 4px' }, sx]}
           color={color ?? 'semantic.primary.normal'}
@@ -251,7 +251,7 @@ const TextFieldContent = forwardRef<
     case 'icon':
       return (
         <FlexBox
-          wds-component="text-field-content"
+          data-component="text-field-content"
           ref={ref}
           sx={[
             textFieldContentStyle,
@@ -270,7 +270,7 @@ const TextFieldContent = forwardRef<
     case 'icon-button':
       return (
         <FlexBox
-          wds-component="text-field-content"
+          data-component="text-field-content"
           ref={ref}
           sx={[
             textFieldContentStyle,
@@ -289,7 +289,7 @@ const TextFieldContent = forwardRef<
     case 'text-button':
       return (
         <FlexBox
-          wds-component="text-field-content"
+          data-component="text-field-content"
           ref={ref}
           sx={[textFieldContentStyle, sx]}
           alignItems="center"
@@ -302,7 +302,7 @@ const TextFieldContent = forwardRef<
     default:
       return (
         <FlexBox
-          wds-component="text-field-content"
+          data-component="text-field-content"
           ref={ref}
           sx={[textFieldContentStyle, sx]}
           {...props}

--- a/packages/core/src/components/thumbnail/index.tsx
+++ b/packages/core/src/components/thumbnail/index.tsx
@@ -54,7 +54,7 @@ const Thumbnail = forwardRef<
     return imageLoadingStatus !== 'error' && Boolean(props.src) ? (
       <FlexBox
         as="figure"
-        wds-component="thumbnail"
+        data-component="thumbnail"
         className={className}
         style={style}
         data-status={imageLoadingStatus}
@@ -94,7 +94,7 @@ const Thumbnail = forwardRef<
     ) : (
       <FlexBox
         as="figure"
-        wds-component="thumbnail"
+        data-component="thumbnail"
         className={className}
         style={style}
         aria-label={props.alt}
@@ -149,7 +149,7 @@ const ThumbnailSkeleton = forwardRef(
     return (
       <Skeleton
         ref={ref}
-        wds-component="thumbnail-skeleton"
+        data-component="thumbnail-skeleton"
         as="figure"
         variant="rectangle"
         aria-hidden

--- a/packages/core/src/components/time-view/index.tsx
+++ b/packages/core/src/components/time-view/index.tsx
@@ -104,7 +104,7 @@ const TimeView = forwardRef<
       >
         <FlexBox
           ref={ref}
-          wds-component="time-view"
+          data-component="time-view"
           sx={[timeViewStyle, sx]}
           {...props}
         >
@@ -313,7 +313,7 @@ const TimeItem = forwardRef<
       if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
 
       const timeViewElement = e.currentTarget.closest(
-        '[wds-component="time-view"]',
+        '[data-component="time-view"]',
       );
       const currentTimeListScrollArea = e.currentTarget.closest(
         '[data-role="time-list-scroll-area"]',

--- a/packages/core/src/components/time-view/style.ts
+++ b/packages/core/src/components/time-view/style.ts
@@ -88,7 +88,7 @@ export const timeItemStyle =
     &:focus-visible {
       outline: none;
 
-      [wds-component='with-interaction'] {
+      [data-component='with-interaction'] {
         opacity: 0.06;
       }
     }

--- a/packages/core/src/components/toast/hooks.ts
+++ b/packages/core/src/components/toast/hooks.ts
@@ -117,8 +117,8 @@ export const useToastAnimation = ({
     handleMouseEnter,
     handleMouseLeave,
     style: {
-      [`--wds-${component}-animation-height`]: `${height}px`,
-      [`--wds-${component}-animation-margin-top`]: disablePortal ? 0 : '10px',
+      [`--${component}-animation-height`]: `${height}px`,
+      [`--${component}-animation-margin-top`]: disablePortal ? 0 : '10px',
     } as CSSProperties,
   };
 };

--- a/packages/core/src/components/toast/index.tsx
+++ b/packages/core/src/components/toast/index.tsx
@@ -117,7 +117,9 @@ const Toast = forwardRef(
           container={
             container ??
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            globalThis?.document?.querySelector('#wds-region-manager-bottom')
+            globalThis?.document?.querySelector(
+              '#montage-region-manager-bottom',
+            )
           }
         >
           <Box

--- a/packages/core/src/components/toast/style.ts
+++ b/packages/core/src/components/toast/style.ts
@@ -13,16 +13,16 @@ const mountKeyframes = keyframes`
   }
   to {
     opacity: 1;
-    height: var(--wds-toast-animation-height);
-    margin-top: var(--wds-toast-animation-margin-top);
+    height: var(--toast-animation-height);
+    margin-top: var(--toast-animation-margin-top);
   }
 `;
 
 const unmountKeyframes = keyframes`
   from {
     opacity: 1;
-    height: var(--wds-toast-animation-height);
-    margin-top: var(--wds-toast-animation-margin-top);
+    height: var(--toast-animation-height);
+    margin-top: var(--toast-animation-margin-top);
   }
   to {
     opacity: 0;
@@ -37,7 +37,7 @@ export const wrapperStyle =
     backdrop-filter: blur(32px);
     will-change: backdrop-filter;
     border-radius: 12px;
-    margin-top: var(--wds-toast-animation-margin-top);
+    margin-top: var(--toast-animation-margin-top);
     max-width: 100%;
 
     ${respondMore(theme.breakpoint.sm)} {

--- a/packages/core/src/components/tooltip/style.ts
+++ b/packages/core/src/components/tooltip/style.ts
@@ -75,7 +75,7 @@ export const tooltipWrapperSizeStyle = ({
         [data-role='tooltip-content-close-button'] {
           font-size: 10px;
 
-          & > [wds-component='with-interaction'] {
+          & > [data-component='with-interaction'] {
             width: calc(100% + 8px);
             height: calc(100% + 8px);
           }
@@ -113,7 +113,7 @@ export const tooltipWrapperSizeStyle = ({
         [data-role='tooltip-content-close-button'] {
           font-size: 16px;
 
-          & > [wds-component='with-interaction'] {
+          & > [data-component='with-interaction'] {
             width: calc(100% + 16px);
             height: calc(100% + 16px);
           }
@@ -161,7 +161,7 @@ export const tooltipContentStyle = (theme: Theme) => css`
     )} !important;
   }
 
-  [wds-component='with-interaction'] {
+  [data-component='with-interaction'] {
     background: ${theme.semantic.inverse.label};
   }
 `;

--- a/packages/core/src/components/top-navigation/index.tsx
+++ b/packages/core/src/components/top-navigation/index.tsx
@@ -50,7 +50,7 @@ const TopNavigation = forwardRef<
   ) => {
     return (
       <FlexBox
-        wds-component="top-navigation"
+        data-component="top-navigation"
         ref={ref}
         flexDirection="column"
         data-background={background}
@@ -189,7 +189,7 @@ const TopNavigationButton = forwardRef(
           variant="normal"
           size={24}
           {...props}
-          wds-component="top-navigation-button"
+          data-component="top-navigation-button"
           ref={ref}
         >
           {children}
@@ -204,7 +204,7 @@ const TopNavigationButton = forwardRef(
           size="medium"
           {...props}
           sx={[topNavigationButtonTextStyle, props.sx]}
-          wds-component="top-navigation-button"
+          data-component="top-navigation-button"
           ref={ref}
         >
           {children}

--- a/packages/core/src/components/top-navigation/style.ts
+++ b/packages/core/src/components/top-navigation/style.ts
@@ -34,24 +34,24 @@ export const topNavigationWrapperStyle = (
     case 'normal':
       return css`
         width: 100%;
-        padding: var(--wds-top-navigation-padding-y, 16px)
-          var(--wds-top-navigation-padding-x, 16px);
+        padding: var(--top-navigation-padding-y, 16px)
+          var(--top-navigation-padding-x, 16px);
         justify-content: center;
-        min-height: var(--wds-top-navigation-min-height, 56px);
+        min-height: var(--top-navigation-min-height, 56px);
         position: relative;
       `;
     case 'display':
       return css`
-        padding: var(--wds-top-navigation-padding-y, 16px)
-          var(--wds-top-navigation-padding-x, 16px);
+        padding: var(--top-navigation-padding-y, 16px)
+          var(--top-navigation-padding-x, 16px);
         gap: 20px;
         width: 100%;
         position: relative;
       `;
     case 'floating':
       return css`
-        padding: var(--wds-top-navigation-padding-y, 16px)
-          var(--wds-top-navigation-padding-x, 16px);
+        padding: var(--top-navigation-padding-y, 16px)
+          var(--top-navigation-padding-x, 16px);
         top: 0px;
         left: 0px;
         position: absolute;
@@ -60,8 +60,8 @@ export const topNavigationWrapperStyle = (
       `;
     case 'search':
       return css`
-        padding: var(--wds-top-navigation-padding-y, 16px)
-          var(--wds-top-navigation-padding-x, 16px);
+        padding: var(--top-navigation-padding-y, 16px)
+          var(--top-navigation-padding-x, 16px);
         gap: 12px;
         width: 100%;
         position: relative;
@@ -192,7 +192,7 @@ export const topNavigationTitleStyle = (
         padding: 0px 4px;
 
         h2 {
-          width: var(--wds-top-navigation-title-width, 80%);
+          width: var(--top-navigation-title-width, 80%);
           text-align: center;
           ${ellipsisTypographyStyle(2)}
           -webkit-line-clamp: 1;
@@ -206,7 +206,7 @@ export const topNavigationTitleStyle = (
         flex: 1 1 auto;
         padding: 0px;
 
-        [wds-component='search-field'] {
+        [data-component='search-field'] {
           width: 100%;
         }
       `;
@@ -238,8 +238,8 @@ export const topNavigationRightIconStyle = (
     case 'floating':
       return css`
         position: absolute;
-        right: var(--wds-top-navigation-padding-x, 16px);
-        top: var(--wds-top-navigation-padding-y, 16px);
+        right: var(--top-navigation-padding-x, 16px);
+        top: var(--top-navigation-padding-y, 16px);
       `;
     case 'display':
       return undefined;
@@ -254,8 +254,8 @@ export const topNavigationLeftIconStyle = (
     case 'floating':
       return css`
         position: absolute;
-        left: var(--wds-top-navigation-padding-x, 16px);
-        top: var(--wds-top-navigation-padding-y, 16px);
+        left: var(--top-navigation-padding-x, 16px);
+        top: var(--top-navigation-padding-y, 16px);
       `;
     case 'display':
       return undefined;
@@ -270,7 +270,7 @@ export const topNavigationButtonTextStyle = css`
     ${typographyStyle('headline2', 'regular')}
   }
 
-  [wds-component='with-interaction'] {
+  [data-component='with-interaction'] {
     height: calc(100% + 8px);
   }
 `;

--- a/packages/core/src/components/with-interaction/index.test.tsx
+++ b/packages/core/src/components/with-interaction/index.test.tsx
@@ -26,7 +26,7 @@ describe('when given with-interaction component', () => {
     expect(
       screen
         .getByTestId('element')
-        .querySelector('[wds-component="with-interaction"]'),
+        .querySelector('[data-component="with-interaction"]'),
     ).toBeInTheDocument();
   });
 
@@ -35,7 +35,7 @@ describe('when given with-interaction component', () => {
       await axe(
         screen
           .getByTestId('element')
-          .querySelector('[wds-component="with-interaction"]') as Element,
+          .querySelector('[data-component="with-interaction"]') as Element,
       ),
     ).toHaveNoViolations();
   });
@@ -43,7 +43,7 @@ describe('when given with-interaction component', () => {
   it('should have correct initial styles', () => {
     const element = screen
       .getByTestId('element')
-      .querySelector('[wds-component="with-interaction"]') as HTMLElement;
+      .querySelector('[data-component="with-interaction"]') as HTMLElement;
 
     expect(element).toBeInTheDocument();
     expect(element).toHaveStyle({
@@ -85,7 +85,7 @@ describe('when given with-interaction component with color prop', () => {
 
     const colorElement = screen
       .getByTestId('color-element')
-      .querySelector('[wds-component="with-interaction"]') as HTMLElement;
+      .querySelector('[data-component="with-interaction"]') as HTMLElement;
 
     expect(colorElement).toBeInTheDocument();
     expect(colorElement).toHaveStyle({

--- a/packages/core/src/components/with-interaction/index.tsx
+++ b/packages/core/src/components/with-interaction/index.tsx
@@ -74,7 +74,7 @@ const Interaction = ({
 }: WithInteractionProps) => {
   return (
     <Box
-      wds-component="with-interaction"
+      data-component="with-interaction"
       role="presentation"
       sx={interactionStyle({ color, width, height })}
     />

--- a/packages/core/src/components/with-interaction/style.ts
+++ b/packages/core/src/components/with-interaction/style.ts
@@ -46,36 +46,36 @@ export const getWrapperStyle =
 
     ${!disabled &&
     css`
-      &:hover > [wds-component='with-interaction'] {
+      &:hover > [data-component='with-interaction'] {
         ${hoverInteractionStyle(theme, variant)}
       }
 
       @media not (pointer: fine) {
-        &:hover > [wds-component='with-interaction'] {
+        &:hover > [data-component='with-interaction'] {
           opacity: ${theme.opacity[0]};
         }
       }
 
-      &:focus-visible > [wds-component='with-interaction'] {
+      &:focus-visible > [data-component='with-interaction'] {
         opacity: ${theme.opacity[0]};
       }
-      &:active > [wds-component='with-interaction'] {
+      &:active > [data-component='with-interaction'] {
         ${activeInteractionStyle(theme, variant)}
       }
 
       ${scale &&
       css`
-        & > [wds-component='with-interaction'] {
+        & > [data-component='with-interaction'] {
           will-change: transform;
           transform: translate(-50%, -50%) scale(0.95);
         }
 
-        &:hover > [wds-component='with-interaction'] {
+        &:hover > [data-component='with-interaction'] {
           transform: translate(-50%, -50%) scale(1);
         }
 
         @media not (pointer: fine) {
-          & > [wds-component='with-interaction'] {
+          & > [data-component='with-interaction'] {
             transform: translate(-50%, -50%) scale(1);
           }
         }

--- a/packages/core/src/theme-provider/store-provider/region.tsx
+++ b/packages/core/src/theme-provider/store-provider/region.tsx
@@ -36,20 +36,20 @@ const RegionArea = () => {
   return (
     <>
       <Box
-        wds-ignore-dismissable-layer="true"
+        data-ignore-dismissable-layer="true"
         style={
           {
-            '--wds-region-viewport-max-width': `calc(${config.viewportMaxWidth})`,
-            '--wds-region-viewport-bottom': `calc(env(safe-area-inset-bottom, 0px) + ${config.viewportBottom})`,
+            '--region-viewport-max-width': `calc(${config.viewportMaxWidth})`,
+            '--region-viewport-bottom': `calc(env(safe-area-inset-bottom, 0px) + ${config.viewportBottom})`,
           } as CSSProperties
         }
         role="region"
         aria-live="polite"
-        id="wds-region-manager"
+        id="montage-region-manager"
         aria-label="Notifications"
       >
         <Box
-          id="wds-region-manager-bottom"
+          id="montage-region-manager-bottom"
           sx={(theme) => ({
             position: 'fixed',
             zIndex: 5500,
@@ -60,11 +60,11 @@ const RegionArea = () => {
             alignItems: 'center',
             display: 'flex',
             flexDirection: 'column',
-            maxWidth: 'var(--wds-region-viewport-max-width, 100%)',
+            maxWidth: 'var(--region-viewport-max-width, 100%)',
             padding: '20px',
             left: '50%',
             transform: 'translateX(-50%)',
-            bottom: 'var(--wds-region-viewport-bottom, 0px)',
+            bottom: 'var(--region-viewport-bottom, 0px)',
             paddingBottom: '40px',
             [`@media (max-width: ${theme.breakpoint.sm})`]: {
               minWidth: '100%',

--- a/packages/core/src/utils/framed-style.ts
+++ b/packages/core/src/utils/framed-style.ts
@@ -33,9 +33,9 @@ export const framedStyle = (params?: FramedStyleParams) => (theme: Theme) => {
 
     background-color: transparent;
     display: flex;
-    padding: var(--wds-framed-style-vertical-padding)
-      var(--wds-framed-style-horizontal-padding);
-    border-radius: var(--wds-framed-style-border-radius);
+    padding: var(--framed-style-vertical-padding)
+      var(--framed-style-horizontal-padding);
+    border-radius: var(--framed-style-border-radius);
     position: relative;
     width: fit-content;
     height: fit-content;
@@ -71,28 +71,28 @@ const getSizeStyle = (size: FramedStyleParams['size']) => {
   switch (size) {
     case 'small':
       return css`
-        --wds-framed-style-border-radius: 12px;
-        --wds-framed-style-vertical-padding: 4px;
-        --wds-framed-style-horizontal-padding: 12px;
+        --framed-style-border-radius: 12px;
+        --framed-style-vertical-padding: 4px;
+        --framed-style-horizontal-padding: 12px;
       `;
     case 'medium':
     default:
       return css`
-        --wds-framed-style-border-radius: 14px;
-        --wds-framed-style-vertical-padding: 4px;
-        --wds-framed-style-horizontal-padding: 16px;
+        --framed-style-border-radius: 14px;
+        --framed-style-vertical-padding: 4px;
+        --framed-style-horizontal-padding: 16px;
       `;
     case 'large':
       return css`
-        --wds-framed-style-border-radius: 16px;
-        --wds-framed-style-vertical-padding: 4px;
-        --wds-framed-style-horizontal-padding: 20px;
+        --framed-style-border-radius: 16px;
+        --framed-style-vertical-padding: 4px;
+        --framed-style-horizontal-padding: 20px;
       `;
     case 'xlarge':
       return css`
-        --wds-framed-style-border-radius: 20px;
-        --wds-framed-style-vertical-padding: 8px;
-        --wds-framed-style-horizontal-padding: 24px;
+        --framed-style-border-radius: 20px;
+        --framed-style-vertical-padding: 8px;
+        --framed-style-horizontal-padding: 24px;
       `;
   }
 };

--- a/packages/nextjs/src/app-router-cache-provider.tsx
+++ b/packages/nextjs/src/app-router-cache-provider.tsx
@@ -75,7 +75,6 @@ const AppRouterCacheProvider = (props: AppRouterCacheProviderProps) => {
             nonce={options?.nonce}
             key={name}
             data-emotion={`${registry.cache.key}-global ${name}`}
-            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: style! }}
           />
         ))}
@@ -83,7 +82,6 @@ const AppRouterCacheProvider = (props: AppRouterCacheProviderProps) => {
           <style
             nonce={options?.nonce}
             data-emotion={dataEmotionAttribute}
-            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: styles }}
           />
         )}

--- a/packages/nextjs/src/pages-router-cache-provider.tsx
+++ b/packages/nextjs/src/pages-router-cache-provider.tsx
@@ -113,7 +113,6 @@ export async function documentGetInitialProps(
             <style
               data-emotion={`${style.key} ${style.ids.join(' ')}`}
               key={style.key}
-              // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: style.css }}
             />
           )),


### PR DESCRIPTION
## Summary

- core의 `--wds-*` CSS 변수를 `--*`로 변경 (`--wds-column/row-spacing`은 충돌 방지 위해 `--grid-*`로 스코프)
- DOM 식별자: `wds-component` → `data-component`, `wds-ignore-first-focus`/`wds-ignore-dismissable-layer` → `data-ignore-*`, `#wds-region-manager(-bottom)` → `#montage-region-manager(-bottom)`
- codemod v4 추가: `css-variable-migration`, `dom-identifier-migration` — css``/inline style/scss/JSX attribute 변환, CLI 텍스트 패스로 스타일시트까지 처리
- docs(src/mdx)의 CSS 변수/셀렉터 참조 일괄 업데이트
- `MIGRATION.md` 4.0.0 마이그레이션 가이드 추가

## Jira

[WRP-1055](https://wantedlab.atlassian.net/browse/WRP-1055) — [디자인시스템] wds- CSS Variable / DOM attribute 4.0 네이밍 마이그레이션 (codemod 포함)

- Status: 열림
- Type: 작업

## Test plan

- [x] core 유닛 테스트 247/247 통과 (스냅샷 영향 없음)
- [x] codemod fixture로 css``/inline/scss/JSX 전 케이스 변환 + idempotency 확인
- [ ] docs 사이트 빌드/렌더 정상 (CI)
- [ ] visual regression (CI)

## 참고

- nextjs의 emotion cache key `'wds'`는 core와 동기화가 필요한 별개 항목이라 이 PR 범위에서 제외

[WRP-1055]: https://wantedlab.atlassian.net/browse/WRP-1055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 4.0.0 마이그레이션 가이드 추가 — CSS 변수 및 DOM 식별자 변경 안내 및 적용 명령어 포함
* **변경 사항**
  * CSS 변수 네이밍 간소화: `--wds-` 접두사 제거(예: `--modal-...`, `--table-...` 등)
  * DOM 식별자 표준화: `wds-component`/`wds-*` → `data-*` 또는 `montage-*`
  * 마이그레이션용 codemod 명령 추가로 일괄 치환 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->