### PR TITLE
feat(core): form control message accessory 추가 및 스타일 수정

### DIFF
--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -208,7 +208,7 @@ Cautions:
 - Global identifier rename within gated files — unrelated identifiers named `FormControl`/
   `FormField` (object keys, `styles.FormControl`) get renamed too. Review the diff.
 - Namespace imports (`M.FormField`), re-exports, and subpath imports are skipped → manual.
-- New v4 API adoption (`FormControlPositiveMessage`, `FormControlCharacterCounter`,
+- New v4 API adoption (`FormControlPositiveMessage`, `FormControlMessageAccessory`,
   `size`/`labelPlacement`) must happen only AFTER this step, for the same double-swap reason.
 
 Post-step verification (expect zero hits):

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
@@ -191,8 +191,9 @@ ancestor. Two classes of usage need manual review:
   `FormControlNegativeMessage`) may fight the new default — review each occurrence.
   Scan: `FormControl(Message|NegativeMessage)\b[^>]*\b(variant|weight)=`.
 - New API available (informational, no action required): `FormControlPositiveMessage`,
-  `FormControlCharacterCounter`, root `size` (`'large' | 'medium'`) and
-  `labelPlacement` (`'top' | 'start'`) props.
+  `FormControlMessageAccessory` (passed via the message components' `accessory` prop;
+  `variant="character-counter"` by default), root `size` (`'large' | 'medium'`) and
+  `labelPlacement` (`'top' | 'leading'`) props.
 
 ## M6. Modal (bottom sheet) behavior change
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -280,12 +280,12 @@ npx @montage-ui/codemod@latest form-control-migration src
 #### 신규 컴포넌트
 
 - **`FormControlPositiveMessage`** — 성공 상태 메시지 (`semantic.label.alternative` 색상)
-- **`FormControlCharacterCounter`** — 글자 수 카운터. `length`(현재 글자 수)와 `maxLength`(최대 글자 수) props를 받으며, `FormControlMessage` / `FormControlNegativeMessage` / `FormControlPositiveMessage`의 `characterCounter` prop으로 전달합니다.
+- **`FormControlMessageAccessory`** — 메시지 우측에 붙는 액세서리. `variant="character-counter"`(기본값)이면 글자 수 카운터로 동작하며 `length`(현재 글자 수)와 `maxLength`(최대 글자 수) props를 받고, `variant="custom"`이면 children으로 임의 콘텐츠를 렌더링합니다. `FormControlMessage` / `FormControlNegativeMessage` / `FormControlPositiveMessage`의 `accessory` prop으로 전달합니다.
 
 ```tsx
 <FormControlMessage
-  characterCounter={
-    <FormControlCharacterCounter length={value.length} maxLength={100} />
+  accessory={
+    <FormControlMessageAccessory length={value.length} maxLength={100} />
   }
 >
   도움말

--- a/docs/data/components/selection-and-input/check-mark/web.mdx
+++ b/docs/data/components/selection-and-input/check-mark/web.mdx
@@ -98,7 +98,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, CheckMark } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/checkbox/web.mdx
+++ b/docs/data/components/selection-and-input/checkbox/web.mdx
@@ -98,7 +98,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, Checkbox } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/date-picker/web.mdx
+++ b/docs/data/components/selection-and-input/date-picker/web.mdx
@@ -259,7 +259,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, DatePicker } from '@montage-ui/core';

--- a/docs/data/components/selection-and-input/radio/web.mdx
+++ b/docs/data/components/selection-and-input/radio/web.mdx
@@ -123,7 +123,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, RadioGroup, RadioGroupItem } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/select/web.mdx
+++ b/docs/data/components/selection-and-input/select/web.mdx
@@ -468,7 +468,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, Select, Option, OptionGroup } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/switch/web.mdx
+++ b/docs/data/components/selection-and-input/switch/web.mdx
@@ -49,7 +49,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, Switch } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/text-area/web.mdx
+++ b/docs/data/components/selection-and-input/text-area/web.mdx
@@ -71,7 +71,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, TextArea } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/text-field/web.mdx
+++ b/docs/data/components/selection-and-input/text-field/web.mdx
@@ -54,7 +54,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, TextField } from '@montage-ui/core';
 

--- a/docs/data/components/selection-and-input/time-picker/web.mdx
+++ b/docs/data/components/selection-and-input/time-picker/web.mdx
@@ -258,7 +258,7 @@ Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
 - `FormControlMessage`
 - `FormControlNegativeMessage`
 - `FormControlPositiveMessage`
-- `FormControlCharacterCounter`
+- `FormControlMessageAccessory`
 
 
 <Demo code={`import { FlexBox, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, TimePicker } from '@montage-ui/core';

--- a/docs/data/utilities/web-utility-components/form.mdx
+++ b/docs/data/utilities/web-utility-components/form.mdx
@@ -326,9 +326,12 @@ const Demo = () => {
 export default Demo;`}/>
 
 
-## With character counter
+## With message accessory
 
-Message 종류 컴포넌트에 character counter를 추가할 수 있습니다.
+Message 종류 컴포넌트에 `FormControlMessageAccessory` 를 사용하여 accessory를 추가할 수 있습니다.
+
+- `character-counter` (default)
+- `custom`
 
 <Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlMessageAccessory } from '@montage-ui/core';
 import { useForm, Controller } from 'react-hook-form';

--- a/docs/data/utilities/web-utility-components/form.mdx
+++ b/docs/data/utilities/web-utility-components/form.mdx
@@ -34,10 +34,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl>
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.content)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.content)} />
             </FormControlField>
 
             {Boolean(formState.errors.content) ? (
@@ -109,10 +109,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl>
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
             </FormControlField>
 
             {Boolean(formState.errors.top) ? (
@@ -137,10 +137,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl labelPlacement="leading">
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
             </FormControlField>
 
             {Boolean(formState.errors.leading) ? (
@@ -195,10 +195,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl size="medium">
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
             </FormControlField>
 
             {Boolean(formState.errors.top) ? (
@@ -223,10 +223,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl labelPlacement="leading" size="medium">
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
             </FormControlField>
 
             {Boolean(formState.errors.leading) ? (
@@ -273,10 +273,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl size="large">
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
             </FormControlField>
 
             {Boolean(formState.errors.top) ? (
@@ -301,10 +301,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl labelPlacement="leading" size="large">
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
             </FormControlField>
 
             {Boolean(formState.errors.leading) ? (
@@ -357,10 +357,10 @@ const Demo = () => {
         }}
         render={({ field, formState }) => (
           <FormControl>
-            <FormControlLabel>라벨</FormControlLabel>
+            <FormControlLabel required>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.content)} />
+              <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.content)} />
             </FormControlField>
 
             {Boolean(formState.errors.content) ? (

--- a/docs/data/utilities/web-utility-components/form.mdx
+++ b/docs/data/utilities/web-utility-components/form.mdx
@@ -83,16 +83,16 @@ export default Demo;`}/>
 
 `labelPlacement` 를 조절하여 라벨의 위치를 조절할 수 있습니다.
 - top (default)
-- start
+- leading
 
-<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlCharacterCounter } from '@montage-ui/core';
+<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlMessageAccessory } from '@montage-ui/core';
 import { useForm, Controller } from 'react-hook-form';
 
 const Demo = () => {
   const form = useForm({
     defaultValues: {
       top: '',
-      start: ''
+      leading: ''
     }
   });
 
@@ -128,7 +128,7 @@ const Demo = () => {
 
       <Controller
         control={form.control}
-        name="start"
+        name="leading"
         rules={{
           required: {
             value: true,
@@ -136,16 +136,16 @@ const Demo = () => {
           }
         }}
         render={({ field, formState }) => (
-          <FormControl labelPlacement="start">
+          <FormControl labelPlacement="leading">
             <FormControlLabel>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.start)} />
+              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
             </FormControlField>
 
-            {Boolean(formState.errors.start) ? (
+            {Boolean(formState.errors.leading) ? (
               <FormControlNegativeMessage>
-                {formState.errors.start?.message}
+                {formState.errors.leading?.message}
               </FormControlNegativeMessage>
             ) : (
              <FormControlMessage>값을 입력해주세요.</FormControlMessage>
@@ -171,13 +171,14 @@ export default Demo;`}/>
 
 ### Medium
 
-<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlCharacterCounter } from '@montage-ui/core';
+<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlMessageAccessory } from '@montage-ui/core';
 import { useForm, Controller } from 'react-hook-form';
 
 const Demo = () => {
   const form = useForm({
     defaultValues: {
-      content: ''
+      top: '',
+      leading: ''
     }
   });
 
@@ -185,7 +186,7 @@ const Demo = () => {
     <FlexBox as="form" flexDirection="column" gap="12px" onSubmit={form.handleSubmit(v => alert(JSON.stringify(v)))}>
       <Controller
         control={form.control}
-        name="content"
+        name="top"
         rules={{
           required: {
             value: true,
@@ -197,12 +198,40 @@ const Demo = () => {
             <FormControlLabel>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.content)} />
+              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
             </FormControlField>
 
-            {Boolean(formState.errors.content) ? (
+            {Boolean(formState.errors.top) ? (
               <FormControlNegativeMessage>
-                {formState.errors.content?.message}
+                {formState.errors.top?.message}
+              </FormControlNegativeMessage>
+            ) : (
+             <FormControlMessage>값을 입력해주세요.</FormControlMessage>
+            )}
+          </FormControl>
+        )}
+      />
+
+      <Controller
+        control={form.control}
+        name="leading"
+        rules={{
+          required: {
+            value: true,
+            message: '필수 값입니다.'
+          }
+        }}
+        render={({ field, formState }) => (
+          <FormControl labelPlacement="leading" size="medium">
+            <FormControlLabel>라벨</FormControlLabel>
+
+            <FormControlField>
+              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
+            </FormControlField>
+
+            {Boolean(formState.errors.leading) ? (
+              <FormControlNegativeMessage>
+                {formState.errors.leading?.message}
               </FormControlNegativeMessage>
             ) : (
              <FormControlMessage>값을 입력해주세요.</FormControlMessage>
@@ -220,13 +249,14 @@ export default Demo;`}/>
 
 ### Large
 
-<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlCharacterCounter } from '@montage-ui/core';
+<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlMessageAccessory } from '@montage-ui/core';
 import { useForm, Controller } from 'react-hook-form';
 
 const Demo = () => {
   const form = useForm({
     defaultValues: {
-      content: ''
+      top: '',
+      leading: ''
     }
   });
 
@@ -234,7 +264,7 @@ const Demo = () => {
     <FlexBox as="form" flexDirection="column" gap="12px" onSubmit={form.handleSubmit(v => alert(JSON.stringify(v)))}>
       <Controller
         control={form.control}
-        name="content"
+        name="top"
         rules={{
           required: {
             value: true,
@@ -246,12 +276,40 @@ const Demo = () => {
             <FormControlLabel>라벨</FormControlLabel>
 
             <FormControlField>
-              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.content)} />
+              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.top)} />
             </FormControlField>
 
-            {Boolean(formState.errors.content) ? (
+            {Boolean(formState.errors.top) ? (
               <FormControlNegativeMessage>
-                {formState.errors.content?.message}
+                {formState.errors.top?.message}
+              </FormControlNegativeMessage>
+            ) : (
+             <FormControlMessage>값을 입력해주세요.</FormControlMessage>
+            )}
+          </FormControl>
+        )}
+      />
+
+      <Controller
+        control={form.control}
+        name="leading"
+        rules={{
+          required: {
+            value: true,
+            message: '필수 값입니다.'
+          }
+        }}
+        render={({ field, formState }) => (
+          <FormControl labelPlacement="leading" size="large">
+            <FormControlLabel>라벨</FormControlLabel>
+
+            <FormControlField>
+              <TextField {...field} width="300px" placeholder="값을 입력하세요." invalid={Boolean(formState.errors.leading)} />
+            </FormControlField>
+
+            {Boolean(formState.errors.leading) ? (
+              <FormControlNegativeMessage>
+                {formState.errors.leading?.message}
               </FormControlNegativeMessage>
             ) : (
              <FormControlMessage>값을 입력해주세요.</FormControlMessage>
@@ -272,7 +330,7 @@ export default Demo;`}/>
 
 Message 종류 컴포넌트에 character counter를 추가할 수 있습니다.
 
-<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlCharacterCounter } from '@montage-ui/core';
+<Demo code={`import { Button, FlexBox, TextField, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlMessageAccessory } from '@montage-ui/core';
 import { useForm, Controller } from 'react-hook-form';
 
 const Demo = () => {
@@ -306,11 +364,11 @@ const Demo = () => {
             </FormControlField>
 
             {Boolean(formState.errors.content) ? (
-              <FormControlNegativeMessage characterCounter={<FormControlCharacterCounter length={field.value.length} maxLength={20} />}>
+              <FormControlNegativeMessage accessory={<FormControlMessageAccessory length={field.value.length} maxLength={20} />}>
                 {formState.errors.content?.message}
               </FormControlNegativeMessage>
             ) : (
-             <FormControlMessage characterCounter={<FormControlCharacterCounter length={field.value.length} maxLength={20} />}>값을 입력해주세요.</FormControlMessage>
+             <FormControlMessage accessory={<FormControlMessageAccessory length={field.value.length} maxLength={20} />}>값을 입력해주세요.</FormControlMessage>
             )}
           </FormControl>
         )}
@@ -362,6 +420,6 @@ children으로 form 요소 컴포넌트를 넣어 사용합니다.
 
 <PropsTable component="FormControlPositiveMessage" />
 
-### FormControlCharacterCounter
+### FormControlMessageAccessory
 
-<PropsTable component="FormControlCharacterCounter" />
+<PropsTable component="FormControlMessageAccessory" />

--- a/packages/core/src/components/form-control/constants.ts
+++ b/packages/core/src/components/form-control/constants.ts
@@ -4,4 +4,5 @@ export const FORM_CONTROL_FIELD_NAME = 'FormControlField';
 export const FORM_CONTROL_MESSAGE_NAME = 'FormControlMessage';
 export const FORM_CONTROL_NEGATIVE_MESSAGE_NAME = 'FormControlNegativeMessage';
 export const FORM_CONTROL_POSITIVE_MESSAGE_NAME = 'FormControlPositiveMessage';
-export const FORM_CONTROL_CHARACTER_COUNTER = 'FormControlCharacterCounter';
+export const FORM_CONTROL_MESSAGE_ACCESSORY_NAME =
+  'FormControlMessageAccessory';

--- a/packages/core/src/components/form-control/index.tsx
+++ b/packages/core/src/components/form-control/index.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
 import { forwardRef, useId } from 'react';
+import { Box } from '@montage-ui/engine';
 
 import { FlexBox } from '../flex-box';
 import { Label } from '../label';
@@ -7,9 +8,9 @@ import { Typography } from '../typography';
 import { splitResponsiveBreakpoints } from '../../utils/internal/responsive-props';
 
 import {
-  FORM_CONTROL_CHARACTER_COUNTER,
   FORM_CONTROL_FIELD_NAME,
   FORM_CONTROL_LABEL_NAME,
+  FORM_CONTROL_MESSAGE_ACCESSORY_NAME,
   FORM_CONTROL_MESSAGE_NAME,
   FORM_CONTROL_NAME,
   FORM_CONTROL_NEGATIVE_MESSAGE_NAME,
@@ -35,9 +36,9 @@ import type {
 } from '@montage-ui/engine';
 import type { ElementType, ForwardedRef } from 'react';
 import type {
-  FormControlCharacterCounterProps,
   FormControlFieldProps,
   FormControlLabelProps,
+  FormControlMessageAccessoryProps,
   FormControlMessageProps,
   FormControlNegativeMessageProps,
   FormControlPositiveMessageProps,
@@ -171,7 +172,7 @@ const FormControlMessage = forwardRef(
     {
       as,
       children,
-      characterCounter,
+      accessory,
       ...props
     }: PolymorphicPropsInternal<FormControlMessageProps, T>,
     ref: ForwardedRef<T>,
@@ -196,7 +197,7 @@ const FormControlMessage = forwardRef(
       >
         <span data-role="form-control-message-content">{children}</span>
 
-        {characterCounter}
+        {accessory}
       </Typography>
     );
   },
@@ -209,7 +210,7 @@ const FormControlNegativeMessage = forwardRef(
     {
       as,
       children,
-      characterCounter,
+      accessory,
       ...props
     }: PolymorphicPropsInternal<FormControlNegativeMessageProps, T>,
     ref: ForwardedRef<T>,
@@ -238,7 +239,7 @@ const FormControlNegativeMessage = forwardRef(
           {children}
         </span>
 
-        {characterCounter}
+        {accessory}
       </Typography>
     );
   },
@@ -251,7 +252,7 @@ const FormControlPositiveMessage = forwardRef(
     {
       as,
       children,
-      characterCounter,
+      accessory,
       ...props
     }: PolymorphicPropsInternal<FormControlPositiveMessageProps, T>,
     ref: ForwardedRef<T>,
@@ -280,7 +281,7 @@ const FormControlPositiveMessage = forwardRef(
           {children}
         </span>
 
-        {characterCounter}
+        {accessory}
       </Typography>
     );
   },
@@ -288,31 +289,52 @@ const FormControlPositiveMessage = forwardRef(
 
 FormControlPositiveMessage.displayName = FORM_CONTROL_POSITIVE_MESSAGE_NAME;
 
-const FormControlCharacterCounter = forwardRef<
+const FormControlMessageAccessory = forwardRef<
   HTMLSpanElement,
-  DefaultComponentPropsInternal<FormControlCharacterCounterProps, 'span'>
->(({ length, maxLength, ...props }, ref) => {
-  return (
-    <Typography
-      data-component="form-control-character-counter"
-      variant="label2"
-      weight="medium"
-      ref={ref}
-      data-is-overflow={length > maxLength}
-      {...props}
-      color="semantic.label.alternative"
-      sx={[formCharacterCounterStyle, props.sx]}
-    >
-      <span data-role="form-control-character-counter-length">{length}</span>
-      <span data-role="form-control-character-counter-divider">/</span>
-      <span data-role="form-control-character-counter-max-length">
-        {maxLength}
-      </span>
-    </Typography>
-  );
-});
+  DefaultComponentPropsInternal<FormControlMessageAccessoryProps, 'span'>
+>(
+  (
+    { variant = 'character-counter', length = 0, maxLength = 0, ...props },
+    ref,
+  ) => {
+    switch (variant) {
+      case 'character-counter':
+        return (
+          <Typography
+            data-component="form-control-message-accessory"
+            variant="caption1"
+            weight="regular"
+            ref={ref}
+            data-is-overflow={length > maxLength}
+            {...props}
+            color="semantic.label.alternative"
+            sx={[formCharacterCounterStyle, props.sx]}
+          >
+            <span data-role="form-control-character-counter-length">
+              {length}
+            </span>
+            <span data-role="form-control-character-counter-divider">/</span>
+            <span data-role="form-control-character-counter-max-length">
+              {maxLength}
+            </span>
+          </Typography>
+        );
+      case 'custom':
+        return (
+          <Box
+            ref={ref}
+            as="span"
+            data-component="form-control-message-accessory"
+            {...props}
+          />
+        );
+      default:
+        return null;
+    }
+  },
+);
 
-FormControlCharacterCounter.displayName = FORM_CONTROL_CHARACTER_COUNTER;
+FormControlMessageAccessory.displayName = FORM_CONTROL_MESSAGE_ACCESSORY_NAME;
 
 export {
   FormControl,
@@ -321,7 +343,7 @@ export {
   FormControlMessage,
   FormControlNegativeMessage,
   FormControlPositiveMessage,
-  FormControlCharacterCounter,
+  FormControlMessageAccessory,
 };
 
 export type {
@@ -331,5 +353,5 @@ export type {
   FormControlMessageProps,
   FormControlNegativeMessageProps,
   FormControlPositiveMessageProps,
-  FormControlCharacterCounterProps,
+  FormControlMessageAccessoryProps,
 };

--- a/packages/core/src/components/form-control/style.ts
+++ b/packages/core/src/components/form-control/style.ts
@@ -97,7 +97,7 @@ const formControlLayoutStyle = (
       return css`
         display: grid;
         gap: ${gap === undefined
-          ? `${theme.spacing[8]} ${theme.spacing[20]}`
+          ? `${theme.spacing[8]} ${theme.spacing[16]}`
           : toCssValue(gap)};
 
         ${rowGap !== undefined &&

--- a/packages/core/src/components/form-control/style.ts
+++ b/packages/core/src/components/form-control/style.ts
@@ -93,7 +93,7 @@ const formControlLayoutStyle = (
           max-height: initial;
         }
       `;
-    case 'start':
+    case 'leading':
       return css`
         display: grid;
 
@@ -207,7 +207,7 @@ export const formMessageStyle = (theme: Theme) => css`
   padding: ${theme.spacing[0]} ${theme.spacing[2]};
   display: flex;
   flex-direction: row;
-  gap: 6px;
+  gap: ${theme.spacing[8]};
   justify-content: space-between;
 
   [data-role='form-control-positive-message-content'],

--- a/packages/core/src/components/form-control/style.ts
+++ b/packages/core/src/components/form-control/style.ts
@@ -77,7 +77,7 @@ const formControlLayoutStyle = (
     case 'top':
       return css`
         display: flex;
-        gap: ${gap === undefined ? '8px' : toCssValue(gap)};
+        gap: ${gap === undefined ? theme.spacing[8] : toCssValue(gap)};
 
         ${rowGap !== undefined &&
         css`
@@ -96,8 +96,9 @@ const formControlLayoutStyle = (
     case 'leading':
       return css`
         display: grid;
-
-        gap: ${gap === undefined ? '8px 20px' : toCssValue(gap)};
+        gap: ${gap === undefined
+          ? `${theme.spacing[8]} ${theme.spacing[20]}`
+          : toCssValue(gap)};
 
         ${rowGap !== undefined &&
         css`

--- a/packages/core/src/components/form-control/types.ts
+++ b/packages/core/src/components/form-control/types.ts
@@ -8,8 +8,8 @@ import type { TypographyProps } from '../typography/types';
 type FormControlDefaultProps = FlexBoxDefaultProps & {
   /** Size propagated to child input components. Defaults to `'large'` */
   size?: 'large' | 'medium';
-  /** Label placement direction. `'top'` stacks above, `'start'` aligns inline to the left */
-  labelPlacement?: 'top' | 'start';
+  /** Label placement direction. `'top'` stacks above, `'leading'` aligns inline to the left */
+  labelPlacement?: 'top' | 'leading';
 };
 
 export type FormControlProps = Merge<
@@ -20,24 +20,28 @@ export type FormControlLabelProps = LabelProps;
 export type FormControlMessageProps = Merge<
   TypographyProps,
   {
-    characterCounter?: ReactNode;
+    /** Accessory element to be rendered alongside the message */
+    accessory?: ReactNode;
   }
 >;
 export type FormControlPositiveMessageProps = Merge<
   TypographyProps,
   {
-    characterCounter?: ReactNode;
+    /** Accessory element to be rendered alongside the message */
+    accessory?: ReactNode;
   }
 >;
 export type FormControlNegativeMessageProps = Merge<
   TypographyProps,
   {
-    characterCounter?: ReactNode;
+    /** Accessory element to be rendered alongside the message */
+    accessory?: ReactNode;
   }
 >;
 export type FormControlFieldProps = SlotProps;
 
-export type FormControlCharacterCounterProps = WithSxProps<{
-  length: number;
-  maxLength: number;
+export type FormControlMessageAccessoryProps = WithSxProps<{
+  length?: number;
+  maxLength?: number;
+  variant?: 'character-counter' | 'custom';
 }>;

--- a/packages/core/src/components/label/index.tsx
+++ b/packages/core/src/components/label/index.tsx
@@ -25,8 +25,7 @@ const Label = forwardRef<
         <Box
           as="span"
           sx={(theme) => ({
-            display: 'inline-block',
-            marginLeft: '4px',
+            display: 'contents',
             font: 'inherit',
             fontWeight: '500',
             color: theme.semantic.status.negative,

--- a/packages/core/src/components/label/index.tsx
+++ b/packages/core/src/components/label/index.tsx
@@ -31,7 +31,7 @@ const Label = forwardRef<
             color: theme.semantic.status.negative,
           })}
         >
-          *
+          {' *'}
         </Box>
       )}
     </Typography>


### PR DESCRIPTION
## Summary

- `FormControlCharacterCounter`를 `FormControlMessageAccessory`로 개편
  - 메시지 컴포넌트(`FormControlMessage` / `FormControlNegativeMessage` / `FormControlPositiveMessage`)의 `characterCounter` prop을 `accessory` prop으로 변경
  - `variant="character-counter"`(기본값, 글자 수 카운터) / `variant="custom"`(임의 콘텐츠) 지원
- 옛 네이밍 잔재 정리: `FORM_CONTROL_CHARACTER_COUNTER` 상수 → `FORM_CONTROL_MESSAGE_ACCESSORY_NAME` (displayName 포함)
- `MIGRATION.md` 및 v3→v4 마이그레이션 스킬 문서(`codemod-steps.md`, `manual-migrations.md`)의 신규 API 안내 갱신
- docs 컴포넌트 페이지 10곳의 Form control 관련 컴포넌트 목록 및 데모 갱신

## Jira

[WRP-1584](https://wantedlab.atlassian.net/browse/WRP-1584) — [Web] FormControl accessory 추가 및 스타일 수정

- Status: 열림
- Type: 하위 작업

## Test plan

- [x] `packages/core` 타입 체크(`tsc --noEmit`) 통과
- [x] form-control 파일 eslint 통과
- [x] 저장소 전체에서 `FormControlCharacterCounter` / `characterCounter=` 잔재 0건 확인
- [ ] docs 사이트에서 FormControl 데모 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-1584]: https://wantedlab.atlassian.net/browse/WRP-1584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 폼 메시지 컴포넌트에 `accessory`를 지원해 내장 글자 수 카운터와 사용자 지정 보조 콘텐츠를 `FormControlMessageAccessory`로 유연하게 구성할 수 있습니다.
  * `labelPlacement` 옵션이 `leading` 중심으로 정리되어 레이블 레이아웃 선택이 확장/정돈되었습니다.
* **Documentation**
  * 마이그레이션 및 컴포넌트/데모 문서가 `FormControlMessageAccessory` 기반 예시로 업데이트되었습니다.
* **Style**
  * 폼 레이아웃 간격과 필수 별표 표시가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->