### PR TITLE
chore(*): tsup → tsdown 전환 잔여 파일 정리

### DIFF
--- a/internal/montage-mcp/.npmignore
+++ b/internal/montage-mcp/.npmignore
@@ -1,4 +1,4 @@
-tsup.config.ts
+tsdown.config.ts
 .eslintrc.cjs
 .eslintignore
 tsconfig.json

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -31,7 +31,7 @@
     "build": "tsc --noEmit && tsdown",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "watch": "tsup --watch"
+    "watch": "tsdown --watch"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/dummy/package.json
+++ b/packages/dummy/package.json
@@ -31,7 +31,7 @@
     "build": "tsc --noEmit && tsdown",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "watch": "tsup --watch"
+    "watch": "tsdown --watch"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -36,7 +36,7 @@
     "build": "tsc --noEmit && tsdown",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "watch": "tsup --watch"
+    "watch": "tsdown --watch"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,7 +11,7 @@
   "exclude": ["**/node_modules", "./dist", "*.cjs"],
   "include": [
     "scripts/**/*.mjs",
-    ".tsup/**/*.ts",
+    ".tsdown/**/*.ts",
     "vitest.config.ts",
     ".vitest",
     "eslint.config.mjs",


### PR DESCRIPTION
## Summary

- 빌드 도구 tsup → tsdown 전환 이후 남아있던 잔여 참조 정리
- `packages/brand`, `packages/dummy`, `packages/icon`의 `watch` 스크립트를 `tsup --watch` → `tsdown --watch`로 변경
- `internal/montage-mcp/.npmignore`의 `tsup.config.ts` → `tsdown.config.ts`
- `tsconfig.node.json` include의 `.tsup/**/*.ts` → `.tsdown/**/*.ts`

## Jira

[WRP-1133](https://wantedlab.atlassian.net/browse/WRP-1133) — [디자인시스템] tsup -> tsdown 잔여 파일 수정

- Status: 열림
- Type: 작업

## Test plan

- [ ] 변경된 패키지에서 `pnpm watch` 정상 동작 확인

[WRP-1133]: https://wantedlab.atlassian.net/browse/WRP-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 빌드 도구 설정 파일을 업데이트하여 개발 환경을 개선했습니다.
  * 개발 감시 모드 스크립트를 최적화했습니다.
  * 프로젝트 구성 파일을 정리하여 개발 워크플로우를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->