### PR TITLE
fix(wds): pagination dots 마지막 페이지에서 첫 dot 간격 오류 수정

### DIFF
--- a/packages/wds/src/components/pagination-dots/index.test.tsx
+++ b/packages/wds/src/components/pagination-dots/index.test.tsx
@@ -60,6 +60,18 @@ describe('when given pagination dots component', () => {
     });
   });
 
+  it('should not add leading margin to the first dot when visibleArea starts below zero', () => {
+    // totalPages(4) < maxDotCount(5) + 마지막 페이지 → visibleArea가 [-1, 3]이 되는 케이스
+    const { container } = render(
+      <PaginationDots totalPages={4} currentPage={4} maxDotCount={5} />,
+    );
+
+    const buttons = container.querySelectorAll(
+      '[data-role="pagination-dot-button"]',
+    );
+    expect(getComputedStyle(buttons[0]!).marginLeft).toBe('0px');
+  });
+
   it('should throw on invalid totalPages in non-production env', () => {
     expect(() => render(<PaginationDots totalPages={-1} />)).toThrow(
       'Invalid totalPages in PaginationDots',

--- a/packages/wds/src/components/pagination-dots/index.tsx
+++ b/packages/wds/src/components/pagination-dots/index.tsx
@@ -107,7 +107,10 @@ const PaginationDots = forwardRef<
                   type="button"
                   onClick={() => onClickDot?.(i + 1)}
                   data-role="pagination-dot-button"
-                  sx={paginationDotsStyle(scale, i === visibleArea[0])}
+                  sx={paginationDotsStyle(
+                    scale,
+                    i === Math.max(visibleArea[0], 0),
+                  )}
                   aria-selected={isActive}
                   aria-label={`Slide dot ${i + 1}`}
                   onFocus={(e) => {


### PR DESCRIPTION
## Summary

- `totalPages`가 `maxDotCount`보다 작고 마지막 페이지인 경우(예: `totalPages=4`, `maxDotCount=5`, `currentPage=4`) `getPaginationDotsVisibleArea`의 last 분기가 `[totalPages - maxDotCount, totalPages - 1]` = `[-1, 3]`을 반환합니다.
- 기존 `isFirst` 조건 `i === visibleArea[0]`은 어떤 dot 인덱스도 `-1`과 같을 수 없어 첫 dot이 first로 인식되지 않았고, 첫 dot에 `margin-left`가 적용되어 다른 페이지 대비 간격이 틀어졌습니다.
- `i === Math.max(visibleArea[0], 0)`으로 클램프하여 `visibleArea[0]`이 음수여도 dot 0이 first로 인식되도록 수정했습니다. `visibleArea[0] >= 0`인 기존 케이스는 동작 변화가 없습니다.
- 해당 케이스의 회귀 테스트를 추가했습니다 (수정 전 코드에서 실패, 수정 후 통과 확인).

_No Jira ticket — minor fix._

## Test plan

- [x] `pnpm vitest run packages/wds/src/components/pagination-dots/index.test.tsx` — 6개 테스트 통과
- [x] 추가된 회귀 테스트가 수정 전 코드에서 실패하는 것 확인
- [ ] CI visual regression 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 페이지네이션 닷 컴포넌트에서 특정 상황(전체 페이지 수가 최대 닷 개수보다 적을 때)의 렌더링 문제를 해결했습니다.

* **테스트**
  * 페이지네이션 닷 컴포넌트의 경계 조건에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->