### PR TITLE
feat(theme): semantic 토큰에 status background·line, primary line 추가

### DIFF
--- a/packages/wds-theme/src/theme/semantic/index.ts
+++ b/packages/wds-theme/src/theme/semantic/index.ts
@@ -33,6 +33,11 @@ export const light = {
       normal: addHexOpacity(atomic.common[100], opacity[8]),
       alternative: addHexOpacity(atomic.common[100], opacity[28]),
     },
+    status: {
+      negative: addHexOpacity(atomic.red[50], opacity[8]),
+      cautionary: addHexOpacity(atomic.orange[50], opacity[8]),
+      positive: addHexOpacity(atomic.green[50], opacity[8]),
+    },
   },
   interaction: {
     inactive: atomic.coolNeutral[70],
@@ -48,6 +53,22 @@ export const light = {
       normal: atomic.coolNeutral[96],
       neutral: atomic.coolNeutral[97],
       alternative: atomic.coolNeutral[98],
+    },
+    primary: {
+      normal: addHexOpacity(atomic.blue[50], opacity[28]),
+      strong: addHexOpacity(atomic.blue[50], opacity[43]),
+    },
+    status: {
+      negative: {
+        normal: addHexOpacity(atomic.red[50], opacity[43]),
+        strong: addHexOpacity(atomic.red[50], opacity[52]),
+      },
+      cautionary: {
+        normal: addHexOpacity(atomic.orange[50], opacity[43]),
+      },
+      positive: {
+        normal: addHexOpacity(atomic.green[50], opacity[43]),
+      },
     },
   },
   status: {
@@ -147,6 +168,11 @@ export const dark = {
       normal: addHexOpacity(atomic.coolNeutral[17], opacity[61]),
       alternative: addHexOpacity(atomic.coolNeutral[17], opacity[61]),
     },
+    status: {
+      negative: addHexOpacity(atomic.red[60], opacity[8]),
+      cautionary: addHexOpacity(atomic.orange[60], opacity[8]),
+      positive: addHexOpacity(atomic.green[60], opacity[8]),
+    },
   },
   interaction: {
     inactive: atomic.coolNeutral[40],
@@ -162,6 +188,22 @@ export const dark = {
       normal: atomic.coolNeutral[25],
       neutral: atomic.coolNeutral[23],
       alternative: atomic.coolNeutral[22],
+    },
+    primary: {
+      normal: addHexOpacity(atomic.blue[60], opacity[28]),
+      strong: addHexOpacity(atomic.blue[60], opacity[43]),
+    },
+    status: {
+      negative: {
+        normal: addHexOpacity(atomic.red[60], opacity[43]),
+        strong: addHexOpacity(atomic.red[60], opacity[52]),
+      },
+      cautionary: {
+        normal: addHexOpacity(atomic.orange[60], opacity[43]),
+      },
+      positive: {
+        normal: addHexOpacity(atomic.green[60], opacity[43]),
+      },
     },
   },
   status: {


### PR DESCRIPTION
## Summary

- `background.status` 토큰 추가 — negative(red·8%), cautionary(orange·8%), positive(green·8%) (light/dark)
- `line.primary` 토큰 추가 — normal(blue·28%), strong(blue·43%) (light/dark)
- `line.status` 토큰 추가 — negative normal(43%)/strong(52%), cautionary normal(43%), positive normal(43%) (light/dark)

WRP-1524 표의 9개 토큰을 atomic 팔레트 참조(light: `[50]`, dark: `[60]`) + opacity 토큰으로 반영했습니다. minor 배포 대상입니다.

## Jira

[WRP-1524](https://wantedlab.atlassian.net/browse/WRP-1524) — [WDS] Semantic Token 업데이트

- Status: 열림
- Type: 하위 작업

> 추가할 컬러 토큰 반영 (*minor 배포에 포함) — Background/Status 3종, Line/Primary 2종, Line/Status 4종

## Test plan

- [x] 티켓 표의 hex·opacity ↔ atomic/opacity 토큰 매핑 전수 대조 (9/9 일치)
- [x] `wds-theme` 빌드 및 단위 테스트 통과
- [x] `wds` 패키지 빌드 통과 (토큰 타입 파생 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnaZfjjNXipt55u81gLuqL

[WRP-1524]: https://wantedlab.atlassian.net/browse/WRP-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 라이트/다크 테마의 상태 색상 토큰이 더 세분화되어, 경고/긍정/부정 상태 표현이 한층 일관되게 적용됩니다.
  * 주요 색상 토큰도 더 정교하게 나뉘어, 다양한 화면 상태에서 색상 대비와 표현력이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->