### PR TITLE
chore: v3 → v4 마이그레이션 스킬 및 작성 가이드 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,13 +3,18 @@
   "owner": {
     "name": "wanteddev"
   },
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Wanted Lab Design System for Web",
   "plugins": [
     {
       "name": "montage-web-guide",
       "source": "./.claude-plugin/montage-web-guide",
       "description": "Guide to use Wanted Lab Design System for Web"
+    },
+    {
+      "name": "montage-web-migration",
+      "source": "./.claude-plugin/montage-migration",
+      "description": "Migration tool for Wanted Lab Design System for Web"
     }
   ]
 }

--- a/.claude-plugin/montage-migration/.claude-plugin/plugin.json
+++ b/.claude-plugin/montage-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "montage-web-guide",
-  "version": "1.0.2",
-  "description": "Wanted Design System Plugin",
+  "name": "montage-web-migration",
+  "version": "1.1.0",
+  "description": "Wanted Design System Migration Plugin",
   "author": {
     "name": "Sh031224"
   },

--- a/.claude-plugin/montage-migration/README.ko.md
+++ b/.claude-plugin/montage-migration/README.ko.md
@@ -1,0 +1,43 @@
+# Montage Web Migration
+
+Montage(Wanted Design System for Web) 메이저 버전 간 마이그레이션을 수행하는 플러그인입니다.
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+## 설치
+
+```bash
+/plugin marketplace add wanteddev/montage-web
+```
+
+```bash
+/plugin install montage-web-migration@montage-web
+```
+
+## 스킬
+
+### montage-v3-to-v4
+
+프로젝트를 Montage v3(`@wanteddev/wds*` 3.x)에서 v4(`@montage-ui/*` 4.x)로 마이그레이션합니다.
+
+다음과 같이 요청하면 실행됩니다:
+
+- "montage v4로 마이그레이션해줘"
+- "wds 4.0으로 업그레이드해줘"
+- "Migrate this project to @montage-ui 4"
+
+동작 방식:
+
+1. **사전 점검** — 버전 확인, git 클린 상태 확인, 대상 디렉토리 선택, 마이그레이션 상태 파일 생성.
+2. **Codemod 단계** — 5개 v4 codemod를 **엄격한 순서로, 각각 정확히 한 번씩** 실행
+   (`package-name-migration` → `css-variable-migration` → `dom-identifier-migration` →
+   `list-card-migration` → `form-control-migration`). Workflow 도구로 오케스트레이션되어
+   codemod는 순차 실행(단계별 검증·선택적 단계별 커밋), 이후 수동 마이그레이션 대상
+   스캔은 병렬로 수행됩니다.
+3. **수동 마이그레이션** — theme 토큰 `var(--...)` 산술 코드, package.json/설정 파일의
+   패키지명 변경, DOM 식별자 잔여물, Modal/TextField 동작 변경 대응.
+4. **최종 검증** — 잔여 패턴 grep, install/typecheck/lint/build, 결과 요약.
+
+codemod는 순서에 민감하고 두 번 실행하면 안 됩니다(`form-control-migration` 재실행 시
+마이그레이션된 코드가 손상됩니다). 진행 상태는 `.claude/montage-migration-v4.local.md`에
+기록되어, 중단된 마이그레이션은 완료된 단계를 건너뛰고 첫 미완료 단계부터 재개됩니다.

--- a/.claude-plugin/montage-migration/README.md
+++ b/.claude-plugin/montage-migration/README.md
@@ -1,0 +1,45 @@
+# Montage Web Migration
+
+A plugin that migrates consumer projects between major versions of Montage (Wanted Design
+System for Web).
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+## Installation
+
+```bash
+/plugin marketplace add wanteddev/montage-web
+```
+
+```bash
+/plugin install montage-web-migration@montage-web
+```
+
+## Skills
+
+### montage-v3-to-v4
+
+Migrates a project from Montage v3 (`@wanteddev/wds*` 3.x) to v4 (`@montage-ui/*` 4.x).
+
+Trigger it by asking, for example:
+
+- "montage v4로 마이그레이션해줘"
+- "wds 4.0으로 업그레이드해줘"
+- "Migrate this project to @montage-ui 4"
+
+What it does:
+
+1. **Preflight** — version check, clean git tree, target selection, migration state file.
+2. **Codemod phase** — runs the 5 v4 codemods **strictly in sequence, each exactly once**
+   (`package-name-migration` → `css-variable-migration` → `dom-identifier-migration` →
+   `list-card-migration` → `form-control-migration`), orchestrated with the Workflow tool:
+   sequential codemod execution with per-step verification and optional per-step commits,
+   then parallel scans for the manual-migration worklist.
+3. **Manual migrations** — theme token `var(--...)` arithmetic, package.json/config
+   renames, DOM identifier leftovers, Modal/TextField behavioral changes.
+4. **Verification** — leftover greps, install/typecheck/lint/build, summary.
+
+The codemods are order-sensitive and must not run twice (re-running
+`form-control-migration` corrupts migrated code), so progress is tracked in
+`.claude/montage-migration-v4.local.md` — interrupted migrations resume from the first
+incomplete step and never repeat a completed one.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
@@ -98,18 +98,23 @@ Orchestrate the codemod phase with the Workflow tool using the bundled script �
 guarantees deterministic sequencing (each codemod is a sequential `await`; a failure
 aborts the chain) and runs the manual-migration scans in parallel afterwards:
 
-```
+```js
 Workflow({
   scriptPath: "<this skill's base directory>/scripts/migration-workflow.js",
   args: {
-    repoRoot: "<absolute repo root>",
-    targets: ["src"],
-    stateFile: "<absolute path>/.claude/montage-migration-v4.local.md",
+    repoRoot: '<absolute repo root>',
+    targets: ['src'],
+    stateFile: '<absolute path>/.claude/montage-migration-v4.local.md',
     referencesDir: "<this skill's base directory>/references",
-    autoCommit: true
-  }
-})
+    autoCommit: true,
+    completedSteps: [], // step ids already marked completed in the state file
+  },
+});
 ```
+
+Populate `completedSteps` from the state file read in preflight (empty on a first run) —
+the script skips those steps deterministically without spawning an agent, and each step
+agent re-checks the state file as a second layer.
 
 Resolve `<this skill's base directory>` from the "Base directory for this skill" line
 announced when this skill loaded. Optionally pass `codemodVersion` (npm version or
@@ -118,8 +123,8 @@ resumed runs use the same codemod build. The workflow returns per-step results p
 `manualScan` report (assessed occurrences for manual steps M1–M7).
 
 - If the workflow reports `aborted`, surface the failed step's error to the user, fix the
-  cause, and re-run the same Workflow invocation — completed steps are skipped via the
-  state file, so resuming is safe.
+  cause, and re-run the same Workflow invocation with `completedSteps` refreshed from the
+  state file — completed steps are skipped, so resuming is safe.
 - **Fallback without the Workflow tool:** execute the exact per-step procedure embedded in
   `scripts/migration-workflow.js` (read it) inline — one step at a time, same order, same
   state-file checks. Never parallelize the codemod steps.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: montage-v3-to-v4
+description: This skill should be used when the user asks to migrate a project from Montage (WDS) v3 to v4, upgrade @wanteddev/wds to @montage-ui/* 4.x, run any Montage v4 codemod (package-name-migration, css-variable-migration, dom-identifier-migration, list-card-migration, form-control-migration), or resume an in-progress v4 migration. Triggers include "montage v4 마이그레이션", "montage 4 적용해줘", "몬타지 v4로 올려줘", "wds 4.0으로 업그레이드", "디자인시스템 v4로 올려줘", "@montage-ui로 전환해줘", "마이그레이션 이어서 해줘". Covers v3→v4 only (earlier migrations live in the repo's MIGRATION.md). Orchestrates the 5 codemods strictly in sequence with run-once protection, then guides the manual migrations.
+---
+
+# montage-v3-to-v4
+
+Migrate a consumer project from Montage (Wanted Design System) v3 (`@wanteddev/wds*` 3.x)
+to v4 (`@montage-ui/*` 4.x). The migration is: 5 codemods run **strictly in sequence,
+each exactly once**, followed by manual migrations the codemods cannot express, followed
+by verification.
+
+## Critical rules
+
+1. **Never run a codemod twice on the same tree.** `form-control-migration` swaps
+   `FormField→FormControl` while renaming `FormControl→FormControlField`; a second run
+   renames the new root again and silently corrupts the code. Treat all 5 steps as
+   run-once; the state file is the source of truth.
+2. **Fixed order, one step at a time.** Complete (and commit) step N before starting
+   step N+1: ① `package-name-migration` ② `css-variable-migration`
+   ③ `dom-identifier-migration` ④ `list-card-migration` ⑤ `form-control-migration`.
+   Manual steps reference post-codemod names, so they come after all 5.
+3. **Codemods first, hand-edits after.** Do not hand-migrate any `Form*` / `Card*` usage
+   (or adopt new v4 APIs) before the codemods run — `form-control-migration` corrupts
+   hand-migrated files even on its first run.
+4. **Start from a clean git tree** and keep one commit per step so any step can be
+   reverted in isolation.
+5. Run codemods through the CLI (`npx -y @montage-ui/codemod@latest <transform> <path>`),
+   never raw jscodeshift — steps ② and ③ rewrite stylesheets only via the CLI.
+
+## Step 0 — Preflight
+
+Perform all checks before changing anything:
+
+1. **Version check.** Read the project's `package.json`:
+   - `@wanteddev/wds*` at 3.x → proceed.
+   - `@wanteddev/wds*` at 2.x or lower → stop; complete the v2→v3 migration first
+     (MIGRATION.md in the wanteddev/montage-web repo).
+   - Only `@montage-ui/*` 4.x present and no state file → likely already migrated; run
+     the leftover greps from `references/codemod-steps.md` and report instead of migrating.
+   - BOTH `@wanteddev/wds*` and `@montage-ui/*` present → the project is partially
+     hand-migrated. Run the step ④/⑤ pre-checks from `references/codemod-steps.md` before
+     anything else and expect file exclusions in step ⑤.
+2. **State file.** Look for `.claude/montage-migration-v4.local.md` (format below). If it
+   exists, this is a resume: skip every step marked `completed` and continue from the
+   first `pending` step. Never downgrade a `completed` mark. Before resuming, sanity-check
+   the marks against reality (e.g. a step marked `completed` but its renames absent from
+   the tree — the user may have reverted commits): on any mismatch, stop and reconcile
+   with the user; never re-run a marked step automatically. On resume, the `targets`
+   recorded in the state file are locked — if the user requests different targets, that is
+   a new migration decision to surface, not a silent override.
+3. **Clean tree.** `git status --porcelain` must be empty (the state file itself is the
+   only allowed exception). Otherwise ask the user to commit/stash first.
+4. **Targets.** Identify source directories to transform (default `src`). Include
+   directories containing stylesheets that reference `--wds-*` variables. Use plain
+   directory paths — the codemod CLI takes exactly one path per invocation and does not
+   expand globs; each step runs once per target directory. In a monorepo, list ALL
+   package source directories as targets of ONE migration (one state file) — do not run
+   separate per-package migrations, or the run-once guarantee fragments per path.
+5. **Ask the user once** (single `AskUserQuestion`): confirm the target directories, and
+   whether to auto-commit after each step (recommended; enables safe rollback of a failed
+   step). Do not ask again mid-migration.
+
+### State file format
+
+Create `.claude/montage-migration-v4.local.md` before step ①, and append the path to
+`.git/info/exclude` (repo-local ignore) so per-step `git add -A` commits never include it:
+
+```markdown
+---
+migration: montage-v3-to-v4
+targets:
+  - src
+autoCommit: true
+steps:
+  package-name-migration: pending
+  css-variable-migration: pending
+  dom-identifier-migration: pending
+  list-card-migration: pending
+  form-control-migration: pending
+manual:
+  M1: pending
+  M2: pending
+  M3: pending
+  M4: pending
+  M5: pending
+  M6: pending
+  M7: pending
+---
+```
+
+Mark each step `completed` immediately after it succeeds. Delete the file only after the
+final verification passes.
+
+## Step 1 — Codemod phase (use the Workflow tool)
+
+Orchestrate the codemod phase with the Workflow tool using the bundled script — it
+guarantees deterministic sequencing (each codemod is a sequential `await`; a failure
+aborts the chain) and runs the manual-migration scans in parallel afterwards:
+
+```
+Workflow({
+  scriptPath: "<this skill's base directory>/scripts/migration-workflow.js",
+  args: {
+    repoRoot: "<absolute repo root>",
+    targets: ["src"],
+    stateFile: "<absolute path>/.claude/montage-migration-v4.local.md",
+    referencesDir: "<this skill's base directory>/references",
+    autoCommit: true
+  }
+})
+```
+
+Resolve `<this skill's base directory>` from the "Base directory for this skill" line
+announced when this skill loaded. Optionally pass `codemodVersion` (npm version or
+dist-tag, default `latest`) — pin it when a migration may span multiple sessions so
+resumed runs use the same codemod build. The workflow returns per-step results plus a
+`manualScan` report (assessed occurrences for manual steps M1–M7).
+
+- If the workflow reports `aborted`, surface the failed step's error to the user, fix the
+  cause, and re-run the same Workflow invocation — completed steps are skipped via the
+  state file, so resuming is safe.
+- **Fallback without the Workflow tool:** execute the exact per-step procedure embedded in
+  `scripts/migration-workflow.js` (read it) inline — one step at a time, same order, same
+  state-file checks. Never parallelize the codemod steps.
+
+Details per step (commands, pre-checks, post-step verification greps, hazards):
+`references/codemod-steps.md`.
+
+## Step 2 — Manual migrations
+
+Work through `references/manual-migrations.md` (M1–M7) using the workflow's `manualScan`
+hits as the worklist. Apply mechanical fixes directly; ask the user before behavioral
+decisions:
+
+- **M6 (Modal bottom sheet):** per occurrence — accept the new close-on-dismiss default
+  (delete `onVisibilityChange` workarounds) or pin with `peekHeight`.
+- **M7 (TextField):** whether any field should adopt `size="medium"` (40px) now that the
+  single size maps to Large.
+
+M1 (package.json + configs) ends with a dependency install to refresh the lockfile.
+Mark each M-section `completed` in the state file as it finishes.
+
+## Step 3 — Final verification
+
+1. Leftover greps all clean: re-run EVERY post-step verification grep from
+   `references/codemod-steps.md` and every M-section scan pattern from
+   `references/manual-migrations.md` — the union is the checklist; do not improvise a
+   shorter list.
+2. Project checks: install, typecheck, lint, build, unit tests — whatever the project
+   defines.
+3. Remind the user to visually QA TextField / bottom-sheet Modal / Card list screens
+   (v4 changed their rendering and behavior, not just names).
+4. Delete the state file, then summarize: steps run, commits created, manual fixes
+   applied, items intentionally left (with reasons).
+
+## Additional resources
+
+- **`references/codemod-steps.md`** — the 5 codemods in order: exact commands,
+  idempotency analysis, pre-checks, post-step verification greps, hazards.
+- **`references/manual-migrations.md`** — manual migrations M1–M7 with scan patterns and
+  fix rules.
+- **`scripts/migration-workflow.js`** — Workflow-tool script for the codemod phase; also
+  the canonical per-step procedure for inline fallback execution.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -9,6 +9,11 @@ npx -y @montage-ui/codemod@latest <transform> <target>
 
 - One transform per invocation — the CLI has no batch mode. Passing both the transform name
   and the path makes the run fully non-interactive.
+- `@latest` is acceptable for a single-session run, but `npx -y` executes whatever is
+  published at that moment — for a migration that may span multiple sessions (or to
+  reduce supply-chain exposure), pin a specific version
+  (`npx -y @montage-ui/codemod@<x.y.z> ...`, or the `codemodVersion` workflow arg) so
+  every step runs the same codemod build.
 - **One file-or-directory path per invocation.** The CLI reads only the first path
   argument — extra positional paths are silently dropped, and globs are NOT expanded
   (despite the help text; a shell-expanded glob passes only its first match). For multiple

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -1,0 +1,222 @@
+# Codemod Steps (v3 → v4)
+
+The 5 v4 codemods, in canonical execution order. Run each step **exactly once**, strictly
+in this order, completing (and ideally committing) one step before starting the next.
+
+```sh
+npx -y @montage-ui/codemod@latest <transform> <target>
+```
+
+- One transform per invocation — the CLI has no batch mode. Passing both the transform name
+  and the path makes the run fully non-interactive.
+- **One file-or-directory path per invocation.** The CLI reads only the first path
+  argument — extra positional paths are silently dropped, and globs are NOT expanded
+  (despite the help text; a shell-expanded glob passes only its first match). For multiple
+  target directories, run the SAME transform once per directory before moving to the next
+  step — separate trees, so this does not violate the run-once rule, which is per-tree.
+- jscodeshift processes `.tsx/.ts/.jsx/.js` and ignores `node_modules` / `.next` / `dist`.
+  Steps 2 and 3 additionally rewrite `.css/.scss/.sass/.less` files under the same path as
+  plain text.
+- Always run through the CLI (`npx @montage-ui/codemod`), never raw jscodeshift — the
+  stylesheet text pass only runs via the CLI wrapper.
+- If stylesheets live outside the source target (e.g. a top-level `styles/` directory),
+  add that directory to the target list so steps 2 and 3 cover it (again: one invocation
+  per directory).
+
+## Why the order and the run-once rule matter
+
+| Step | Transform                  | Re-run on migrated code                                      |
+| ---- | -------------------------- | ------------------------------------------------------------ |
+| 1    | `package-name-migration`   | safe (no-op)                                                 |
+| 2    | `css-variable-migration`   | safe (no-op)                                                 |
+| 3    | `dom-identifier-migration` | safe (no-op)                                                 |
+| 4    | `list-card-migration`      | safe (no-op), EXCEPT on half-hand-migrated files (see below) |
+| 5    | `form-control-migration`   | **CORRUPTS CODE** — never re-run (see below)                 |
+
+Even for the "safe" steps, treat every step as run-once: the state file is the single
+source of truth, and mixed states (a step applied to half the tree) are hard to diagnose.
+The hard inter-step constraints are between codemods and MANUAL steps: manual fixes
+reference post-codemod names, so all 5 codemods run first, manual migrations after
+(see `manual-migrations.md`).
+
+## Step 1 — `package-name-migration`
+
+Rewrites `import` declaration sources `@wanteddev/*` → `@montage-ui/*` (11-entry map),
+including subpath imports (`@wanteddev/wds/style.css` → `@montage-ui/core/style.css`).
+Exception: `@wanteddev/wds-mcp` → `@wanteddev/montage-mcp` (stays in the `@wanteddev`
+scope — do not blanket-rename it to `@montage-ui` in package.json).
+
+Not covered by the codemod. Ownership split: JS/TS code references are fixed NOW as part
+of this step's verification; config files and stylesheets are manual step M1.
+
+- Fix in this step (code): `export { X } from '@wanteddev/...'` / `export * from ...`
+  re-export barrels (different AST node), `require()`, dynamic `import()`,
+  `jest.mock()` / `vi.mock()` first arguments, `declare module '@wanteddev/wds'`
+  augmentations.
+- Leave for M1 (config/styles): package.json, tsconfig paths, next.config
+  `transpilePackages`, bundler aliases, ESLint config, `@import` / `url()` references in
+  stylesheets.
+
+Post-step verification:
+
+```
+grep -rn "@wanteddev/" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" <targets>
+```
+
+(Do not anchor on `^import` — multi-line imports put `from '@wanteddev/...'` on its own
+line.) Every remaining hit is a construct the codemod cannot reach (re-export, require,
+dynamic import, mock, `declare module`) — fix them by hand now, in the same commit.
+
+## Step 2 — `css-variable-migration`
+
+Renames `--wds-*` CSS custom properties: strips the `--wds-` prefix, with two exceptions —
+`--wds-column-spacing` → `--grid-column-spacing`, `--wds-row-spacing` → `--grid-row-spacing`.
+Rewrites string literals and template literals in JS/TS plus stylesheets as text.
+
+Cautions:
+
+- NOT import-gated — it renames ANY `--wds-*` token by prefix, including consumer-defined
+  variables that were never Montage's. Review the diff.
+- The pattern is lowercase-only (`--wds-[a-z0-9-]+`): a camelCase custom property like
+  `--wds-myVar` gets partially rewritten (`--myVar`). All shipped Montage variables are
+  lowercase, but grep the diff if the codebase has camelCase `--wds-` properties.
+- Card sub-component variables come out as **intermediate names**: `--wds-card-content-item-*`
+  → `--card-content-item-*`, which v4 core does NOT ship (it ships `--card-row-*`). The
+  manual rename `--card-content-item-*` → `--card-row-*` (manual step M4) only works AFTER
+  this step — this is a hard ordering constraint.
+- Dynamically built names (`'--wds-' + name`, `` `--wds-${x}` ``) are not matched → manual M3.
+
+Post-step verification: `grep -rn -- "--wds-" <targets>` — remaining hits should only be
+dynamically-built names (manual M3).
+
+## Step 3 — `dom-identifier-migration`
+
+Renames 4 DOM identifier tokens in string literals, template literals, JSX attribute names,
+and stylesheets:
+
+| 기존                           | 변경                              |
+| ------------------------------ | --------------------------------- |
+| `wds-component`                | `data-component`                  |
+| `wds-ignore-first-focus`       | `data-ignore-first-focus`         |
+| `wds-ignore-dismissable-layer` | `data-ignore-dismissable-layer`   |
+| `wds-region-manager(-bottom)`  | `montage-region-manager(-bottom)` |
+
+Cautions:
+
+- Blind substring replacement over ANY string literal — unrelated strings containing a token
+  (analytics event names, doc strings) get rewritten too. Review the diff.
+- Renames attribute NAMES only, never VALUES: `wds-component="card-content"` becomes
+  `data-component="card-content"`; the value rename `card-content` → `card-body` is manual
+  step M4 and therefore MUST come after this step.
+
+Post-step verification: `grep -rn -E "wds-(component|ignore-|region-manager)" <targets>` —
+remaining hits should only be dynamically-built strings (manual M3).
+
+## Step 4 — `list-card-migration`
+
+Renames the CardList family to ListCard and Card sub-components context-sensitively based
+on the nearest JSX ancestor (`CardList`/`CardListSkeleton` → `ListCard*` names;
+`Card`/`CardSkeleton` or undeterminable → new `Card*` names). Handles alias imports,
+`leadingContent`/`trailingContent` prop JSX, mixed-context files (splits imports into
+`CardBody` + `ListCardBody`), and Props types.
+
+Cautions:
+
+- Import-gated on a file-level import from exactly `@montage-ui/core` or `@wanteddev/wds` —
+  deep/subpath component imports, namespace imports, and re-exports are skipped entirely.
+- Non-JSX identifier references (`component={CardContent}`) always become the Card-family
+  name (`CardBody`) — if actually used in ListCard context, fix by hand (manual M4).
+- Cross-file context is invisible: a child-component file importing only Card sub-components
+  defaults to Card names even when the parent mounts it inside a `ListCard` — review shared
+  child components (manual M4).
+- Half-hand-migrated files (importing BOTH an old name and its new name) can end up with a
+  duplicate import specifier — check for files importing both `CardContent` and
+  `CardBody`/`ListCardBody` before running; clean them up first.
+
+Post-step verification (expect zero hits): `grep -rn -E "\bCard(List|Content)" <targets>`
+(prefix pattern on purpose — `\bCardContent\b` would miss `CardContentProps` /
+`CardContentItemSkeleton` leftovers in gate-skipped files; the prefix form catches all old
+names and matches none of the new ones, `ListCard*` included).
+
+## Step 5 — `form-control-migration`
+
+Renames the Form family, including a two-way swap:
+
+| 기존               | 변경                         |
+| ------------------ | ---------------------------- |
+| `FormField`        | `FormControl`                |
+| `FormControl`      | `FormControlField`           |
+| `FormLabel`        | `FormControlLabel`           |
+| `FormMessage`      | `FormControlMessage`         |
+| `FormErrorMessage` | `FormControlNegativeMessage` |
+
+(+ the same renames for `*Props` types.)
+
+**⚠️ NOT idempotent — this is the step that corrupts code when run twice.** After the first
+run, files import `FormControl` (the new root). A second run matches that import again and
+renames every `FormControl` to `FormControlField` — the root wrapper silently becomes the
+inner field slot, and duplicate import specifiers appear. The same corruption hits
+`FormControlProps` → `FormControlFieldProps`.
+
+The same failure fires on the FIRST run against code that was already **hand-migrated** to
+the new v4 API. Pre-check before running — two-pass, because a single line-based
+`import {...FormControl...}` grep misses multi-line (prettier-formatted) imports:
+
+```sh
+# files referencing FormControl at all, minus files that also reference FormField
+comm -23 \
+  <(grep -rlE '\bFormControl\b' <targets> | sort) \
+  <(grep -rlE '\bFormField\b' <targets> | sort)
+```
+
+For each resulting file, inspect it: if it already uses the
+new v4 API (root `<FormControl>` wrapping `<FormControlField>`, or imports any
+`FormControl*` sub-component), it is hand-migrated and must be excluded. A v3 file
+importing only `FormControl` (the old inner slot, unusual but possible) is safe to
+transform.
+
+**Exclusion procedure** — the CLI has no exclude flag, so temporarily move hand-migrated
+files out of the target tree:
+
+```sh
+# 1. move each flagged file out, preserving its relative path
+mkdir -p /tmp/montage-mig-excluded
+for f in <flagged files>; do
+  mkdir -p "/tmp/montage-mig-excluded/$(dirname "$f")"
+  mv "$f" "/tmp/montage-mig-excluded/$f"
+done
+
+# 2. run the codemod on the targets as usual
+npx -y @montage-ui/codemod@latest form-control-migration <target>
+
+# 3. move the files back to their exact original paths
+(cd /tmp/montage-mig-excluded && find . -type f) | while read -r f; do
+  mv "/tmp/montage-mig-excluded/$f" "$f"
+done
+```
+
+Verify with `git status` that the moved-back files show no diff, and confirm the temp
+directory is empty before continuing.
+
+Cautions:
+
+- Global identifier rename within gated files — unrelated identifiers named `FormControl`/
+  `FormField` (object keys, `styles.FormControl`) get renamed too. Review the diff.
+- Namespace imports (`M.FormField`), re-exports, and subpath imports are skipped → manual.
+- New v4 API adoption (`FormControlPositiveMessage`, `FormControlCharacterCounter`,
+  `size`/`labelPlacement`) must happen only AFTER this step, for the same double-swap reason.
+
+Post-step verification (expect zero hits):
+`grep -rn -E "\bForm(Field|Label|Message|ErrorMessage)" <targets>`
+(prefix pattern on purpose — a `\bFormField\b` form would miss `FormFieldProps` leftovers
+in gate-skipped files; the prefix form matches no new `FormControl*` name.)
+`FormControl` hits are EXPECTED — it is the new root name; do not "fix" them.
+
+## After all 5 steps
+
+Proceed to `manual-migrations.md` (M1–M7), then final verification:
+
+1. All leftover greps clean (see each step + M-sections).
+2. Dependency install with the renamed `@montage-ui/*` packages succeeded.
+3. Project typecheck / lint / build / tests pass.
+4. Visual QA on TextField / Modal bottom-sheet / Card list screens (behavioral changes).

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
@@ -1,0 +1,239 @@
+# Manual Migrations (v3 → v4)
+
+Changes the codemods cannot apply automatically. Run these AFTER all 5 codemod steps
+completed (see `codemod-steps.md`). Each section lists scan patterns to locate affected
+code — scan first, then apply fixes only where a real occurrence exists.
+
+Scan patterns use `grep -E` syntax with `\b`/`\s`/`\w` shorthands — supported by GNU grep,
+macOS BSD grep, and ripgrep alike (translate the shorthands to POSIX classes for busybox
+or other minimal greps). The patterns are line-based heuristics: multi-line JSX props and
+non-literal forms (`variant={'bottom'}`, responsive objects) escape them, so treat a clean
+scan as "nothing obvious", not proof of absence.
+
+## M1. Package references outside import declarations
+
+The `package-name-migration` codemod only rewrites `import` declaration sources in JS/TS
+files — nothing else. Everything below must be updated by hand.
+
+| 기존                           | 변경                        |
+| ------------------------------ | --------------------------- |
+| `@wanteddev/wds`               | `@montage-ui/core`          |
+| `@wanteddev/wds-icon`          | `@montage-ui/icon`          |
+| `@wanteddev/wds-nextjs`        | `@montage-ui/nextjs`        |
+| `@wanteddev/wds-lottie`        | `@montage-ui/lottie`        |
+| `@wanteddev/wds-codemod`       | `@montage-ui/codemod`       |
+| `@wanteddev/wds-theme`         | `@montage-ui/theme`         |
+| `@wanteddev/wds-engine`        | `@montage-ui/engine`        |
+| `@wanteddev/wds-dummy`         | `@montage-ui/dummy`         |
+| `@wanteddev/wds-brand`         | `@montage-ui/brand`         |
+| `@wanteddev/eslint-plugin-wds` | `@montage-ui/eslint-plugin` |
+
+Exception: `@wanteddev/wds-mcp` maps to `@wanteddev/montage-mcp` — it stays in the
+`@wanteddev` scope (GitHub Package Registry); do not blanket-rename it to `@montage-ui/*`.
+
+Check and update:
+
+- `package.json` — `dependencies` / `devDependencies` / `peerDependencies` / `resolutions` / `overrides` / `pnpm.overrides`. Replace each `@wanteddev/wds*` entry with its `@montage-ui/*` counterpart at version `^4.0.0`, then run the project's package manager install to refresh the lockfile.
+- Code the codemod cannot reach — these must already have been fixed during Step 1's
+  post-step verification (they are code, not config); the scan here is a safety net, and
+  any hit is a Step 1 escape:
+  - `export { X } from '@wanteddev/...'` / `export * from '@wanteddev/...'` re-export barrels
+  - `require('@wanteddev/...')`, dynamic `import('@wanteddev/...')`
+  - `jest.mock('@wanteddev/...')` / `vi.mock('@wanteddev/...')`
+  - `declare module '@wanteddev/wds'` TypeScript module augmentations
+- `@import` / `url()` package references inside stylesheets — Step 1's verification only
+  scans JS/TS, so these are genuine M1 work.
+- ESLint config — `@wanteddev/eslint-plugin-wds` → `@montage-ui/eslint-plugin`: legacy `extends` becomes `plugin:@montage-ui/recommended` (or `/strict`), flat config imports `montagePlugin from '@montage-ui/eslint-plugin'`, and rule prefixes become `@montage-ui/<rule>`.
+- `next.config.*` — `transpilePackages`, `modularizeImports`, webpack aliases.
+- Test config — `jest.config.*` / `vitest.config.*` `moduleNameMapper` / `alias` / `deps.inline` entries.
+- `tsconfig.json` — `paths` mappings, `types` entries.
+- `.storybook/*`, bundler aliases (webpack/vite/rspack), `.npmrc` scope config.
+
+Scan pattern (all file types, not only JS/TS):
+
+```
+@wanteddev/(wds|eslint-plugin-wds)
+```
+
+Any remaining hit after this step is a bug — every package the pattern matches is
+published only under `@montage-ui/*` in v4 (the pattern deliberately does not match the
+`@wanteddev/montage-mcp` exception).
+
+## M2. Theme tokens now return `var(--...)` strings
+
+`theme.primitive`, `theme.opacity`, `theme.spacing`, `theme.radius`, `theme.dimension`,
+`theme.zIndex` return `var(--...)` strings instead of raw values (`'16px'`, `0.88`, `1300`).
+Usage inside CSS contexts (template literals, inline style objects) keeps working — **only
+JS arithmetic on the raw value breaks**, returning `NaN` or string concatenation garbage.
+
+`theme.breakpoint` is NOT converted (CSS variables cannot be used in `@media` queries) —
+leave media-query code untouched.
+
+Scan patterns (`.ts`/`.tsx`/`.js`/`.jsx`):
+
+```
+parse(Int|Float)\(\s*theme\.
+theme\.(spacing|radius|dimension|primitive)\[[^\]]+\]\s*[-+*/]
+theme\.opacity\[[^\]]+\]\s*[-+*/]
+theme\.zIndex\.\w+\s*[-+*/]
+[-+*/]\s*theme\.(spacing|radius|dimension|opacity|primitive)\[
+[-+*/]\s*theme\.zIndex\.
+```
+
+Also review destructured/aliased usages the patterns above miss (e.g.
+`const { spacing } = theme` followed by `parseInt(spacing[16])`).
+
+Fixes:
+
+- CSS-computable arithmetic → `calc()` (`var()` works inside `calc`):
+
+  ```ts
+  // AS-IS
+  const half = parseInt(theme.spacing[16]) / 2;
+  style={{ width: parseInt(theme.dimension[40]) - 4 }}
+  style={{ zIndex: theme.zIndex.modal + 1 }}
+  opacity: ${theme.opacity[88] * 0.5};
+
+  // TO-BE
+  const half = `calc(${theme.spacing[16]} / 2)`;
+  style={{ width: `calc(${theme.dimension[40]} - 4px)` }}
+  style={{ zIndex: `calc(${theme.zIndex.modal} + 1)` }}
+  opacity: calc(${theme.opacity[88]} * 0.5);
+  ```
+
+- Genuinely needs a JS number (measurements, non-CSS APIs, chart libs) → import raw values:
+
+  ```ts
+  import { lightOriginTheme, darkOriginTheme } from '@montage-ui/core';
+
+  lightOriginTheme.spacing[16]; // '16px' — raw value
+  ```
+
+- `rgba(0, 0, 0, ${theme.opacity[43]})` and `addOpacity(color, theme.opacity[N])` keep
+  working as-is — the alpha slot of `rgba()` resolves `var()` fine. No change needed.
+- React inline style `zIndex` is now a string. Props typed `zIndex: number` need widening
+  to `number | string` or a raw-value fallback. Scan: `zIndex` props on custom components
+  fed from `theme.zIndex.*`.
+
+## M3. CSS variable / DOM identifier leftovers
+
+The `css-variable-migration` and `dom-identifier-migration` codemods rewrite string
+literals, template literals, and stylesheets. They cannot rewrite:
+
+- Dynamically built names whose static part is exactly `--wds-`: `` `--wds-${name}` ``,
+  `'--wds-' + name`, `el.style.setProperty('--wds-' + key, v)`. Careful: a LONGER static
+  head IS rewritten (`` `--wds-card-${x}` `` → `` `--card-${x}` ``), and a split grid
+  token like `'--wds-column-' + 'spacing'` gets wrongly stripped to `--column-spacing`
+  instead of `--grid-column-spacing` — review every dynamic construction site.
+- Selectors living outside the transformed directories: E2E specs (Playwright/Cypress),
+  snapshot files, CSS-in-JS in other packages, HTML files, styled-components in `.md`/MDX.
+- camelCase custom properties: the rename pattern is lowercase-only, so `--wds-myVar` comes
+  out partially rewritten as `--myVar` — grep the diff if such names exist.
+
+Conversely, review the codemod diff for **false positives**: both transforms do blind
+substring replacement over any string literal, so unrelated strings containing a token
+(analytics event names, documentation strings, consumer-defined `--wds-*` variables that
+were never Montage's) get rewritten too.
+
+Scan patterns (all file types):
+
+```
+--wds-
+wds-component
+wds-ignore-first-focus
+wds-ignore-dismissable-layer
+wds-region-manager
+```
+
+Rename rules for anything found:
+
+| 기존                                                 | 변경                                                         |
+| ---------------------------------------------------- | ------------------------------------------------------------ |
+| `--wds-column-spacing` / `--wds-row-spacing` (grid)  | `--grid-column-spacing` / `--grid-row-spacing`               |
+| all other `--wds-*`                                  | drop the `--wds-` prefix (`--wds-x` → `--x`)                 |
+| `wds-component` attribute                            | `data-component`                                             |
+| `wds-ignore-first-focus`                             | `data-ignore-first-focus`                                    |
+| `wds-ignore-dismissable-layer`                       | `data-ignore-dismissable-layer`                              |
+| `#wds-region-manager` / `#wds-region-manager-bottom` | `#montage-region-manager` / `#montage-region-manager-bottom` |
+
+## M4. Card / ListCard follow-ups
+
+The `list-card-migration` codemod resolves Card vs ListCard context from the nearest JSX
+ancestor. Two classes of usage need manual review:
+
+- **Non-JSX identifier references** (`component={CardContent}`, `React.createElement(CardContent)`,
+  maps of components): context cannot be inferred, so the codemod converts to the Card-family
+  name (`CardBody`). If the value is actually rendered inside a `ListCard`, replace with the
+  `ListCard*` equivalent (`ListCardBody`, `ListCardRow`, ...) by hand.
+  Scan: `Card(Body|Row|Title|Caption|Thumbnail)\w*` used outside JSX tags in files that also
+  render `ListCard`.
+- **Cross-file context**: a child-component file that imports only Card sub-components (no
+  `ListCard` import in the same file) is converted to Card-family names even when a parent
+  file mounts it inside a `ListCard`. Review shared child components rendered inside
+  `ListCard` and switch them to `ListCard*` names by hand.
+- **DOM identifiers of renamed sub-components** (selectors in CSS/tests/E2E):
+
+  ```
+  data-component="card-content"               → data-component="card-body"
+  data-component="card-content-item"          → data-component="card-row"
+  data-component="card-content-item-skeleton" → data-component="card-row-skeleton"
+  --card-content-item-*                       → --card-row-*
+  ```
+
+  Scan patterns: `card-content` and `--card-content-item-`.
+  Note: after `dom-identifier-migration`, old `wds-component="card-content"` selectors have
+  become `data-component="card-content"` — this step renames the _value_ part.
+
+## M5. FormControl follow-ups
+
+- Message typography changed from `label2` to `caption1`. Code that passed explicit
+  `variant` / `weight` to `FormMessage` / `FormErrorMessage` (now `FormControlMessage` /
+  `FormControlNegativeMessage`) may fight the new default — review each occurrence.
+  Scan: `FormControl(Message|NegativeMessage)\b[^>]*\b(variant|weight)=`.
+- New API available (informational, no action required): `FormControlPositiveMessage`,
+  `FormControlCharacterCounter`, root `size` (`'large' | 'medium'`) and
+  `labelPlacement` (`'top' | 'start'`) props.
+
+## M6. Modal (bottom sheet) behavior change
+
+`variant="bottom"` + `handle` behavior changed:
+
+- ESC / handle swipe-down / dimmer click now **close the sheet immediately** unless
+  `ModalContainer` has `peekHeight` set. Previously the sheet pinned to the bottom.
+- To keep the old pin-to-bottom behavior, set `peekHeight` on `ModalContainer`.
+- `onVisibilityChange` was removed — the workaround of calling `onClose` inside it is no
+  longer needed; delete the prop and rely on the new default.
+
+Scan patterns:
+
+```
+onVisibilityChange
+variant="bottom"
+```
+
+For each bottom-sheet Modal, decide: default close-on-dismiss (delete workaround code) or
+`peekHeight` (restore pinning).
+
+## M7. TextField changes
+
+- **`size` prop introduced** (`'large'` default, `'medium'` = 40px height). The former
+  single size maps to Large, but Large's details changed: radius 12→14px, input typography
+  body1→body2, icon 22→20px. Code that hard-coded a 40px height should switch to
+  `size="medium"`. Visual QA recommended on all TextField/DatePicker/TimePicker screens.
+- **`TextFieldButton` `variant` prop removed** (was `"normal" | "assistive"`). Delete the
+  prop. The trailing button now renders inside the field.
+  Scan: `TextFieldButton[^>]*variant=`.
+- **`TextFieldContent` `variant="text-button"` removed**. Replace with another variant.
+  Scan: `text-button`.
+- **Negative-state trailing icon removed** — the circle-exclamation icon no longer renders.
+  Code compensating for its width can be simplified.
+- **`[data-role='text-field-wrapper']` styling moved** — `padding` and inset `box-shadow`
+  now live on the TextField root. Custom styles targeting the wrapper must move to the root
+  element (`sx` or root selector).
+  Scan: `text-field-wrapper`.
+
+## Suggested commit boundary
+
+Group M1 with Step 1's commit (package rename), M3 with Step 2/3, M4 with Step 4, M5 with
+Step 5 when convenient; M2, M6, M7 are independent commits. Keeping manual fixes in the
+same commit as their codemod step makes review and revert straightforward.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
@@ -19,6 +19,9 @@ export const meta = {
 //   autoCommit:    boolean — commit after each completed step
 // Optional args:
 //   codemodVersion: npm dist-tag or version for @montage-ui/codemod (default 'latest')
+//   completedSteps: step ids already marked "completed" in the state file (default []).
+//                   Read the state file in preflight and pass the list so completed
+//                   steps are skipped deterministically, without spawning an agent.
 
 const CODEMOD_STEPS = [
   {
@@ -138,10 +141,27 @@ manual:
   M7: pending
 ---`
 
+const completedSteps = args.completedSteps || []
+
 const stepResults = []
 let aborted = null
 
 for (const step of CODEMOD_STEPS) {
+  if (completedSteps.includes(step.id)) {
+    // Deterministic orchestrator-level skip. The step agent's own state-file check
+    // (procedure step 1) stays as the second layer, guarding runs launched with a
+    // stale completedSteps list.
+    log(`${step.id}: skipped (state file marks it completed)`)
+    stepResults.push({
+      step: step.id,
+      status: 'skipped',
+      filesChanged: 0,
+      committed: false,
+      verifyFindings: [],
+    })
+    continue
+  }
+
   const result = await agent(
     `You are executing ONE step of the Montage v3 → v4 migration in the repo at ${args.repoRoot}.
 Work only on this step. Do not run any other codemod.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
@@ -1,0 +1,206 @@
+export const meta = {
+  name: 'montage-v3-to-v4-migration',
+  description:
+    'Run the 5 Montage v4 codemods strictly in sequence (never re-running a completed step), then scan for manual migration targets in parallel',
+  whenToUse:
+    'Invoked by the montage-v3-to-v4 skill to migrate a consumer repo from Montage (WDS) v3 to v4',
+  phases: [
+    { title: 'Codemods', detail: '5 v4 codemods, strictly sequential' },
+    { title: 'Scan', detail: 'parallel read-only scans for manual migrations' },
+  ],
+}
+
+// Required args (pass via Workflow tool `args`):
+//   repoRoot:      absolute path of the repo being migrated
+//   targets:       array of source directories to transform, e.g. ['src'] — plain paths,
+//                  no globs (the codemod CLI takes one directory per invocation)
+//   stateFile:     absolute path of the migration state file
+//   referencesDir: absolute path of this skill's references/ directory
+//   autoCommit:    boolean — commit after each completed step
+// Optional args:
+//   codemodVersion: npm dist-tag or version for @montage-ui/codemod (default 'latest')
+
+const CODEMOD_STEPS = [
+  {
+    id: 'package-name-migration',
+    title: 'Package name migration (@wanteddev/* → @montage-ui/*)',
+    precheck: 'None.',
+    verify:
+      'grep for "@wanteddev/" in .ts/.tsx/.js/.jsx inside the targets. Import declarations must have zero hits. Remaining hits in `export ... from`, require(), dynamic import(), jest.mock()/vi.mock(), or `declare module` lines are NOT covered by the codemod — fix those by hand NOW as part of this step (they are code, unlike the config-file work of manual step M1). Hits in package.json/configs belong to manual step M1; leave them.',
+  },
+  {
+    id: 'css-variable-migration',
+    title: 'CSS variable migration (--wds-* prefix removal)',
+    precheck: 'None.',
+    verify:
+      'grep for "--wds-" in the targets including .css/.scss/.sass/.less — remaining hits should only be dynamically-built names (template interpolation / string concat), which belong to manual step M3. Then skim the diff for false positives: the rename is a blind prefix substitution, so consumer-defined --wds-* variables were also renamed (declarations and usages stay consistent inside the targets, but note them in verifyFindings). Expect intermediate --card-content-item-* names in the output — they are handled later by manual step M4; do NOT revert them.',
+  },
+  {
+    id: 'dom-identifier-migration',
+    title: 'DOM identifier migration (wds-component → data-component, region manager ids)',
+    precheck: 'None.',
+    verify:
+      'grep for "wds-component", "wds-ignore-", "wds-region-manager" in the targets including stylesheets — remaining hits should only be dynamically-built strings (manual step M3). Skim the diff for false positives: replacement is a blind substring pass over any string literal (analytics event names, doc strings). Attribute VALUES like data-component="card-content" are intentionally unchanged — manual step M4 handles them; do NOT rename values here.',
+  },
+  {
+    id: 'list-card-migration',
+    title: 'Card / ListCard naming migration (CardList → ListCard, CardContent → CardBody/ListCardBody)',
+    precheck:
+      'grep the targets for files importing BOTH an old Card name (CardContent, CardContentItem, CardList) AND its new counterpart (CardBody, ListCardBody, CardRow, ListCard) from @montage-ui/core or @wanteddev/wds. Such half-hand-migrated files can end up with duplicate import specifiers — report them as "failed" with the file list so they can be cleaned up first, unless there are none.',
+    verify:
+      'grep -E "\\bCard(List|Content)" over the targets — expect zero hits (prefix pattern: \\bCardContent\\b would miss CardContentProps/CardContentItemSkeleton leftovers; the prefix form matches no new name, ListCard* included). Also grep for non-JSX identifier references (e.g. component={CardBody}) in files that render ListCard; report them in verifyFindings for manual step M4 review.',
+  },
+  {
+    id: 'form-control-migration',
+    title: 'Form Control naming migration (FormField → FormControl → FormControlField swap)',
+    precheck:
+      'THIS CODEMOD CORRUPTS ALREADY-MIGRATED CODE. Find files referencing FormControl WITHOUT also referencing FormField — use two file-level greps and diff the file lists (a single-line import-statement grep misses multi-line imports; see the "Step 5" pre-check in the codemod-steps.md reference next to manual-migrations.md). Inspect each: if the file already uses the NEW v4 API (root <FormControl> wrapping <FormControlField>, or imports FormControlField/FormControlLabel), it was hand-migrated — report "failed" with the file list; those files must be excluded (codemod-steps.md documents the move-out/move-back exclusion procedure) before this codemod may run. A v3 file importing only the old FormControl slot (no other Form* imports, <FormControl> used inside another file\'s FormField) is safe.',
+    verify:
+      'grep -E "\\bForm(Field|Label|Message|ErrorMessage)" over the targets — expect zero hits (prefix pattern: \\bFormField\\b would miss FormFieldProps leftovers; the prefix form matches no FormControl* name). NOTE: "FormControl" hits are EXPECTED after this step (it is the new root name); do not flag them and NEVER re-run this codemod to "fix" them.',
+  },
+]
+
+const MANUAL_SCAN_SECTIONS = [
+  { id: 'M1', title: 'Package references outside import declarations' },
+  { id: 'M2', title: 'Theme tokens now return var(--...) strings (JS arithmetic breakage)' },
+  { id: 'M3', title: 'CSS variable / DOM identifier leftovers (dynamic names, E2E, configs)' },
+  { id: 'M4', title: 'Card / ListCard follow-ups (non-JSX refs, data-component values)' },
+  { id: 'M5', title: 'FormControl follow-ups (message typography variant/weight)' },
+  { id: 'M6', title: 'Modal bottom sheet behavior change (onVisibilityChange removal, peekHeight)' },
+  { id: 'M7', title: 'TextField changes (size, TextFieldButton variant, wrapper DOM)' },
+]
+
+const STEP_RESULT_SCHEMA = {
+  type: 'object',
+  required: ['step', 'status', 'filesChanged', 'committed', 'verifyFindings'],
+  properties: {
+    step: { type: 'string' },
+    status: { type: 'string', enum: ['completed', 'skipped', 'failed'] },
+    filesChanged: { type: 'number' },
+    committed: { type: 'boolean' },
+    commitHash: { type: 'string' },
+    verifyFindings: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Leftover patterns or anomalies found by the post-step verification greps',
+    },
+    error: { type: 'string' },
+  },
+}
+
+const SCAN_RESULT_SCHEMA = {
+  type: 'object',
+  required: ['section', 'hits', 'summary'],
+  properties: {
+    section: { type: 'string' },
+    summary: { type: 'string' },
+    hits: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['file', 'line', 'snippet', 'note'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'number' },
+          snippet: { type: 'string' },
+          note: {
+            type: 'string',
+            description:
+              'Assessment: what fix this occurrence needs, or why it is a false positive',
+          },
+        },
+      },
+    },
+  },
+}
+
+const codemodVersion = args.codemodVersion || 'latest'
+const targets = JSON.stringify(args.targets)
+
+const STATE_FILE_TEMPLATE = `---
+migration: montage-v3-to-v4
+targets:
+${args.targets.map((t) => '  - ' + t).join('\n')}
+autoCommit: ${args.autoCommit}
+steps:
+  package-name-migration: pending
+  css-variable-migration: pending
+  dom-identifier-migration: pending
+  list-card-migration: pending
+  form-control-migration: pending
+manual:
+  M1: pending
+  M2: pending
+  M3: pending
+  M4: pending
+  M5: pending
+  M6: pending
+  M7: pending
+---`
+
+const stepResults = []
+let aborted = null
+
+for (const step of CODEMOD_STEPS) {
+  const result = await agent(
+    `You are executing ONE step of the Montage v3 → v4 migration in the repo at ${args.repoRoot}.
+Work only on this step. Do not run any other codemod.
+
+Step: ${step.id} — ${step.title}
+Targets (JSON array; one codemod invocation per element): ${targets}
+State file: ${args.stateFile}
+Auto-commit: ${args.autoCommit}
+
+Procedure (follow exactly, in order):
+
+1. Read the state file. If it marks steps.${step.id} as "completed", do NOTHING and report status "skipped". This is critical: running a codemod twice corrupts code (e.g. the form-control codemod renames FormControl → FormControlField on a second run).
+2. If autoCommit is true, run \`git -C ${args.repoRoot} status --porcelain\` and confirm the working tree is clean apart from the state file. If it is dirty, report status "failed" with the reason — do not run the codemod on top of unrelated changes.
+3. Pre-check: ${step.precheck}
+4. For each element of the targets array, run:
+   \`npx -y @montage-ui/codemod@${codemodVersion} ${step.id} <target>\`
+   from ${args.repoRoot}. The command is non-interactive when both the transform name and the path are passed. Capture the output; jscodeshift prints per-file errors — treat any "ERR" as a failure.
+5. If the codemod failed partway: when autoCommit is true (tree was clean at step start), restore this step's partial changes with \`git -C ${args.repoRoot} checkout -- <each target>\` and report status "failed" with the error. When autoCommit is false, do NOT restore anything (earlier steps' uncommitted changes would be lost) — just report "failed" with the error and stop.
+6. Post-step verification: ${step.verify} Record findings in verifyFindings; apply only the fixes the verification instructions explicitly assign to this step — leave everything marked M1–M7 to the manual phase.
+7. Update the state file: set steps.${step.id} to "completed". If the file is missing, create it from this template first (and append its path to .git/info/exclude so it never enters commits):
+${STATE_FILE_TEMPLATE}
+8. If autoCommit is true: \`git -C ${args.repoRoot} add -A && git commit -m "chore(montage): v4 codemod — ${step.id}"\` and record the commit hash. The state file is excluded via .git/info/exclude, so it must not appear in the commit.
+
+Report filesChanged from \`git diff --stat\` (or the commit stat). Your final output is structured data for the orchestrator, not prose.`,
+    { label: `codemod:${step.id}`, phase: 'Codemods', schema: STEP_RESULT_SCHEMA },
+  )
+
+  stepResults.push(result)
+
+  if (!result || result.status === 'failed') {
+    aborted = step.id
+    log(`Aborting migration at step ${step.id} — fix the reported error, then resume; completed steps will be skipped.`)
+    break
+  }
+  log(`${step.id}: ${result.status} (${result.filesChanged} files)`)
+}
+
+let scanResults = []
+
+if (!aborted) {
+  scanResults = await parallel(
+    MANUAL_SCAN_SECTIONS.map((section) => () =>
+      agent(
+        `You are scanning (READ-ONLY — do not edit any file) the repo at ${args.repoRoot} for Montage v3 → v4 manual-migration targets.
+
+Section: ${section.id} — ${section.title}
+
+1. Read the section "${section.id}" in ${args.referencesDir}/manual-migrations.md for the scan patterns and fix rules.
+2. Run the section's scan patterns over the repo. Scan the WHOLE repo (configs, E2E tests, stylesheets), not just source targets, but skip node_modules, .next, dist, build output, and lockfiles.
+3. For each hit, assess it against the fix rules: does it actually need the manual migration, or is it a false positive (e.g. theme token used inside a CSS template literal is fine)? Record file, line, a one-line snippet, and your assessment.
+4. Do not fix anything. Your final output is structured data for the orchestrator.`,
+        { label: `scan:${section.id}`, phase: 'Scan', schema: SCAN_RESULT_SCHEMA },
+      ),
+    ),
+  )
+}
+
+return {
+  aborted,
+  steps: stepResults.filter(Boolean),
+  manualScan: scanResults.filter(Boolean),
+}

--- a/.claude/skills/migration-skill-authoring/SKILL.md
+++ b/.claude/skills/migration-skill-authoring/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: migration-skill-authoring
+description: This skill should be used when the user asks to create a new Montage migration skill for the montage-web-migration plugin (e.g. a future v4-to-v5), add or update content in an existing one (e.g. montage-v3-to-v4) after new breaking changes or codemods land, validate a migration skill, or says "마이그레이션 스킬 만들어줘", "마이그레이션 스킬 업데이트해줘", "v3-to-v4 스킬에 내용 추가해줘", "마이그레이션 스킬 검증해줘", "create/update/validate the migration skill". The pipeline (codemod analysis, ordering/idempotency derivation, authoring conventions, adversarial validation) is Workflow-orchestrated.
+---
+
+# migration-skill-authoring
+
+Author or update consumer-facing migration skills in
+`.claude-plugin/montage-migration/skills/`. The pipeline: **analyze the codemods with a
+Workflow (never trust MIGRATION.md prose alone) → derive ordering and run-once
+constraints from source facts → author the four-file deliverable per convention →
+validate with a Workflow, fix, and re-run until clean**.
+
+`skills/montage-v3-to-v4/` is the reference implementation; all conventions live in
+`references/authoring-conventions.md`.
+
+## Core principles
+
+1. **Idempotency and ordering come from transform SOURCE, not docs.** The one migration
+   fact that matters most — "does re-running corrupt code?" — is a rename-chain property
+   of the transform (a rename VALUE appearing as another rename KEY). It must be traced
+   in code, with file:line evidence.
+2. **Codemods run strictly in sequence, each exactly once per tree.** Every skill encodes
+   this with a state file, per-step verification, and defense-in-depth warnings for any
+   non-idempotent transform.
+3. **Every factual claim ships validated.** Grep patterns are empirically executed
+   (macOS BSD grep included), rename tables are diffed against the transform maps, and
+   consistency surfaces are cross-checked — by adversarial agents, before the skill ships.
+
+## Mode A — Create a new version skill
+
+### Prerequisites
+
+- The MIGRATION.md section for the target version is written.
+- The codemods exist in `packages/codemod/src/transforms/<vN>/` and are registered in
+  `MIGRATION_TRANSFORMS` in `packages/codemod/src/constants.ts`.
+
+If either is missing, stop and surface it — the skill is authored FROM these, never ahead
+of them.
+
+### Step 1 — Analyze the codemods
+
+Enumerate the version's transforms from `constants.ts`, then run the analysis Workflow:
+
+```
+Workflow({
+  scriptPath: "<this skill's base directory>/scripts/analyze-codemods.js",
+  args: {
+    repoRoot: "<absolute repo root>",
+    migrationSection: "## <N>.0.0",
+    transforms: [
+      { key: "<transform-name>",
+        files: "<absolute transform path(s), plus any *-map.ts files it imports>",
+        extra: "<transform-specific questions>" },
+      ...
+    ]
+  }
+})
+```
+
+Resolve `<this skill's base directory>` from the "Base directory for this skill" line
+announced when this skill loaded. If the result's `missing` array is non-empty (or
+`docs` is null when the docs agent was not skipped), re-run the analysis for those
+transforms before Step 2 — never derive ordering or idempotency from partial analysis.
+
+Write a pointed `extra` per transform: rename-chain suspects (any A→B where B is also
+renamed), map-file interactions with other transforms' outputs, whether it touches
+attribute names vs values, string literals vs identifiers.
+
+### Step 2 — Derive the design from the analysis
+
+- **Canonical order**: MIGRATION.md section order, adjusted only by hard constraints the
+  analysis surfaced. Record every constraint WITH its reason.
+- **Run-once machinery**: flag every non-idempotent transform (and every
+  hand-migration-collision hazard) for defense-in-depth treatment — see the consistency
+  surfaces table in `references/authoring-conventions.md`.
+- **Manual steps (M-sections)**: everything the codemods cannot reach, each with scan
+  patterns and an unambiguous owner (exactly one phase fixes it; safety-net scans say so).
+
+### Step 3 — Author the deliverable
+
+Follow `references/authoring-conventions.md` exactly: the four files (SKILL.md,
+`references/codemod-steps.md`, `references/manual-migrations.md`,
+`scripts/migration-workflow.js`), the state-file spec, the workflow script conventions,
+the writing conventions, and the grep pattern rules. Copy the montage-v3-to-v4 structure
+and adapt content — do not invent a new shape.
+
+### Step 4 — Validate until clean
+
+```
+Workflow({
+  scriptPath: "<this skill's base directory>/scripts/validate-migration-skill.js",
+  args: {
+    repoRoot: "<absolute repo root>",
+    skillDir: "<absolute path of the authored skill>",
+    migrationSection: "## <N>.0.0",
+    transformsDir: "<absolute path of packages/codemod/src/transforms/vN>"
+  }
+})
+```
+
+Fix every `critical`/`major` finding (and `minor` unless there is a stated reason not
+to), then RE-RUN the validation Workflow. Repeat until it returns `clean: true`. The
+structure reviewer already runs the mechanical checks (workflow-script syntax wrap +
+`node --check`, prettier) — run them manually (procedure in the conventions doc) only
+when iterating on a fix or when the structure reviewer itself failed.
+
+### Step 5 — Ship
+
+Update the plugin `README.md`/`README.ko.md` skill listing, bump
+`.claude-plugin/montage-migration/.claude-plugin/plugin.json` (minor) and
+`.claude-plugin/marketplace.json`. Suggest a trigger test:
+`claude --plugin-dir .claude-plugin/montage-migration`.
+
+## Mode B — Update an existing migration skill
+
+For new breaking changes, a new codemod, or corrections landing in a version that already
+has a skill:
+
+1. **Impact analysis first.** Read the consistency surfaces table in
+   `references/authoring-conventions.md` — a new step or M-section touches EVERY listed
+   surface (SKILL.md, both references, the workflow script's `CODEMOD_STEPS` /
+   `MANUAL_SCAN_SECTIONS` / `STATE_FILE_TEMPLATE`, both READMEs). Partial updates are how
+   the files start contradicting each other.
+2. **Analyze only what changed** — run `scripts/analyze-codemods.js` with just the new or
+   modified transforms (`skipDocsAgent: true` if the CLI is untouched). A changed
+   transform's idempotency must be re-traced from source, not assumed stable. For a step
+   inserted anywhere but last, the `extra` MUST also ask: "does this transform behave
+   correctly on code already migrated by the steps that canonically follow it?" —
+   consumers who completed later steps will run it on a post-migration tree.
+3. **Respect state-schema stability.** Consumers may be mid-migration with a live state
+   file: never rename existing step keys or M-numbers (renamed transforms are the one
+   exception — see the conventions doc); add new steps at the position the constraint
+   analysis dictates with value `pending`. Then encode the semantics INTO the consumer
+   deliverable, not just here: the consumer SKILL.md's Step 0 resume item and the
+   workflow step-agent prompt must both state that a step key missing from an older
+   state file is `pending` (so resuming consumers pick up the new step), and if the new
+   step lands before steps consumers may have completed, the resume item must say the
+   new step still runs and what to verify first. Add the new step's post-step
+   verification grep to the consumer skill's "already migrated" preflight path and final
+   verification, so consumers who FINISHED the migration get flagged when they invoke
+   the skill again.
+4. **Re-run the FULL validation Workflow** (Step 4 above) — not just on the delta; the
+   consistency reviewer exists precisely for update-mode drift.
+5. **Bump versions** (plugin.json minor for new content, patch for corrections) and
+   update READMEs if behavior changed.
+
+## Additional resources
+
+- **`references/authoring-conventions.md`** — the deliverable structure, consistency
+  surfaces, sequencing/run-once design, workflow-script and writing conventions, verified
+  CLI facts, grep pattern rules, mechanical validation.
+- **`scripts/analyze-codemods.js`** — analysis Workflow (per-transform facts + CLI/docs).
+- **`scripts/validate-migration-skill.js`** — validation Workflow (fact-check,
+  consistency, quality, structure); re-run until `clean: true`.

--- a/.claude/skills/migration-skill-authoring/SKILL.md
+++ b/.claude/skills/migration-skill-authoring/SKILL.md
@@ -42,7 +42,7 @@ of them.
 
 Enumerate the version's transforms from `constants.ts`, then run the analysis Workflow:
 
-```
+```js
 Workflow({
   scriptPath: "<this skill's base directory>/scripts/analyze-codemods.js",
   args: {
@@ -87,16 +87,17 @@ and adapt content — do not invent a new shape.
 
 ### Step 4 — Validate until clean
 
-```
+```js
 Workflow({
-  scriptPath: "<this skill's base directory>/scripts/validate-migration-skill.js",
+  scriptPath:
+    "<this skill's base directory>/scripts/validate-migration-skill.js",
   args: {
-    repoRoot: "<absolute repo root>",
-    skillDir: "<absolute path of the authored skill>",
-    migrationSection: "## <N>.0.0",
-    transformsDir: "<absolute path of packages/codemod/src/transforms/vN>"
-  }
-})
+    repoRoot: '<absolute repo root>',
+    skillDir: '<absolute path of the authored skill>',
+    migrationSection: '## <N>.0.0',
+    transformsDir: '<absolute path of packages/codemod/src/transforms/vN>',
+  },
+});
 ```
 
 Fix every `critical`/`major` finding (and `minor` unless there is a stated reason not

--- a/.claude/skills/migration-skill-authoring/references/authoring-conventions.md
+++ b/.claude/skills/migration-skill-authoring/references/authoring-conventions.md
@@ -64,6 +64,10 @@ changing a step or M-section, update every row:
 - Codemod steps: a sequential `for` loop of `await agent(...)` — a failed/null result
   aborts the chain and the return carries `aborted: <step id>`. Never `parallel()` the
   codemod steps.
+- Deterministic skip: the script cannot read files, so the orchestrator (main loop)
+  reads the state file at preflight and passes `completedSteps` (step-id array) via
+  args; the loop skips those steps without spawning an agent. The step agent's own
+  state-file check stays as the second layer.
 - Manual scans: `parallel()` read-only agents, one per M-section, reading the section's
   patterns from `referencesDir` (pass it via args, do not duplicate patterns in the
   script).

--- a/.claude/skills/migration-skill-authoring/references/authoring-conventions.md
+++ b/.claude/skills/migration-skill-authoring/references/authoring-conventions.md
@@ -1,0 +1,150 @@
+# Migration Skill Authoring Conventions
+
+Conventions for every `montage-vN-to-vM` skill in the `montage-web-migration` plugin
+(`.claude-plugin/montage-migration/`). `skills/montage-v3-to-v4/` is the reference
+implementation — when in doubt, mirror it.
+
+## The deliverable
+
+| File                              | Role                                                                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `SKILL.md`                        | Lean orchestration (~1,000–1,500 words): critical rules, preflight, Workflow invocation, manual phase, final verification  |
+| `references/codemod-steps.md`     | The codemods in canonical order: command, idempotency analysis, pre-checks, post-step verification greps, hazards          |
+| `references/manual-migrations.md` | Manual migrations (M-sections) with scan patterns and fix rules                                                            |
+| `scripts/migration-workflow.js`   | Workflow-tool script: sequential codemod steps + parallel manual scans; also the canonical per-step procedure for fallback |
+
+Plus: plugin `README.md` / `README.ko.md` skill listing, `plugin.json` version bump
+(minor for a new skill or new content), `marketplace.json` version bump.
+
+## Consistency surfaces
+
+The same facts are stated in several places and MUST stay identical. When adding or
+changing a step or M-section, update every row:
+
+| Fact                   | Stated in                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Codemod step order     | SKILL.md critical rules + state-file template, codemod-steps.md table + section order, script `CODEMOD_STEPS` + `STATE_FILE_TEMPLATE`, both READMEs |
+| M-section numbering    | manual-migrations.md headings, script `MANUAL_SCAN_SECTIONS`, SKILL.md mentions, state-file template `manual:` keys                                 |
+| State file path/schema | SKILL.md (definition), script step-agent prompt (inlined template), READMEs (mention)                                                               |
+| CLI command shape      | SKILL.md critical rules, codemod-steps.md intro, script step-agent prompt                                                                           |
+| Corruption hazards     | SKILL.md critical rule, codemod-steps.md idempotency table + step section, script `precheck`/`verify`, README                                       |
+| Resume semantics       | SKILL.md Step 0 resume item (missing key = pending, state-vs-git mismatch, targets locked), script step-agent prompt step ①                         |
+
+## Sequencing and run-once design
+
+- **Canonical order**: MIGRATION.md section order is the default. Verify against the
+  analysis: the only HARD constraints usually run codemod → manual (manual steps are
+  written in terms of post-codemod names, e.g. `--card-content-item-*` → `--card-row-*`
+  only exists after `css-variable-migration`). State every constraint with its reason in
+  codemod-steps.md.
+- **Idempotency is a source-level fact, not an assumption.** Trace rename chains in the
+  transform source: if any rename VALUE appears as another rename KEY (the
+  `FormField→FormControl→FormControlField` shape), the transform corrupts on re-run and on
+  hand-migrated code. Such transforms need defense-in-depth — a warning at EVERY layer
+  listed in the consistency table, a pre-check that detects hand-migrated files, and an
+  actionable exclusion procedure (move-out/move-back; the CLI has no exclude flag).
+- **State file**: `.claude/montage-migration-v<major>.local.md` in the consumer repo
+  (e.g. `montage-migration-v4.local.md` — matches the reference implementation). YAML
+  frontmatter with `migration` / `targets` / `autoCommit` / `steps` (key = transform name,
+  value `pending|completed`) / `manual` (M-keys). Registered in `.git/info/exclude` at
+  preflight so per-step `git add -A` commits never include it; deleted only after final
+  verification.
+- **State schema stability**: step keys are transform names — never rename them; a
+  consumer mid-migration resumes by key. A step key missing from an older state file is
+  treated as `pending` — this rule must be stated IN the consumer skill (its Step 0
+  resume item and the workflow step-agent prompt), not only here. If a transform itself
+  is renamed in `constants.ts`, the key must follow (it doubles as the CLI positional):
+  treat it as a new key and add a key-migration note to the consumer skill's resume item
+  mapping the old completed mark to the new key.
+- **Run-once is per tree**: multiple target directories get one CLI invocation each
+  within the same step — that is not a re-run.
+
+## Workflow script conventions
+
+- Codemod steps: a sequential `for` loop of `await agent(...)` — a failed/null result
+  aborts the chain and the return carries `aborted: <step id>`. Never `parallel()` the
+  codemod steps.
+- Manual scans: `parallel()` read-only agents, one per M-section, reading the section's
+  patterns from `referencesDir` (pass it via args, do not duplicate patterns in the
+  script).
+- Each `CODEMOD_STEPS` entry: `id` (transform name), `title`, `precheck`, `verify`. The
+  step-agent prompt is the canonical 8-step procedure: ① state check (skip if completed)
+  ② clean-tree check (autoCommit only) ③ precheck ④ run codemod per target ⑤ failure
+  handling (restore only when autoCommit, else stop) ⑥ verification ⑦ state update
+  (template inlined in the prompt — the sub-agent cannot see SKILL.md) ⑧ commit.
+- `targets` travels as a JSON array into prompts; the npx command takes ONE directory per
+  invocation.
+- Structured output: use `schema` on every agent; step results
+  `{step, status, filesChanged, committed, commitHash?, verifyFindings, error?}`, scan
+  results `{section, summary, hits: [{file, line, snippet, note}]}`.
+- Workflow scripts run in an async context with injected globals (`args`, `agent`,
+  `parallel`, `log`, `phase`) and allow top-level `return`; no `Date.now()` /
+  `Math.random()` / fs access. `export const meta = {...}` must be a pure literal.
+
+## Writing conventions
+
+- SKILL.md body in **imperative English**; frontmatter description in third person
+  ("This skill should be used when...") with BOTH Korean and English trigger phrases.
+  Include resume phrases ("마이그레이션 이어서 해줘") and single-codemod phrases (running
+  one codemod ad hoc is exactly when run-once protection gets bypassed).
+- Scope the description: name the versions it covers and where other migrations live.
+- Keep SKILL.md lean; details go to references. State a fact in SKILL.md only if it is an
+  invariant the orchestrator needs before reading references.
+- Behavioral decisions (e.g. Modal `peekHeight` vs new default) are the USER's — the
+  skill instructs asking, not deciding.
+
+## Codemod CLI facts (verified against `packages/codemod/src/cli.ts`, 2026-07)
+
+Re-verify these when the CLI changes:
+
+- `npx -y @montage-ui/codemod@<version> <transform> <path>` — non-interactive only when
+  BOTH positionals are present; transform names WITHOUT the `vN/` prefix.
+- One transform per invocation; no batch mode.
+- ONE file-or-directory path per invocation. Extra positional paths are silently dropped;
+  globs are NOT expanded (the CLI help text claims otherwise — it lies).
+- jscodeshift runs with `--extensions=tsx,ts,jsx,js` and ignores
+  `node_modules`/`.next`/`dist`.
+- The stylesheet text pass (`.css/.scss/.sass/.less`) runs ONLY via the CLI wrapper and
+  ONLY for transforms registered in `STYLE_TEXT_TRANSFORMS` — check that map for the new
+  version's transforms; document per step whether stylesheets are covered.
+- Import-gated transforms match import sources against `MONTAGE_SOURCES` exactly —
+  subpath/namespace/re-export imports are skipped; document as manual follow-ups.
+
+## Grep pattern rules
+
+Every scan/verification pattern must survive macOS BSD grep. Each rule below is a bug
+that shipped once:
+
+1. **Bracket ranges**: `[+\-*/]` is an invalid range in POSIX ERE (BSD grep exits 2 —
+   the scan silently finds nothing). Write `[-+*/]` (dash first). `\b`/`\s`/`\w` are fine
+   on GNU and BSD grep.
+2. **Never line-anchor import greps**: `^(import|export).*from '@x'` misses multi-line
+   (prettier-formatted) imports. Grep the bare token and eyeball hits.
+3. **"references X without Y" checks must be file-level two-pass**, not a single-line
+   import grep: `comm -23 <(grep -rlE '\bX\b' … | sort) <(grep -rlE '\bY\b' … | sort)`.
+4. **Prefer prefix patterns over trailing `\b`** for leftover detection:
+   `\bCardContent\b` misses `CardContentProps`/`CardContentItemSkeleton`; use
+   `\bCard(List|Content)` — and confirm the prefix form matches NO new (post-migration)
+   name before adopting it.
+5. **Explicit `--include=` per extension**: `--include="*.js*"` also matches `.json`
+   (package.json noise).
+6. **Declare patterns as heuristics**: line-based greps miss multi-line JSX props and
+   non-literal forms; a clean scan is "nothing obvious", not proof of absence.
+
+## Mechanical validation
+
+- Workflow script syntax: top-level `return` is valid in the Workflow DSL but not plain
+  ESM — check by wrapping:
+
+  ```sh
+  # split off the meta export, wrap the body in an async fn, then:
+  node --check wrapped.mjs
+  ```
+
+- `npx prettier --check` on every touched `.md`/`.json` (the repo hook formats on write,
+  but verify).
+- Trigger test: `claude --plugin-dir .claude-plugin/montage-migration` and ask with each
+  trigger phrase.
+- ESLint: `.claude-plugin` and `.claude` are in `eslint.config.mjs` `globalIgnores` — new
+  script files there are not linted; keep it that way rather than adding tsconfig
+  coverage.

--- a/.claude/skills/migration-skill-authoring/scripts/analyze-codemods.js
+++ b/.claude/skills/migration-skill-authoring/scripts/analyze-codemods.js
@@ -1,0 +1,143 @@
+export const meta = {
+  name: 'analyze-migration-codemods',
+  description:
+    'Analyze codemod transforms for behavior, idempotency, and ordering constraints before authoring a migration skill',
+  whenToUse:
+    'Invoked by the migration-skill-authoring skill: one analysis agent per transform + one CLI/docs agent',
+  phases: [{ title: 'Analyze', detail: 'one agent per transform + CLI/docs facts' }],
+}
+
+// Required args:
+//   repoRoot:   absolute path of this design-system repo
+//   transforms: array of { key, files, extra? }
+//     key   — transform name as registered in constants.ts (e.g. 'foo-migration')
+//     files — comma/`and`-joined absolute paths of the transform source (+ map files)
+//     extra — transform-specific questions (rename-chain suspects, map interactions, ...)
+//   migrationSection: the MIGRATION.md heading covering this version (e.g. '## 5.0.0')
+// Optional args:
+//   skipDocsAgent: true to skip the CLI/docs agent (e.g. update mode, CLI unchanged)
+
+const TRANSFORM_SCHEMA = {
+  type: 'object',
+  required: [
+    'transform',
+    'summary',
+    'detection',
+    'importGated',
+    'idempotency',
+    'ordering',
+    'manualFollowUps',
+    'cliCommand',
+  ],
+  properties: {
+    transform: { type: 'string' },
+    summary: { type: 'string', description: 'What the codemod does, 2-4 sentences' },
+    detection: {
+      type: 'string',
+      description:
+        'Exactly what the codemod matches: which imports gate it, which patterns it rewrites, which file types it touches, whether a stylesheet text pass is registered for it',
+    },
+    importGated: {
+      type: 'boolean',
+      description: 'true if the transform only fires when specific gating imports are present',
+    },
+    idempotency: {
+      type: 'object',
+      required: ['safeToRerun', 'secondRunEffect', 'evidence'],
+      properties: {
+        safeToRerun: { type: 'boolean' },
+        secondRunEffect: {
+          type: 'string',
+          description:
+            'Concretely what happens on a second run over already-migrated code. Trace rename chains: does any rename VALUE appear as another rename KEY? Also state what happens on hand-migrated code.',
+        },
+        evidence: { type: 'string', description: 'file:line references backing the claim' },
+      },
+    },
+    ordering: {
+      type: 'array',
+      items: { type: 'string' },
+      description:
+        'Constraints relative to the other transforms of this version AND to manual steps, each with a reason. Say explicitly when order does not matter and why.',
+    },
+    manualFollowUps: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Things the codemod cannot do that consumers must fix by hand afterwards',
+    },
+    cliCommand: { type: 'string', description: 'Exact npx command for a src directory' },
+    testFiles: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const DOCS_SCHEMA = {
+  type: 'object',
+  required: ['invocation', 'batchMode', 'notes'],
+  properties: {
+    invocation: { type: 'string', description: 'Canonical non-interactive CLI usage line' },
+    batchMode: {
+      type: 'string',
+      description: 'Whether the CLI can batch transforms or takes one per invocation; how many path args it honors; whether globs are expanded',
+    },
+    styleTextTransforms: {
+      type: 'string',
+      description: 'Which transforms are registered in STYLE_TEXT_TRANSFORMS (stylesheet pass)',
+    },
+    latestPublishedVersion: {
+      type: 'string',
+      description: 'Latest published version per CHANGELOG.md and current lerna.json version',
+    },
+    recommendedOrder: {
+      type: 'string',
+      description: 'Ordering implied by the MIGRATION.md section order and constants.ts',
+    },
+    notes: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+phase('Analyze')
+
+const tasks = args.transforms.map((t) => () =>
+  agent(
+    `You are analyzing a jscodeshift codemod in the Montage design system repo at ${args.repoRoot}.
+
+Target transform: ${t.key}
+Read these files completely: ${t.files}
+Also read the shared helpers they import from ${args.repoRoot}/packages/codemod/src/helpers/, ${args.repoRoot}/packages/codemod/src/constants.ts, ${args.repoRoot}/packages/codemod/src/cli.ts, and the "${args.migrationSection}" section of ${args.repoRoot}/MIGRATION.md.
+Find and read any test files for this transform (Glob/Grep for "*${t.key}*" under ${args.repoRoot}/packages/codemod).
+
+${t.extra || ''}
+
+Answer with file:line evidence. A consumer-facing skill will run this codemod EXACTLY ONCE in a fixed order in consumer repos, so the idempotency and ordering analysis must be correct, not guessed. Idempotency is a source-level fact: trace whether any rename VALUE appears as another rename KEY (double-swap corruption), and whether running against hand-migrated code corrupts. Your final output is raw data for the orchestrator, not prose for a human.`,
+    { label: `analyze:${t.key}`, phase: 'Analyze', schema: TRANSFORM_SCHEMA },
+  ),
+)
+
+if (!args.skipDocsAgent) {
+  tasks.push(() =>
+    agent(
+      `You are analyzing the CLI and docs of the @montage-ui/codemod package in the repo at ${args.repoRoot}.
+
+Read: packages/codemod/package.json, packages/codemod/src/cli.ts, packages/codemod/src/constants.ts, packages/codemod/README.md, packages/codemod/README.ko.md, lerna.json, and the "${args.migrationSection}" section of MIGRATION.md (all under ${args.repoRoot}). Check CHANGELOG.md briefly for the latest published version.
+
+Determine from SOURCE (not docs — the help text has been wrong before): exact non-interactive invocation, how many path positionals are honored, whether globs are expanded, which transforms get the stylesheet text pass (STYLE_TEXT_TRANSFORMS), extensions and ignore patterns, and any ordering implied for this version's transforms. Your final output is raw data for the orchestrator.`,
+      { label: 'analyze:cli-docs', phase: 'Analyze', schema: DOCS_SCHEMA },
+    ),
+  )
+}
+
+const results = await parallel(tasks)
+const transformResults = results.slice(0, args.transforms.length)
+const transforms = transformResults.filter(Boolean)
+const missing = args.transforms.filter((t, i) => !transformResults[i]).map((t) => t.key)
+const docs = args.skipDocsAgent ? 'skipped' : results[args.transforms.length] || null
+
+log(
+  `Analyzed ${transforms.length}/${args.transforms.length} transforms` +
+    (missing.length ? ` — MISSING: ${missing.join(', ')} (re-run before deriving the design)` : ''),
+)
+
+// missing lists transforms whose analysis agent failed; docs is null when the docs
+// agent failed (vs 'skipped' when skipDocsAgent was set). Never derive ordering or
+// idempotency from a result with missing entries.
+return { transforms, missing, docs }

--- a/.claude/skills/migration-skill-authoring/scripts/validate-migration-skill.js
+++ b/.claude/skills/migration-skill-authoring/scripts/validate-migration-skill.js
@@ -1,0 +1,94 @@
+export const meta = {
+  name: 'validate-migration-skill',
+  description:
+    'Adversarially validate an authored migration skill: fact-check vs codemod sources, cross-file consistency, skill quality, structure',
+  whenToUse:
+    'Invoked by the migration-skill-authoring skill after authoring or updating a migration skill; re-run until zero findings',
+  phases: [{ title: 'Validate', detail: '4 parallel reviewers' }],
+}
+
+// Required args:
+//   repoRoot: absolute path of this design-system repo
+//   skillDir: absolute path of the migration skill under validation
+//             (e.g. <repoRoot>/.claude-plugin/montage-migration/skills/montage-v3-to-v4)
+//   migrationSection: the MIGRATION.md heading covering this version (e.g. '## 4.0.0')
+//   transformsDir: absolute path of this version's transforms
+//             (e.g. <repoRoot>/packages/codemod/src/transforms/v4)
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'file', 'issue', 'fix'],
+        properties: {
+          severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
+          file: { type: 'string' },
+          line: { type: 'number' },
+          issue: { type: 'string', description: 'What is wrong, with evidence' },
+          fix: { type: 'string', description: 'Concrete suggested fix' },
+        },
+      },
+    },
+  },
+}
+
+const SKILL_FILES = `${args.skillDir}/SKILL.md, ${args.skillDir}/references/codemod-steps.md, ${args.skillDir}/references/manual-migrations.md, ${args.skillDir}/scripts/migration-workflow.js`
+
+phase('Validate')
+
+const results = await parallel([
+  () =>
+    agent(
+      `Adversarially FACT-CHECK migration documentation against source code. Try to refute every checkable claim.
+
+Docs: ${SKILL_FILES}
+Ground truth: ${args.transformsDir}/*.ts, ${args.repoRoot}/packages/codemod/src/cli.ts, ${args.repoRoot}/packages/codemod/src/constants.ts, ${args.repoRoot}/packages/codemod/src/helpers/index.ts, and the "${args.migrationSection}" section of ${args.repoRoot}/MIGRATION.md.
+
+Check especially: (1) idempotency claims — trace rename chains in the transform source; (2) CLI invocation claims (positional handling, glob expansion, stylesheet pass registration) — from cli.ts source, not help text; (3) every rename table vs MIGRATION.md and the transform maps, including entries the docs may have MISSED from the maps; (4) every grep pattern — empirically run each one with /usr/bin/grep -E on a synthetic fixture: does it execute without error on BSD grep, does it catch multi-line imports, does it catch *Props/*Skeleton leftovers, does it avoid matching post-migration names? Report only verified findings. Your final output is raw data for the orchestrator.`,
+      { label: 'validate:fact-check', phase: 'Validate', schema: FINDINGS_SCHEMA },
+    ),
+  () =>
+    agent(
+      `Check INTERNAL CONSISTENCY of a migration skill package. Try hard to find contradictions.
+
+Files: ${SKILL_FILES}, plus ${args.repoRoot}/.claude-plugin/montage-migration/README.md, README.ko.md, .claude-plugin/plugin.json.
+
+Verify these consistency surfaces are identical everywhere they appear: (1) codemod step order — SKILL.md rules + state template + workflow example, codemod-steps.md table + sections, script CODEMOD_STEPS + STATE_FILE_TEMPLATE, READMEs; (2) M-section numbering/topics — manual-migrations.md headings vs script MANUAL_SCAN_SECTIONS vs SKILL.md mentions vs state template; (3) state file path and YAML schema; (4) Workflow args in SKILL.md example vs what the script reads (every arg the script reads must be documented, and vice versa); (5) npx command shape; (6) ownership of each manual fix (exactly one phase owns it; safety-net scans must say so). Report every mismatch. Your final output is raw data for the orchestrator.`,
+      { label: 'validate:consistency', phase: 'Validate', schema: FINDINGS_SCHEMA },
+    ),
+  () =>
+    agent(
+      `Review a Claude Code SKILL package for QUALITY as if you were the plugin-dev skill-reviewer.
+
+Files: ${SKILL_FILES}
+
+Check: frontmatter description (third person, Korean AND English triggers, resume + single-codemod phrases, version scoping); SKILL.md lean with details in references; imperative writing; whether a FRESH Claude instance in a consumer repo could execute safely — every instruction actionable (no "exclude it" without a documented mechanism), corruption hazards stated at every layer (SKILL.md rule, reference table, script precheck/verify), behavioral decisions routed to the user, resume semantics unambiguous (state-vs-git mismatch handling, targets locked). Report concrete gaps only — no praise. Your final output is raw data for the orchestrator.`,
+      { label: 'validate:quality', phase: 'Validate', schema: FINDINGS_SCHEMA },
+    ),
+  () =>
+    agent(
+      `Validate PLUGIN STRUCTURE and mechanical health.
+
+Skill dir: ${args.skillDir}
+Plugin root: ${args.repoRoot}/.claude-plugin/montage-migration
+Marketplace: ${args.repoRoot}/.claude-plugin/marketplace.json
+
+Check: plugin.json valid and version bumped for this change; SKILL.md frontmatter parses (name matches directory, kebab-case); every file referenced from SKILL.md exists; any file under references/ or scripts/ NOT referenced from SKILL.md gets flagged (the convention is exactly: references/codemod-steps.md, references/manual-migrations.md, scripts/migration-workflow.js); the workflow script parses — extract the body after the meta export, wrap it in "async function main(){...}" with stub globals (args/agent/parallel/log/phase), write to a temp .mjs and run node --check; meta export is a pure literal with name/description/phases; npx prettier --check on the skill's .md files passes; README.md and README.ko.md both list the skill. Report failures only. Your final output is raw data for the orchestrator.`,
+      { label: 'validate:structure', phase: 'Validate', schema: FINDINGS_SCHEMA },
+    ),
+])
+
+const REVIEWERS = ['fact-check', 'consistency', 'quality', 'structure']
+const order = { critical: 0, major: 1, minor: 2 }
+const completed = results.filter(Boolean).length
+const findings = results
+  .flatMap((r, i) => (r ? r.findings.map((f) => ({ ...f, reviewer: REVIEWERS[i] })) : []))
+  .sort((a, b) => order[a.severity] - order[b.severity])
+
+log(`${findings.length} findings from ${completed}/4 reviewers`)
+
+return { findings, clean: findings.length === 0 && completed === 4 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,8 @@
 | `@wanteddev/wds-codemod`       | `@montage-ui/codemod`       |
 | `@wanteddev/wds-theme`         | `@montage-ui/theme`         |
 | `@wanteddev/wds-engine`        | `@montage-ui/engine`        |
+| `@wanteddev/wds-dummy`         | `@montage-ui/dummy`         |
+| `@wanteddev/wds-brand`         | `@montage-ui/brand`         |
 | `@wanteddev/eslint-plugin-wds` | `@montage-ui/eslint-plugin` |
 
 import 경로를 자동으로 변환하려면 아래 codemod를 실행하세요:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -243,6 +243,8 @@ export default defineConfig(
 
   globalIgnores([
     '.nx',
+    '.claude',
+    '.claude-plugin',
     '**/node_modules',
     '**/dist',
     'packages/**/bin',


### PR DESCRIPTION
## Summary

- **`montage-web-migration` 플러그인 첫 스킬 `montage-v3-to-v4` 추가** — v4 codemod 5종(`package-name` → `css-variable` → `dom-identifier` → `list-card` → `form-control`)을 Workflow 도구로 오케스트레이션. codemod는 순차 실행되고, 소비자 레포의 상태 파일(`.claude/montage-migration-v4.local.md`)로 각 단계가 정확히 1회만 실행되도록 보호. `form-control-migration`은 FormField↔FormControl 스왑 체인 때문에 재실행 시 코드가 실제로 손상됨(소스 레벨 검증 완료) — precheck·검증 grep·수동 마이그레이션(M1~M7) 스캔까지 포함.
- **repo-local 메타 스킬 `.claude/skills/migration-skill-authoring` 추가** — 향후 버전 마이그레이션 스킬을 만들거나(v4→v5) 기존 스킬을 업데이트할 때의 저작 파이프라인: codemod 분석 Workflow(`analyze-codemods.js`) → 순서/멱등성 도출 → 4파일 규약 → 적대적 검증 Workflow(`validate-migration-skill.js`, clean까지 반복). 상태 스키마 안정성 규칙(진행 중인 소비자 보호) 포함.
- **MIGRATION.md 보완** — 4.0.0 패키지 표에 codemod 맵에는 있으나 누락됐던 `wds-dummy`/`wds-brand` 행 추가.
- **기타** — eslint `globalIgnores`에 `.claude`/`.claude-plugin` 추가(플러그인 내 `.js`가 `parserOptions.project`에 걸리는 IDE lint 에러 방지), 플러그인 1.1.0·마켓플레이스 1.1.0 버전 범프, montage-web-guide keywords `wds`→`montage`.

스킬 문서의 모든 사실 주장(멱등성 표, rename 표, CLI 동작, grep 패턴)은 transform 소스 대조 + macOS BSD grep 실행 테스트로 검증했습니다.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [x] Other

## Checklist

- [x] Changes do not break existing functionality
- [ ] Added or updated relevant tests
- [x] Lint and build pass successfully

## Related Issues

[WRP-1506](https://wantedlab.atlassian.net/browse/WRP-1506) — [디자인시스템] 마이그레이션 Claude workflow 설계 및 재사용 가능한 workflow 수정 스킬 추가

- Status: 열림
- Type: 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-1506]: https://wantedlab.atlassian.net/browse/WRP-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Montage Web 마이그레이션 플러그인이 추가되어 v3→v4 전환을 단계별로 지원합니다.
* **Documentation**
  * 마이그레이션 설치/진행(재개 포함) 및 수동 처리·검증 절차 안내 문서가 보강되었습니다.
  * MIGRATION 안내의 패키지명 매핑(예: dummy/brand)이 업데이트되었습니다.
* **Chores**
  * 플러그인 마켓 메타데이터(버전/검색 키워드)가 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->