### PR TITLE
feat(theme): semantic 토큰에 primary/negative interaction·line·fill 추가

### DIFF
--- a/packages/theme/src/theme/semantic/index.ts
+++ b/packages/theme/src/theme/semantic/index.ts
@@ -99,7 +99,7 @@ export const light = {
     strong: addHexOpacity(atomic.coolNeutral[50], opacity[16]),
     alternative: addHexOpacity(atomic.coolNeutral[50], opacity[5]),
     primary: addHexOpacity(atomic.blue[50], opacity[5]),
-    negative: addHexOpacity(atomic.red[50], opacity[5]),
+    negative: addHexOpacity(atomic.red[50], opacity[12]),
   },
   material: {
     dimmer: addHexOpacity(atomic.coolNeutral[10], opacity[52]),

--- a/packages/theme/src/theme/semantic/index.ts
+++ b/packages/theme/src/theme/semantic/index.ts
@@ -37,6 +37,8 @@ export const light = {
   interaction: {
     inactive: atomic.coolNeutral[70],
     disable: atomic.coolNeutral[98],
+    focus: addHexOpacity(atomic.blue[50], opacity[12]),
+    negative: addHexOpacity(atomic.red[50], opacity[12]),
   },
   line: {
     normal: {
@@ -48,6 +50,14 @@ export const light = {
       normal: atomic.coolNeutral[96],
       neutral: atomic.coolNeutral[97],
       alternative: atomic.coolNeutral[98],
+    },
+    primary: {
+      normal: addHexOpacity(atomic.blue[50], opacity[28]),
+      strong: addHexOpacity(atomic.blue[50], opacity[43]),
+    },
+    negative: {
+      normal: addHexOpacity(atomic.red[50], opacity[28]),
+      strong: addHexOpacity(atomic.red[50], opacity[43]),
     },
   },
   status: {
@@ -88,6 +98,8 @@ export const light = {
     normal: addHexOpacity(atomic.coolNeutral[50], opacity[8]),
     strong: addHexOpacity(atomic.coolNeutral[50], opacity[16]),
     alternative: addHexOpacity(atomic.coolNeutral[50], opacity[5]),
+    primary: addHexOpacity(atomic.blue[50], opacity[5]),
+    negative: addHexOpacity(atomic.red[50], opacity[5]),
   },
   material: {
     dimmer: addHexOpacity(atomic.coolNeutral[10], opacity[52]),
@@ -151,6 +163,8 @@ export const dark = {
   interaction: {
     inactive: atomic.coolNeutral[40],
     disable: atomic.coolNeutral[22],
+    focus: addHexOpacity(atomic.blue[60], opacity[12]),
+    negative: addHexOpacity(atomic.red[60], opacity[12]),
   },
   line: {
     normal: {
@@ -162,6 +176,14 @@ export const dark = {
       normal: atomic.coolNeutral[25],
       neutral: atomic.coolNeutral[23],
       alternative: atomic.coolNeutral[22],
+    },
+    primary: {
+      normal: addHexOpacity(atomic.blue[60], opacity[28]),
+      strong: addHexOpacity(atomic.blue[60], opacity[43]),
+    },
+    negative: {
+      normal: addHexOpacity(atomic.red[60], opacity[28]),
+      strong: addHexOpacity(atomic.red[60], opacity[43]),
     },
   },
   status: {
@@ -202,6 +224,8 @@ export const dark = {
     normal: addHexOpacity(atomic.coolNeutral[50], opacity[22]),
     strong: addHexOpacity(atomic.coolNeutral[50], opacity[28]),
     alternative: addHexOpacity(atomic.coolNeutral[50], opacity[12]),
+    primary: addHexOpacity(atomic.blue[60], opacity[5]),
+    negative: addHexOpacity(atomic.red[60], 0.2),
   },
   material: {
     dimmer: addHexOpacity(atomic.coolNeutral[10], opacity[74]),


### PR DESCRIPTION
## Summary

- `interaction.focus` / `interaction.negative` 추가 (light/dark) — focus·negative 상태 그림자 표현용
- `line.primary.normal/strong` / `line.negative.normal/strong` 추가 — chip 기본 보더, TextField focus/negative 보더 색상
- `fill.primary` / `fill.negative` 추가 — chip·negative 요소 내부 색상

투명도가 적용된 semantic 토큰을 디자인 스펙에 맞춰 추가합니다 (additive, breaking 없음).

## Jira

[WRP-1052](https://wantedlab.atlassian.net/browse/WRP-1052) — [WDS] Semantic 토큰 추가

- Status: 진행 중
- Type: 하위 작업

투명도가 있는 Semantic 토큰을 추가합니다. (Line/Primary, Line/Negative, Interaction/Focus·Negative, Fill/Primary·Negative)

## Test plan

- [ ] light/dark 각 테마에서 추가된 토큰 값이 디자인 스펙(투명도 %)과 일치하는지 확인

[WRP-1052]: https://wantedlab.atlassian.net/browse/WRP-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 라이트·다크 테마의 인터랙션에 포커스 및 부정 상태 색상 추가
  * 라인 색상에 프라이머리 및 부정 색상 항목 추가
  * 채우기 설정을 간소화하여 기존 중립 계열을 제거하고 프라이머리·부정 색상으로 대체
  * 전반적인 UI 색상 체계와 상태 표현이 개선되어 시각적 일관성과 접근성이 향상되었습니다
<!-- end of auto-generated comment: release notes by coderabbit.ai -->