### PR TITLE
chore(*): wds → montage 패키지명 변경 잔재 정리

### DIFF
--- a/.claude/references/architecture.md
+++ b/.claude/references/architecture.md
@@ -2,42 +2,42 @@
 
 ## Project Overview
 
-Montage (formerly WDS) is Wanted Lab's design system for web. It's a Lerna + Nx monorepo containing 9 packages, all published under `@wanteddev/*` to GitHub Package Registry.
+Montage (formerly WDS) is Wanted Lab's design system for web. It's a Lerna + Nx monorepo. Public packages are published under `@montage-ui/*` to the npm registry, while internal packages (e.g., `@wanteddev/montage-mcp`) are published to the GitHub Package Private Registry.
 
 ## Package Dependency Graph
 
 ```text
-wds-theme (design tokens, no React dependency)
+theme (design tokens, no React dependency)
     ↓
-wds-engine (Box, ThemeProvider, polymorphic types — depends on wds-theme + Emotion)
+engine (Box, ThemeProvider, polymorphic types — depends on theme + Emotion)
     ↓
-wds, wds-icon, wds-lottie (UI components — depend on wds-engine)
+core, icon, lottie (UI components — depend on engine)
     ↓
-wds-nextjs (Next.js integration — depends on wds-engine)
+nextjs (Next.js integration — depends on engine)
 ```
 
-Tooling packages (`wds-codemod`, `wds-mcp`, `eslint-plugin-wds`) are standalone.
+Tooling packages (`codemod`, `mcp`, `eslint-plugin`) are standalone.
 
 ## Where to make changes (and where not to)
 
-Day-to-day work — adding components, updating styles, reflecting design changes from Figma — happens in **`wds`** (and occasionally `wds-icon` / `wds-lottie`). The foundation packages should be treated as nearly read-only:
+Day-to-day work — adding components, updating styles, reflecting design changes from Figma — happens in **`core`** (and occasionally `icon` / `lottie`). The foundation packages should be treated as nearly read-only:
 
-| Package      | Modify?                                        | Why                                                                                                                                                                                                     |
-| ------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wds`        | **Yes** — primary work surface                 | Component implementations, styles, types live here.                                                                                                                                                     |
-| `wds-icon`   | Via `sync-icons` skill, not by hand            | Icon set is generated from Figma. Manual edits get overwritten on the next sync.                                                                                                                        |
-| `wds-lottie` | Yes (rare)                                     | Only when adding/updating Lottie assets.                                                                                                                                                                |
-| `wds-theme`  | **Almost never** — token additions only        | Adding a new semantic token is OK when one is genuinely missing. Renaming/removing tokens, or changing the token shape, is a breaking change for every consumer of `wds`. Coordinate before touching.   |
-| `wds-engine` | **Almost never** — `Box`/types/`sx` are stable | Box, ThemeProvider, polymorphic types, the `sx` prop runtime, `useSxProps`. These are the primitives every component depends on; bugs here ripple through the entire library. Defer to the maintainers. |
-| `wds-nextjs` | **Almost never** — Next.js integration only    | RSC boundaries, `'use client'` injection. Touch only when a Next.js compatibility issue is the actual root cause.                                                                                       |
+| Package  | Modify?                                        | Why                                                                                                                                                                                                     |
+| -------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `core`   | **Yes** — primary work surface                 | Component implementations, styles, types live here.                                                                                                                                                     |
+| `icon`   | Via `sync-icons` skill, not by hand            | Icon set is generated from Figma. Manual edits get overwritten on the next sync.                                                                                                                        |
+| `lottie` | Yes (rare)                                     | Only when adding/updating Lottie assets.                                                                                                                                                                |
+| `theme`  | **Almost never** — token additions only        | Adding a new semantic token is OK when one is genuinely missing. Renaming/removing tokens, or changing the token shape, is a breaking change for every consumer of `core`. Coordinate before touching.  |
+| `engine` | **Almost never** — `Box`/types/`sx` are stable | Box, ThemeProvider, polymorphic types, the `sx` prop runtime, `useSxProps`. These are the primitives every component depends on; bugs here ripple through the entire library. Defer to the maintainers. |
+| `nextjs` | **Almost never** — Next.js integration only    | RSC boundaries, `'use client'` injection. Touch only when a Next.js compatibility issue is the actual root cause.                                                                                       |
 
-**Rule of thumb**: if a task can be solved by editing files under `packages/wds/src/components/<name>/`, do it there. If it seems to require touching `wds-engine` / `wds-theme` / `wds-nextjs`, stop and confirm with the user — usually the right fix is in `wds` (compose `Box`/tokens/types differently), not in the foundation. Foundation changes are breaking-change territory and belong on a `feature/<major>.<minor>.<patch>` branch with explicit intent.
+**Rule of thumb**: if a task can be solved by editing files under `packages/core/src/components/<name>/`, do it there. If it seems to require touching `engine` / `theme` / `nextjs`, stop and confirm with the user — usually the right fix is in `core` (compose `Box`/tokens/types differently), not in the foundation. Foundation changes are breaking-change territory and belong on a `feature/<major>.<minor>.<patch>` branch with explicit intent.
 
-The token exception worth knowing: if a designer asks for a color/spacing/typography value that doesn't exist as a `theme.semantic.*` token, the right move is to **add** the token in `wds-theme` (small, additive, non-breaking) rather than inline a hex/px literal in the component. This is the one routine reason to touch `wds-theme`.
+The token exception worth knowing: if a designer asks for a color/spacing/typography value that doesn't exist as a `theme.semantic.*` token, the right move is to **add** the token in `theme` (small, additive, non-breaking) rather than inline a hex/px literal in the component. This is the one routine reason to touch `theme`.
 
 ## Component Type System
 
-`wds-engine` exposes two parallel type families. Both have a public variant (with `sx`) and an `Internal` variant (without `sx`, used inside implementations because `Box` consumes `sx` separately).
+`engine` exposes two parallel type families. Both have a public variant (with `sx`) and an `Internal` variant (without `sx`, used inside implementations because `Box` consumes `sx` separately).
 
 ### Choosing the right pattern
 
@@ -95,7 +95,7 @@ Each component follows this layout:
 
 ```text
 component-name/
-├── index.tsx       # Implementation (uses Box from wds-engine)
+├── index.tsx       # Implementation (uses Box from engine)
 ├── types.ts        # Props defined with WithSxProps<{...}> + ResponsiveProps
 ├── style.ts        # Style functions using theme tokens
 ├── constants.ts    # Optional constants
@@ -106,9 +106,9 @@ component-name/
 
 Three-layer architecture:
 
-1. **wds-theme**: Raw atomic tokens + semantic tokens (light/dark) + design tokens (spacing, opacity, breakpoint, zIndex)
-2. **wds-engine**: Emotion-based runtime (ThemeProvider, Box with `sx` prop, `useSxProps` hook)
-3. **wds**: Components compose styles using theme tokens via style functions
+1. **theme**: Raw atomic tokens + semantic tokens (light/dark) + design tokens (spacing, opacity, breakpoint, zIndex)
+2. **engine**: Emotion-based runtime (ThemeProvider, Box with `sx` prop, `useSxProps` hook)
+3. **core**: Components compose styles using theme tokens via style functions
 
 ## Responsive Props
 

--- a/.claude/references/coding-style.md
+++ b/.claude/references/coding-style.md
@@ -12,7 +12,7 @@
 
 ## Component Folder Structure
 
-Every component lives in its own kebab-case directory under `packages/wds/src/components/<component-name>/`. Files are added only when needed — start minimal.
+Every component lives in its own kebab-case directory under `packages/core/src/components/<component-name>/`. Files are added only when needed — start minimal.
 
 ```text
 component-name/
@@ -26,13 +26,13 @@ component-name/
 └── index.test.tsx  # Optional. Vitest + Testing Library unit tests.
 ```
 
-The component is then re-exported from `packages/wds/src/components/index.ts` with `export * from './component-name';` — that one line is the entire registration step.
+The component is then re-exported from `packages/core/src/components/index.ts` with `export * from './component-name';` — that one line is the entire registration step.
 
 ### When to add each optional file
 
 - **`constants.ts`**: as soon as you have a compound component (Accordion, AccordionSummary, ...). Name strings are shared between `displayName` and the Radix context name to keep error messages consistent. Also a good home for non-styling magic numbers.
 - **`contexts.ts`**: whenever a parent component needs to share state with descendants. Use `@radix-ui/react-context`'s `createContext` (returns `[Provider, useContext]` tuple) — never `React.createContext` directly, because the Radix version gives clearer "must be used within X" errors and accepts a name for the message.
-- **`hooks.ts`**: when a hook is component-internal and not reused elsewhere. If it becomes reusable, lift it to `packages/wds/src/hooks/`.
+- **`hooks.ts`**: when a hook is component-internal and not reused elsewhere. If it becomes reusable, lift it to `packages/core/src/hooks/`.
 - **`helpers.ts`**: pure functions (no React, no hooks). Keeps `index.tsx` readable.
 
 ## types.ts — Props Type Patterns
@@ -181,7 +181,7 @@ Note the trailing `as PolymorphicComponentInternal<...>` cast — it's required 
 ### Conventions that apply to both
 
 - **Always `forwardRef`.** Even seemingly leaf components get refs from consumers (focus management, animations, third-party integrations).
-- **Render through `Box`** from `wds-engine` — never a raw `div`/`span`/etc. `Box` handles the `sx` prop, theme access, and the polymorphic `as` plumbing.
+- **Render through `Box`** from `engine` — never a raw `div`/`span`/etc. `Box` handles the `sx` prop, theme access, and the polymorphic `as` plumbing.
 - **Spread `{...props}` _before_ `sx`** so the merged-with-defaults `sx` wins over any incoming `sx` from `props`. Do the same for any prop you intentionally override (`onClick` composed via `composeEventHandlers`, etc).
 - **Compose event handlers, don't replace them.** When you need to add behavior to `onClick` / `onKeyDown`, use `composeEventHandlers(internalHandler, props.onClick)` from `@radix-ui/primitive` so the consumer's handler still runs.
 - **Provide controllable state via `useControllableState`** (`@radix-ui/react-use-controllable-state`) — it gives you the `value`/`defaultValue`/`onChange` triple for free, matching native form-element semantics.
@@ -287,7 +287,7 @@ This expands to the project's breakpoint media queries and applies styles only t
 
 ### Always use theme tokens
 
-Reference `theme.semantic.*` (semantic tokens — light/dark aware) over `theme.color.*` (raw atomic tokens). Never hardcode hex values. If a token doesn't exist, the right move is to add one in `wds-theme`, not to inline a literal.
+Reference `theme.semantic.*` (semantic tokens — light/dark aware) over `theme.color.*` (raw atomic tokens). Never hardcode hex values. If a token doesn't exist, the right move is to add one in `theme`, not to inline a literal.
 
 ## contexts.ts — Compound Component Context
 
@@ -321,7 +321,7 @@ The argument to `useAccordionContext` is the _consumer_ name (used in error mess
 - Unit tests use **Vitest** with **@testing-library/react** and **vitest-axe** for accessibility
 - Test globals are enabled (`describe`, `it`, `expect`, `vi` available without imports)
 - Setup mocks: `matchMedia`, `ResizeObserver`, `HTMLCanvasElement`
-- Bundle size limits enforced via **size-limit** (e.g., wds: 5KB gzipped)
+- Bundle size limits enforced via **size-limit** (e.g., core: 5KB gzipped)
 - Test file lives next to the component as `index.test.tsx` — no separate `__tests__/` directory
 - Always include at least one `vitest-axe` accessibility assertion for interactive components
 

--- a/.claude/references/workflow.md
+++ b/.claude/references/workflow.md
@@ -51,8 +51,8 @@ The `create-pr` skill enforces this: a major bump with `main` as base or a missi
 Conventional Commits are mandatory: `<type>(<scope>): <description>`. `commitlint` enforces this on every commit.
 
 - **Allowed types** (matching repo history): `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `style`, `build`, `ci`
-- **Common scopes**: package names — `wds`, `wds-engine`, `wds-icon`, `wds-mcp`, `ci`. Match what `git log --oneline -20` shows.
-- **Breaking changes**: append `!` after the type/scope (`feat!:`, `feat(wds)!:`) or include a `BREAKING CHANGE:` footer. Either form bumps the major version.
+- **Common scopes**: package names — `core`, `engine`, `icon`, `mcp`, `ci`. Match what `git log --oneline -20` shows.
+- **Breaking changes**: append `!` after the type/scope (`feat!:`, `feat(core)!:`) or include a `BREAKING CHANGE:` footer. Either form bumps the major version.
 - **Body**: focus on the _why_, not the _what_ — the diff already shows the what.
 
 The commit-msg hook (`scripts/commit-msg.mjs`) does extra work for you:

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -115,7 +115,7 @@ Wait for the user's answer:
 
 **The PR title must be Conventional Commits format** — `<type>(<scope>): <subject>` (or `<type>: <subject>` if no scope, `<type>!:` for breaking). This is non-negotiable: PRs are squash-merged here, so the PR title becomes the merged commit message, which lerna parses to compute the version bump and generate the changelog. A non-conventional title silently breaks both. `commitlint` enforces it on commits but **not** on PR titles, so this skill is the gate.
 
-Allowed types (matching the existing repo history): `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `style`, `build`, `ci`. Common scopes are package names (`wds`, `wds-engine`, `wds-icon`, `wds-mcp`, `ci`) — check `git log --oneline -20` to match what's in use.
+Allowed types (matching the existing repo history): `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `style`, `build`, `ci`. Common scopes are package names (`core`, `engine`, `icon`, `theme`, `ci`) — check `git log --oneline -20` to match what's in use.
 
 How to derive the title:
 

--- a/.claude/skills/sync-icons/SKILL.md
+++ b/.claude/skills/sync-icons/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sync-icons
-description: Sync icons from the Figma file into `wds-icon` and open a PR by dispatching the `figma-icon-sync-code-connect.yml` GitHub Actions workflow. The workflow pulls the latest icon set from Figma, generates Code Connect bindings, and opens a PR against the branch you dispatched from. Use this skill whenever the user says "아이콘 업데이트해줘", "아이콘 싱크해줘", "Figma에서 아이콘 가져와줘", "sync icons", "update icons from Figma", "code connect publish", or otherwise indicates they want the icon set refreshed from the Figma source of truth.
+description: Sync icons from the Figma file into `icon` and open a PR by dispatching the `figma-icon-sync-code-connect.yml` GitHub Actions workflow. The workflow pulls the latest icon set from Figma, generates Code Connect bindings, and opens a PR against the branch you dispatched from. Use this skill whenever the user says "아이콘 업데이트해줘", "아이콘 싱크해줘", "Figma에서 아이콘 가져와줘", "sync icons", "update icons from Figma", "code connect publish", or otherwise indicates they want the icon set refreshed from the Figma source of truth.
 ---
 
 # sync-icons
 
-Triggers the `figma-icon-sync-code-connect.yml` workflow that does all the actual work — pulls icons from Figma, regenerates `wds-icon`, wires up Code Connect, and opens a PR. This skill just dispatches the workflow with the right inputs against the right branch.
+Triggers the `figma-icon-sync-code-connect.yml` workflow that does all the actual work — pulls icons from Figma, regenerates `icon`, wires up Code Connect, and opens a PR. This skill just dispatches the workflow with the right inputs against the right branch.
 
 ## When to trigger
 
@@ -19,12 +19,12 @@ Triggers the `figma-icon-sync-code-connect.yml` workflow that does all the actua
 You don't run any of this yourself — it's all in the workflow. But knowing the steps helps you set expectations for the user:
 
 1. Pulls the icon set from the Figma file (uses `FIGMA_TOKEN` secret).
-2. Runs `scripts/figma-icon.mjs` to regenerate `packages/wds-icon`.
+2. Runs `scripts/figma-icon.mjs` to regenerate `packages/icon`.
 3. Creates a branch named `feature/code-connect/<run_id>`, commits, pushes.
 4. Opens a PR with that branch as the **head** and the **branch you dispatched from** as the **base**.
 5. If `publish=true`, also publishes Code Connect mappings to Figma (so designers see the codebase ↔ Figma binding).
 
-The PR title is auto-set to `feat(wds,wds-icon): icon figma sync and new code connect publish`.
+The PR title is auto-set to `feat(core,icon): icon figma sync and new code connect publish`.
 
 ## Workflow inputs
 
@@ -91,7 +91,7 @@ Don't poll for completion unless the user asks — the workflow takes minutes, a
 
 When the auto-generated PR shows up, it should be milestoned as a **minor** version bump — adding icons is a non-breaking feature add, so it falls under `feat` in Conventional Commits and bumps the minor version.
 
-The workflow titles the PR `feat(wds,wds-icon): icon figma sync and new code connect publish`, which `create-pr`'s bump-type detection will already classify as minor. But the workflow opens the PR via the `github-actions[bot]` and doesn't attach a milestone, so:
+The workflow titles the PR `feat(core,icon): icon figma sync and new code connect publish`, which `create-pr`'s bump-type detection will already classify as minor. But the workflow opens the PR via the `github-actions[bot]` and doesn't attach a milestone, so:
 
 - After the workflow finishes, attach the next minor milestone (e.g. current `3.5.0` → `3.6.0`) to the PR. The `create-pr` skill's milestone logic explains how to compute and ensure the milestone exists.
 - The only situation where it's _not_ minor: if the sync also removes or renames existing icons in a way that breaks consumers (i.e. the diff has icon deletions). That's a `feat!:` and bumps major — but it should also be on a major branch, not `main`. Surface the deletion to the user and confirm before touching the milestone.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: 'Bug Report'
 title: 'Bug: '
-description: Report a bug in WDS
+description: Report a bug in Montage
 labels:
   - 'bug'
 body:
@@ -34,9 +34,9 @@ body:
       required: true
   - type: input
     attributes:
-      label: WDS Version
-      description: Which version of WDS are you using?
-      placeholder: e.g. 3.0.0
+      label: Montage Version
+      description: Which version of Montage are you using?
+      placeholder: e.g. 4.0.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/figma-icon-sync-code-connect.yml
+++ b/.github/workflows/figma-icon-sync-code-connect.yml
@@ -77,7 +77,7 @@ jobs:
           git branch feature/code-connect/${{ github.run_id }}
           git checkout feature/code-connect/${{ github.run_id }}
           git add .
-          git commit -m "feat(wds-icon): add icons synced from figma" --no-verify
+          git commit -m "feat(icon): add icons synced from figma" --no-verify
           git push origin feature/code-connect/${{ github.run_id }}
 
       - name: Extract branch name
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create New PR
         run: |
-          gh pr create -B ${{ steps.extract_branch.outputs.branch }} -H feature/code-connect/${{ github.run_id }} --title "feat(wds,wds-icon): icon figma sync and new code connect publish" --body "add icons synced from figma"
+          gh pr create -B ${{ steps.extract_branch.outputs.branch }} -H feature/code-connect/${{ github.run_id }} --title "feat(core,icon): icon figma sync and new code connect publish" --body "add icons synced from figma"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/pr-noti.yml
+++ b/.github/workflows/pr-noti.yml
@@ -19,8 +19,8 @@ jobs:
           script: |
             const { data } = await github.rest.pulls.get({
               pull_number: context.issue.number,
-              owner: 'wanteddev',
-              repo: 'wds',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
             });
 
             const title = data.title.replace(/\\/g, '\\\\').

--- a/docs/data/utilities/web-utilities/add-opacity.mdx
+++ b/docs/data/utilities/web-utilities/add-opacity.mdx
@@ -24,7 +24,7 @@ export const exampleStyle = (theme: Theme) => css`
 위 코드는 아래와 같이 렌더링 됩니다.
 
 ```css
-.wds-exampleStyle1 {
+.montage-exampleStyle1 {
   background-color: rgba(var(--theme-semantic-label-normal-rgb), 0.12);
 }
 ```
@@ -46,7 +46,7 @@ export const exampleStyle = (theme: Theme) => css`
 위 코드는 아래와 같이 렌더링 됩니다.
 
 ```css
-.wds-exampleStyle1 {
+.montage-exampleStyle1 {
   background-color: #0000001f;
 }
 ```

--- a/docs/data/utilities/web-utilities/media.mdx
+++ b/docs/data/utilities/web-utilities/media.mdx
@@ -24,7 +24,7 @@ export const exampleStyle = (theme: Theme) => css`
 위 코드는 아래와 같이 렌더링 됩니다.
 
 ```css
-.wds-exampleStyle1 {
+.montage-exampleStyle1 {
   width: 100px;
   @media only screen and (max-width: 767px) {
     width: 50px;
@@ -52,7 +52,7 @@ export const exampleStyle = (theme: Theme) => css`
 위 코드는 아래와 같이 렌더링 됩니다.
 
 ```css
-.wds-exampleStyle1 {
+.montage-exampleStyle1 {
   width: 100px;
   @media only screen and (min-width: 768px) {
     width: 50px;

--- a/docs/data/utilities/web-utilities/navigation.mdx
+++ b/docs/data/utilities/web-utilities/navigation.mdx
@@ -21,7 +21,7 @@ export const exampleStyle = (theme: Theme) => css`
 위 코드는 아래와 같이 렌더링 됩니다.
 
 ```css
-.wds-exampleStyle1 {
+.montage-exampleStyle1 {
   background-color: rgba(var(--semantic-background-elevated-normal-rgb), 0.74);
   backdrop-filter: blur(32px);
 }

--- a/docs/src/features/docs/components/mdx/demo/hooks.ts
+++ b/docs/src/features/docs/components/mdx/demo/hooks.ts
@@ -2,8 +2,8 @@ import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import copy from 'copy-to-clipboard';
 import { useToast } from '@montage-ui/core';
 import * as React from 'react';
-import * as Wds from '@montage-ui/core';
-import * as WdsIcon from '@montage-ui/icon';
+import * as Montage from '@montage-ui/core';
+import * as MontageIcon from '@montage-ui/icon';
 import * as reactVirtual from '@tanstack/react-virtual';
 import * as HookForm from 'react-hook-form';
 import * as reactSpring from 'react-spring';
@@ -15,7 +15,7 @@ import dynamic from 'next/dynamic';
 
 import { useRunner } from './react-runner';
 
-const WdsLottieLoading = dynamic(
+const MontageLottieLoading = dynamic(
   () => import('@montage-ui/lottie').then(({ Loading }) => Loading),
   { ssr: false },
 );
@@ -31,9 +31,9 @@ export const useReactDemoRunner = ({ code }: UseReactDemoRunnerParams) => {
     return {
       import: {
         react: React,
-        '@montage-ui/core': Wds,
-        '@montage-ui/icon': WdsIcon,
-        '@montage-ui/lottie': { Loading: WdsLottieLoading },
+        '@montage-ui/core': Montage,
+        '@montage-ui/icon': MontageIcon,
+        '@montage-ui/lottie': { Loading: MontageLottieLoading },
         '@tanstack/react-virtual': reactVirtual,
         'react-hook-form': HookForm,
         'copy-to-clipboard': copy,

--- a/docs/src/features/docs/components/mdx/section/hierarchy/index.tsx
+++ b/docs/src/features/docs/components/mdx/section/hierarchy/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as Wds from '@montage-ui/core';
+import * as Montage from '@montage-ui/core';
 import { FlexBox } from '@montage-ui/core';
 import { useMemo } from 'react';
 
@@ -47,7 +47,7 @@ const SectionHierarchyItem = ({
     return {
       import: {
         react: React,
-        '@montage-ui/core': Wds,
+        '@montage-ui/core': Montage,
       },
     };
   }, []);

--- a/docs/src/features/docs/components/mdx/section/variants/index.tsx
+++ b/docs/src/features/docs/components/mdx/section/variants/index.tsx
@@ -16,8 +16,8 @@ import {
   useTheme,
 } from '@montage-ui/core';
 import * as React from 'react';
-import * as Wds from '@montage-ui/core';
-import * as WdsIcon from '@montage-ui/icon';
+import * as Montage from '@montage-ui/core';
+import * as MontageIcon from '@montage-ui/icon';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { IconTune } from '@montage-ui/icon';
 
@@ -264,8 +264,8 @@ const SectionVariantsItemDemo = memo(
       return {
         import: {
           react: React,
-          '@montage-ui/core': Wds,
-          '@montage-ui/icon': WdsIcon,
+          '@montage-ui/core': Montage,
+          '@montage-ui/icon': MontageIcon,
           internal: { Carousel },
         },
       };

--- a/docs/src/features/docs/constants/index.ts
+++ b/docs/src/features/docs/constants/index.ts
@@ -14,7 +14,7 @@ export const DOCS_PAGES = [
   {
     title: 'Web',
     slug: ['getting-started', 'platform', 'web'],
-    url: 'https://github.com/wanteddev/montage-web/blob/main/packages/wds/README.md',
+    url: 'https://github.com/wanteddev/montage-web/blob/main/packages/core/README.md',
     isExternal: true,
   },
   {

--- a/packages/codemod/src/transforms/v4/package-name-migration.ts
+++ b/packages/codemod/src/transforms/v4/package-name-migration.ts
@@ -10,7 +10,7 @@ const PACKAGE_NAME_MAP: Record<string, string> = {
   '@wanteddev/wds-codemod': '@montage-ui/codemod',
   '@wanteddev/wds-dummy': '@montage-ui/dummy',
   '@wanteddev/wds-brand': '@montage-ui/brand',
-  '@wanteddev/wds-eslint-plugin': '@montage-ui/eslint-plugin',
+  '@wanteddev/eslint-plugin-wds': '@montage-ui/eslint-plugin',
   '@wanteddev/wds-mcp': '@wanteddev/montage-mcp',
 };
 

--- a/packages/core/README.ko.md
+++ b/packages/core/README.ko.md
@@ -330,3 +330,51 @@ const MyApp = ({
 
 export default MyApp;
 ```
+
+## 다크 모드
+
+다크 모드는 기본적으로 비활성화되어 있으며, 모든 페이지가 라이트 테마로 렌더링됩니다. `ThemeProvider`에 `enableDarkMode` prop을 전달하면 활성화됩니다.
+
+```tsx
+<ThemeProvider enableDarkMode>
+  <App />
+</ThemeProvider>
+```
+
+`enableDarkMode`를 사용하면:
+
+- 기본적으로 OS 설정(`prefers-color-scheme`)을 따라갑니다.
+- 사용자가 선택한 테마는 `localStorage`에 저장됩니다. (key: `theme`, `storageKey` prop으로 변경 가능)
+- 테마 전환 시 CSS transition을 끄고 싶다면 `disableTransitionOnChange`를 전달하세요.
+
+현재 테마를 읽거나 변경하려면 `useThemeControl` 훅을 사용합니다. 서버에서는 테마가 항상 `'light'`로 결정되기 때문에, Next.js 같은 SSR 환경에서 `theme` 값을 그대로 렌더링하면 hydration mismatch가 발생합니다. 테마에 따라 달라지는 출력은 `NoSsr`로 감싸주세요.
+
+```tsx
+import { NoSsr, useThemeControl } from '@montage-ui/core';
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useThemeControl();
+
+  return (
+    <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+      <NoSsr>현재 테마: {theme}</NoSsr>
+    </button>
+  );
+};
+```
+
+- `theme`: 화면에 실제로 적용된 테마 (`'light' | 'dark'`)
+- `themeOriginValue`: 저장된 설정값 (`'light' | 'dark' | 'system'`)
+- `setTheme`: 테마 변경 — `'light'`, `'dark'`, `'system'`을 전달할 수 있습니다.
+
+> **참고 (Next.js):** 테마 감지는 클라이언트에서 동작하므로, 위의 App router 예시처럼 `<html>` 엘리먼트에 `suppressHydrationWarning`을 추가해야 합니다.
+
+현재 테마와 무관하게 특정 영역에 테마를 고정하려면 `ForceTheme`으로 감싸세요.
+
+```tsx
+import { ForceTheme } from '@montage-ui/core';
+
+<ForceTheme theme="dark">
+  <AlwaysDarkSection />
+</ForceTheme>;
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -330,3 +330,51 @@ const MyApp = ({
 
 export default MyApp;
 ```
+
+## Dark mode
+
+Dark mode is disabled by default — every page renders with the light theme. Pass the `enableDarkMode` prop to `ThemeProvider` to enable it:
+
+```tsx
+<ThemeProvider enableDarkMode>
+  <App />
+</ThemeProvider>
+```
+
+With `enableDarkMode`:
+
+- The theme follows the OS preference (`prefers-color-scheme`) by default.
+- The user's selection is persisted to `localStorage` (key: `theme`, configurable via the `storageKey` prop).
+- Pass `disableTransitionOnChange` to disable CSS transitions while the theme switches.
+
+To read or change the current theme, use the `useThemeControl` hook. On the server the resolved theme is always `'light'`, so rendering `theme` directly causes a hydration mismatch in SSR environments such as Next.js — wrap theme-dependent output in `NoSsr`:
+
+```tsx
+import { NoSsr, useThemeControl } from '@montage-ui/core';
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useThemeControl();
+
+  return (
+    <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+      <NoSsr>Current theme: {theme}</NoSsr>
+    </button>
+  );
+};
+```
+
+- `theme`: the resolved theme applied to the screen (`'light' | 'dark'`)
+- `themeOriginValue`: the stored setting (`'light' | 'dark' | 'system'`)
+- `setTheme`: changes the theme — accepts `'light'`, `'dark'`, or `'system'`
+
+> **Note (Next.js):** theme detection runs on the client, so add `suppressHydrationWarning` to the `<html>` element as shown in the App router example above.
+
+To force a specific theme on part of the tree regardless of the current theme, wrap it with `ForceTheme`:
+
+```tsx
+import { ForceTheme } from '@montage-ui/core';
+
+<ForceTheme theme="dark">
+  <AlwaysDarkSection />
+</ForceTheme>;
+```

--- a/packages/core/src/components/picker-action-area/index.tsx
+++ b/packages/core/src/components/picker-action-area/index.tsx
@@ -56,7 +56,7 @@ const PickerActionAreaButton = forwardRef(
         process.env.NODE_ENV !== 'production'
       ) {
         console.warn(
-          '[WDS] PickerActionAreaButton: "now" variant is not supported in DateRangePicker. Use "accept", "cancel", or "reset" instead.',
+          '[Montage] PickerActionAreaButton: "now" variant is not supported in DateRangePicker. Use "accept", "cancel", or "reset" instead.',
         );
       }
     }, [variant, isRange]);

--- a/packages/engine/src/components/force-theme/index.tsx
+++ b/packages/engine/src/components/force-theme/index.tsx
@@ -13,7 +13,9 @@ const ForceTheme = ({ theme: localTheme, children }: ForceThemeProps) => {
       case 'dark':
         return darkOriginTheme;
       default: {
-        console.error('WDS: Please check if the correct Theme value is set.');
+        console.error(
+          '[Montage] Please check if the correct Theme value is set.',
+        );
       }
     }
   }, [localTheme]);

--- a/packages/engine/src/components/theme-provider/index.tsx
+++ b/packages/engine/src/components/theme-provider/index.tsx
@@ -17,7 +17,9 @@ const ThemeProvider = ({
       case 'dark':
         return theme.dark;
       default: {
-        console.error('WDS: Please check if the correct Theme value is set.');
+        console.error(
+          '[Montage] Please check if the correct Theme value is set.',
+        );
       }
     }
   }, [localTheme]);

--- a/packages/eslint-plugin/src/helpers/ast.ts
+++ b/packages/eslint-plugin/src/helpers/ast.ts
@@ -22,7 +22,7 @@ export class WdsImportParser {
             source:
               specifier.imported.type === 'Identifier'
                 ? specifier.imported.name
-                : specifier.imported.value?.toString() ?? '',
+                : (specifier.imported.value?.toString() ?? ''),
           });
         } else if (specifier.type === 'ImportNamespaceSpecifier') {
           this.wdsImportNamespace.push(specifier.local.name);

--- a/packages/eslint-plugin/src/rules/icon-button-uses-name/index.test.ts
+++ b/packages/eslint-plugin/src/rules/icon-button-uses-name/index.test.ts
@@ -67,9 +67,9 @@ run({
   invalid: [
     {
       code: `
-        import * as wds from '@montage-ui/core';
+        import * as montage from '@montage-ui/core';
 
-        <wds.IconButton />
+        <montage.IconButton />
       `,
       errors: 1,
     },

--- a/packages/eslint-plugin/src/rules/icon-button-uses-name/index.ts
+++ b/packages/eslint-plugin/src/rules/icon-button-uses-name/index.ts
@@ -30,7 +30,7 @@ export default {
     docs: {
       url: 'https://github.com/wanteddev/montage-web/tree/main/packages/eslint-plugin/README.md#icon-button-uses-name',
       description:
-        'Required name or aria-label prop for wds icon button components',
+        'Required name or aria-label prop for montage icon button components',
     },
     messages: {
       error:

--- a/packages/eslint-plugin/src/rules/image-uses-alt/index.test.ts
+++ b/packages/eslint-plugin/src/rules/image-uses-alt/index.test.ts
@@ -31,9 +31,9 @@ run({
   invalid: [
     {
       code: `
-        import * as wds from '@montage-ui/core';
+        import * as montage from '@montage-ui/core';
 
-        <wds.Avatar />
+        <montage.Avatar />
       `,
       errors: 1,
     },

--- a/packages/eslint-plugin/src/rules/image-uses-alt/index.ts
+++ b/packages/eslint-plugin/src/rules/image-uses-alt/index.ts
@@ -13,7 +13,7 @@ export default {
   meta: {
     docs: {
       url: 'https://github.com/wanteddev/montage-web/tree/main/packages/eslint-plugin/README.md#image-uses-alt',
-      description: 'Required alt prop for wds image components',
+      description: 'Required alt prop for montage image components',
     },
     messages: {
       error: 'For accessibility, please provide an alt attribute.',

--- a/packages/nextjs/src/app-router-cache-provider.tsx
+++ b/packages/nextjs/src/app-router-cache-provider.tsx
@@ -18,7 +18,7 @@ const AppRouterCacheProvider = (props: AppRouterCacheProviderProps) => {
   const { options, children } = props;
 
   const [registry] = useState(() => {
-    const cache = createCache({ ...options, key: options?.key ?? 'wds' });
+    const cache = createCache({ ...options, key: options?.key ?? 'montage' });
     cache.compat = true;
 
     const prevInsert = cache.insert;

--- a/packages/nextjs/src/pages-router-cache-provider.tsx
+++ b/packages/nextjs/src/pages-router-cache-provider.tsx
@@ -23,7 +23,7 @@ const createEmotionCache = () => {
     insertionPoint = emotionInsertionPoint ?? undefined;
   }
 
-  return createCache({ key: 'wds', insertionPoint });
+  return createCache({ key: 'montage', insertionPoint });
 };
 
 export type EmotionCacheProviderProps = {

--- a/scripts/figma-icon.mjs
+++ b/scripts/figma-icon.mjs
@@ -172,7 +172,7 @@ const main = async () => {
       ([fileName, fileContents]) =>
         new Promise((resolve, reject) => {
           writeFile(
-            `./packages/wds-icon/src/${fileName}.tsx`,
+            `./packages/icon/src/${fileName}.tsx`,
             fileContents,
             (err) => (err ? reject(err) : resolve()),
           );
@@ -181,7 +181,7 @@ const main = async () => {
   );
 
   writeFileSync(
-    './packages/wds-icon/src/index.ts',
+    './packages/icon/src/index.ts',
     [
       ...data.map(
         ({ name }) =>


### PR DESCRIPTION
## Summary

- `scripts/figma-icon.mjs`가 존재하지 않는 `packages/wds-icon` 경로에 아이콘을 생성하던 문제 수정 (`packages/icon`으로 변경) — 아이콘 싱크 워크플로 실동작 버그
- codemod `package-name-migration`의 eslint 플러그인 옛 이름을 실제 배포명이었던 `@wanteddev/eslint-plugin-wds`로 정정 (기존 `@wanteddev/wds-eslint-plugin`은 존재하지 않던 이름)
- `@montage-ui/nextjs` cache provider의 emotion cache key를 `wds` → `montage`로 변경 (생성되는 CSS 클래스 prefix가 `montage-*`로 바뀜)
- engine/core 콘솔 메시지(`WDS:` → `[Montage]`), eslint-plugin 룰 설명·테스트 fixture의 WDS 브랜드 문구 정리
- `pr-noti` 워크플로의 하드코딩된 `owner/repo`를 `context.repo`로 교체
- `.claude` 레퍼런스/스킬, 이슈 템플릿, docs 문서·예제의 옛 패키지명/경로/스코프 갱신
- core README(en/ko)에 다크 모드 활성화 가이드 추가 (`enableDarkMode`, `useThemeControl`, `NoSsr`, `ForceTheme`)

_No Jira ticket — 패키지명 개편(#519) 후속 정리 작업._

## Test plan

- [ ] `pnpm vitest run packages/eslint-plugin` 통과 확인 (로컬 39개 통과 확인됨)
- [ ] sync-icons 워크플로 디스패치 시 `packages/icon/src`에 아이콘이 생성되는지 확인
- [ ] emotion cache key 변경에 따른 visual regression 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다크 모드 지원 추가 (테마 선택 저장, OS 환경 감지, 전환 애니메이션 제어 포함)

* **문서화**
  * 다크 모드 설정 및 사용 가이드, SSR 환경 대응 방법 추가

* **Chores**
  * 브랜드명 WDS에서 Montage로 업데이트
  * 패키지 및 네임스페이스 명칭 정렬

<!-- end of auto-generated comment: release notes by coderabbit.ai -->