### PR TITLE
feat(core): form control group 추가 및 label 1줄 제한

### DIFF
--- a/docs/data/components/selection-and-input/check-mark/web.mdx
+++ b/docs/data/components/selection-and-input/check-mark/web.mdx
@@ -92,6 +92,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/checkbox/web.mdx
+++ b/docs/data/components/selection-and-input/checkbox/web.mdx
@@ -92,6 +92,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/date-picker/web.mdx
+++ b/docs/data/components/selection-and-input/date-picker/web.mdx
@@ -253,6 +253,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/radio/web.mdx
+++ b/docs/data/components/selection-and-input/radio/web.mdx
@@ -117,6 +117,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/select/web.mdx
+++ b/docs/data/components/selection-and-input/select/web.mdx
@@ -462,6 +462,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/switch/web.mdx
+++ b/docs/data/components/selection-and-input/switch/web.mdx
@@ -43,6 +43,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/text-area/web.mdx
+++ b/docs/data/components/selection-and-input/text-area/web.mdx
@@ -65,6 +65,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/text-field/web.mdx
+++ b/docs/data/components/selection-and-input/text-field/web.mdx
@@ -48,6 +48,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/components/selection-and-input/time-picker/web.mdx
+++ b/docs/data/components/selection-and-input/time-picker/web.mdx
@@ -252,6 +252,7 @@ export default Demo;`}
 ## Form control
 
 Form과 관련된 컴포넌트와 함께 사용할 수 있습니다.
+- `FormControlGroup`
 - `FormControl`
 - `FormControlField`
 - `FormControlLabel`

--- a/docs/data/utilities/web-utility-components/form.mdx
+++ b/docs/data/utilities/web-utility-components/form.mdx
@@ -161,7 +161,76 @@ const Demo = () => {
 
 export default Demo;`}/>
 
+## Group
 
+`FormControlGroup` 은 여러 개의 `FormControl` 을 나열해서 사용할 때 활용하는 컴포넌트입니다.
+
+주로 `labelPlacement="leading"` 을 사용할 때 유용합니다.
+
+`leading` 라벨은 기본적으로 라벨 텍스트 길이만큼 폭을 차지하기 때문에, 여러 `FormControl` 을 나열하면 라벨과 필드의 시작 위치가 제각각 달라집니다.
+이때 `FormControlGroup` 의 `labelWidth` 를 조정하면 하위 `FormControl` 들의 라벨 영역 폭을 통일성 있게 맞출 수 있습니다.
+
+
+> 각 `FormControl` 이 독립적인 grid이기 때문에 `max-content` 같은 콘텐츠 기반 값은 컨트롤마다 다르게 계산될 수 있습니다.
+> 라벨 폭을 통일하려면 `120px` 처럼 고정된 값을 사용하세요.
+
+<Demo code={`import { Button, TextField, FormControlGroup, FormControl, FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage } from '@montage-ui/core';
+import { useForm, Controller } from 'react-hook-form';
+
+const Demo = () => {
+  const form = useForm({
+    defaultValues: {
+      name: '',
+      email: '',
+      phone: ''
+    }
+  });
+
+  const fields = [
+    { name: 'name', label: '이름' },
+    { name: 'email', label: '이메일 주소' },
+    { name: 'phone', label: '휴대폰 번호' }
+  ];
+
+  return (
+    <FormControlGroup as="form" flexDirection="column" labelWidth="120px" onSubmit={form.handleSubmit(v => alert(JSON.stringify(v)))}>
+      {fields.map(({ name, label }) => (
+        <Controller
+          key={name}
+          control={form.control}
+          name={name}
+          rules={{
+            required: {
+              value: true,
+              message: '필수 값입니다.'
+            }
+          }}
+          render={({ field, formState }) => (
+            <FormControl labelPlacement="leading">
+              <FormControlLabel required>{label}</FormControlLabel>
+
+              <FormControlField>
+                <TextField {...field} width="25ch" placeholder="값을 입력하세요." invalid={Boolean(formState.errors[name])} />
+              </FormControlField>
+
+              {Boolean(formState.errors[name]) ? (
+                <FormControlNegativeMessage>
+                  {formState.errors[name]?.message}
+                </FormControlNegativeMessage>
+              ) : (
+               <FormControlMessage>값을 입력해주세요.</FormControlMessage>
+              )}
+            </FormControl>
+          )}
+        />
+      ))}
+
+      <Button type="submit">제출</Button>
+    </FormControlGroup>
+  )
+}
+
+export default Demo;`}/>
 
 ## Size
 
@@ -398,6 +467,10 @@ export default Demo;`}/>
 - aria-describedby, aria-labelledby를 통해 추가 메시지를 연결합니다.
 
 ## API
+
+### FormControlGroup
+
+<PropsTable component="FormControlGroup" />
 
 ### FormControl
 

--- a/packages/core/src/components/form-control/constants.ts
+++ b/packages/core/src/components/form-control/constants.ts
@@ -1,3 +1,4 @@
+export const FORM_CONTROL_GROUP_NAME = 'FormControlGroup';
 export const FORM_CONTROL_NAME = 'FormControl';
 export const FORM_CONTROL_LABEL_NAME = 'FormControlLabel';
 export const FORM_CONTROL_FIELD_NAME = 'FormControlField';

--- a/packages/core/src/components/form-control/index.tsx
+++ b/packages/core/src/components/form-control/index.tsx
@@ -97,7 +97,7 @@ const FormControlGroup = forwardRef(
       </FlexBox>
     );
   },
-);
+) as PolymorphicComponentInternal<FormControlGroupProps, 'div'>;
 
 FormControlGroup.displayName = FORM_CONTROL_GROUP_NAME;
 

--- a/packages/core/src/components/form-control/index.tsx
+++ b/packages/core/src/components/form-control/index.tsx
@@ -9,6 +9,7 @@ import { splitResponsiveBreakpoints } from '../../utils/internal/responsive-prop
 
 import {
   FORM_CONTROL_FIELD_NAME,
+  FORM_CONTROL_GROUP_NAME,
   FORM_CONTROL_LABEL_NAME,
   FORM_CONTROL_MESSAGE_ACCESSORY_NAME,
   FORM_CONTROL_MESSAGE_NAME,
@@ -24,6 +25,7 @@ import {
 import { useFormControl } from './hooks';
 import {
   formCharacterCounterStyle,
+  formControlGroupStyle,
   formControlStyle,
   formLabelStyle,
   formMessageStyle,
@@ -37,6 +39,7 @@ import type {
 import type { ElementType, ForwardedRef } from 'react';
 import type {
   FormControlFieldProps,
+  FormControlGroupProps,
   FormControlLabelProps,
   FormControlMessageAccessoryProps,
   FormControlMessageProps,
@@ -44,6 +47,59 @@ import type {
   FormControlPositiveMessageProps,
   FormControlProps,
 } from './types';
+
+const FormControlGroup = forwardRef(
+  <T extends ElementType = 'div'>(
+    {
+      as,
+      labelWidth,
+      gap,
+      rowGap,
+      columnGap,
+      children,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      ...props
+    }: PolymorphicPropsInternal<FormControlGroupProps, T>,
+    ref: ForwardedRef<T>,
+  ) => {
+    const { picked: responsiveSize, rest: responsiveRest } =
+      splitResponsiveBreakpoints({ xs, sm, md, lg, xl }, [
+        'labelWidth',
+        'gap',
+        'rowGap',
+        'columnGap',
+        'sx',
+      ]);
+
+    return (
+      <FlexBox
+        ref={ref}
+        as={as}
+        data-component="form-control-group"
+        {...responsiveRest}
+        {...props}
+        sx={[
+          formControlGroupStyle({
+            labelWidth,
+            gap,
+            rowGap,
+            columnGap,
+            ...responsiveSize,
+          }),
+          props.sx,
+        ]}
+      >
+        {children}
+      </FlexBox>
+    );
+  },
+);
+
+FormControlGroup.displayName = FORM_CONTROL_GROUP_NAME;
 
 const FormControl = forwardRef(
   <T extends ElementType = 'div'>(
@@ -88,6 +144,7 @@ const FormControl = forwardRef(
             {...props}
             sx={[
               formControlStyle({
+                size,
                 gap,
                 rowGap,
                 columnGap,
@@ -337,6 +394,7 @@ const FormControlMessageAccessory = forwardRef<
 FormControlMessageAccessory.displayName = FORM_CONTROL_MESSAGE_ACCESSORY_NAME;
 
 export {
+  FormControlGroup,
   FormControl,
   FormControlField,
   FormControlLabel,
@@ -347,6 +405,7 @@ export {
 };
 
 export type {
+  FormControlGroupProps,
   FormControlProps,
   FormControlFieldProps,
   FormControlLabelProps,

--- a/packages/core/src/components/form-control/style.ts
+++ b/packages/core/src/components/form-control/style.ts
@@ -4,15 +4,75 @@ import {
   createResponsiveStyle,
   getPreviousValue,
 } from '../../utils/internal/responsive-props';
-import { typographyStyle } from '../../utils';
+import { ellipsisTypographyStyle, typographyStyle } from '../../utils';
 import { toCssValue } from '../../utils/internal/css';
 
-import type { FormControlLabelProps, FormControlProps } from './types';
+import type {
+  FormControlGroupProps,
+  FormControlLabelProps,
+  FormControlProps,
+} from './types';
 import type { FormControlLayoutContextType } from './contexts';
 import type { Theme } from '@montage-ui/engine';
 
+export const formControlGroupStyle =
+  ({
+    labelWidth,
+    gap,
+    rowGap,
+    columnGap,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+  }: FormControlGroupProps) =>
+  (theme: Theme) => css`
+    gap: ${gap === undefined ? theme.spacing[16] : toCssValue(gap)};
+
+    ${rowGap !== undefined &&
+    css`
+      row-gap: ${toCssValue(rowGap)};
+    `}
+    ${columnGap !== undefined &&
+    css`
+      column-gap: ${toCssValue(columnGap)};
+    `}
+    ${labelWidth !== undefined &&
+    css`
+      --form-control-leading-label-width: ${labelWidth};
+    `}
+
+    ${createResponsiveStyle(
+      { xs, sm, md, lg, xl },
+      theme,
+    )(
+      (params) => css`
+        ${params?.gap !== undefined &&
+        css`
+          gap: ${toCssValue(params.gap)};
+        `};
+        ${params?.rowGap !== undefined &&
+        css`
+          row-gap: ${toCssValue(params.rowGap)};
+        `}
+        ${params?.columnGap !== undefined &&
+        css`
+          column-gap: ${toCssValue(params.columnGap)};
+        `}
+        ${params?.labelWidth !== undefined &&
+        css`
+          --form-control-leading-label-width: ${params.labelWidth};
+        `}
+
+        ${params?.sx}
+      `,
+    )}
+  `;
+
 export const formControlStyle =
   ({
+    size,
     gap,
     rowGap,
     columnGap,
@@ -26,11 +86,15 @@ export const formControlStyle =
   (theme: Theme) => css`
     ${formControlLayoutStyle({ labelPlacement, gap, rowGap, columnGap }, theme)}
 
+    ${formControlSizeStyle({ size }, theme)}
+
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
       theme,
     )(
       (params, breakpoint) => css`
+        ${formControlSizeStyle({ size: params?.size }, theme)}
+
         ${formControlLayoutStyle(
           {
             labelPlacement: getPreviousValue(
@@ -60,9 +124,27 @@ export const formControlStyle =
           },
           theme,
         )}
+
+        ${params?.sx}
       `,
     )}
   `;
+
+const formControlSizeStyle = (
+  { size }: Pick<FormControlProps, 'size'>,
+  theme: Theme,
+) => {
+  switch (size) {
+    case 'medium':
+      return css`
+        --form-control-leading-label-max-height: ${theme.dimension[40]};
+      `;
+    case 'large':
+      return css`
+        --form-control-leading-label-max-height: ${theme.dimension[48]};
+      `;
+  }
+};
 
 const formControlLayoutStyle = (
   {
@@ -77,6 +159,7 @@ const formControlLayoutStyle = (
     case 'top':
       return css`
         display: flex;
+        grid-template-columns: initial;
         gap: ${gap === undefined ? theme.spacing[8] : toCssValue(gap)};
 
         ${rowGap !== undefined &&
@@ -96,6 +179,9 @@ const formControlLayoutStyle = (
     case 'leading':
       return css`
         display: grid;
+        grid-template-columns:
+          var(--form-control-leading-label-width, minmax(10px, auto))
+          1fr;
         gap: ${gap === undefined
           ? `${theme.spacing[8]} ${theme.spacing[16]}`
           : toCssValue(gap)};
@@ -121,7 +207,7 @@ const formControlLayoutStyle = (
           padding: ${theme.spacing[0]};
           display: flex;
           align-items: center;
-          max-height: ${theme.dimension[48]};
+          max-height: var(--form-control-leading-label-max-height);
         }
       `;
   }
@@ -143,6 +229,20 @@ export const formLabelStyle =
   (theme: Theme) => css`
     padding: ${theme.spacing[0]} ${theme.spacing[2]};
     ${formLabelSizeStyle({ size, variant, weight })}
+
+    & > [data-role='label-content'] {
+      display: inline-flex;
+      max-width: 100%;
+      min-width: 0;
+
+      [data-role='label-content-text'] {
+        ${ellipsisTypographyStyle(1)}
+      }
+
+      [data-role='label-required-mark'] {
+        flex-shrink: 0;
+      }
+    }
 
     ${createResponsiveStyle(
       {

--- a/packages/core/src/components/form-control/types.ts
+++ b/packages/core/src/components/form-control/types.ts
@@ -1,42 +1,74 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import type { Merge, ResponsiveProps, WithSxProps } from '@montage-ui/engine';
 import type { FlexBoxDefaultProps } from '../flex-box/types';
 import type { LabelProps } from '../label';
 import type { SlotProps } from '@radix-ui/react-slot';
 import type { TypographyProps } from '../typography/types';
 
-type FormControlDefaultProps = FlexBoxDefaultProps & {
-  /** Size propagated to child input components. Defaults to `'large'` */
-  size?: 'large' | 'medium';
-  /** Label placement direction. `'top'` stacks above, `'leading'` aligns inline to the left */
-  labelPlacement?: 'top' | 'leading';
-};
+type FlexBoxResponsiveProps = Omit<FlexBoxDefaultProps, 'children' | 'sx'>;
+
+export type FormControlGroupDefaultProps = Merge<
+  {
+    /** Label column width applied to `grid-template-columns` of descendant `labelPlacement="leading"` FormControls */
+    labelWidth?: CSSProperties['gridTemplateColumns'];
+  },
+  FlexBoxDefaultProps
+>;
+
+export type FormControlGroupResponsiveProps = ResponsiveProps<
+  Merge<
+    Pick<FormControlGroupDefaultProps, 'labelWidth'>,
+    FlexBoxResponsiveProps
+  >
+>;
+
+export type FormControlGroupProps = Merge<
+  FormControlGroupDefaultProps,
+  FormControlGroupResponsiveProps
+>;
+
+export type FormControlDefaultProps = Merge<
+  {
+    /** Size propagated to child input components. Defaults to `'large'` */
+    size?: 'large' | 'medium';
+    /** Label placement direction. `'top'` stacks above, `'leading'` aligns inline to the left */
+    labelPlacement?: 'top' | 'leading';
+  },
+  FlexBoxDefaultProps
+>;
+
+export type FormControlResponsiveProps = ResponsiveProps<
+  Merge<
+    Pick<FormControlDefaultProps, 'size' | 'labelPlacement'>,
+    FlexBoxResponsiveProps
+  >
+>;
 
 export type FormControlProps = Merge<
   FormControlDefaultProps,
-  ResponsiveProps<Omit<FormControlDefaultProps, 'children'>>
+  FormControlResponsiveProps
 >;
 export type FormControlLabelProps = LabelProps;
 export type FormControlMessageProps = Merge<
-  TypographyProps,
   {
     /** Accessory element to be rendered alongside the message */
     accessory?: ReactNode;
-  }
+  },
+  TypographyProps
 >;
 export type FormControlPositiveMessageProps = Merge<
-  TypographyProps,
   {
     /** Accessory element to be rendered alongside the message */
     accessory?: ReactNode;
-  }
+  },
+  TypographyProps
 >;
 export type FormControlNegativeMessageProps = Merge<
-  TypographyProps,
   {
     /** Accessory element to be rendered alongside the message */
     accessory?: ReactNode;
-  }
+  },
+  TypographyProps
 >;
 export type FormControlFieldProps = SlotProps;
 

--- a/packages/core/src/components/label/index.tsx
+++ b/packages/core/src/components/label/index.tsx
@@ -20,20 +20,24 @@ const Label = forwardRef<
       display={display}
       {...props}
     >
-      {children}
-      {required && (
-        <Box
-          as="span"
-          sx={(theme) => ({
-            display: 'contents',
-            font: 'inherit',
-            fontWeight: '500',
-            color: theme.semantic.status.negative,
-          })}
-        >
-          {' *'}
-        </Box>
-      )}
+      <span data-role="label-content">
+        <span data-role="label-content-text">{children}</span>
+
+        {required && (
+          <Box
+            as="span"
+            data-role="label-required-mark"
+            sx={(theme) => ({
+              font: 'inherit',
+              fontWeight: '500',
+              whiteSpace: 'pre',
+              color: theme.semantic.status.negative,
+            })}
+          >
+            {' *'}
+          </Box>
+        )}
+      </span>
     </Typography>
   );
 });

--- a/packages/core/src/utils/internal/responsive-props.ts
+++ b/packages/core/src/utils/internal/responsive-props.ts
@@ -5,10 +5,18 @@ import { respondMore } from '../media';
 
 import type {
   BreakPoint,
+  CSSInterpolation,
+  Merge,
   ResponsiveProps,
   SerializedStyles,
   Theme,
 } from '@montage-ui/engine';
+
+/**
+ * The actual shape of a single breakpoint value inside `ResponsiveProps<T>` —
+ * `ResponsiveProps` merges `sx` into every breakpoint on top of `T`.
+ */
+type ResponsiveBreakpointValue<T> = Merge<T, { sx?: CSSInterpolation }>;
 
 const order: Array<keyof BreakPoint> = ['xs', 'sm', 'md', 'lg', 'xl'];
 
@@ -170,20 +178,20 @@ const splitResponsiveProps = <
  */
 export const splitResponsiveBreakpoints = <
   T extends Record<string, unknown>,
-  K extends keyof T,
+  K extends keyof ResponsiveBreakpointValue<T>,
 >(
   responsive: ResponsiveProps<T>,
   keys: Array<K>,
 ): {
-  picked: ResponsiveProps<Pick<T, K>> | undefined;
-  rest: ResponsiveProps<Omit<T, K>> | undefined;
+  picked: ResponsiveProps<Pick<ResponsiveBreakpointValue<T>, K>> | undefined;
+  rest: ResponsiveProps<Omit<ResponsiveBreakpointValue<T>, K>> | undefined;
 } => {
-  let picked: Record<string, Pick<T, K>> | undefined;
-  let rest: Record<string, Omit<T, K>> | undefined;
+  let picked: Record<string, Pick<ResponsiveBreakpointValue<T>, K>> | undefined;
+  let rest: Record<string, Omit<ResponsiveBreakpointValue<T>, K>> | undefined;
 
   for (const breakpoint of order) {
     const split = splitResponsiveProps(
-      responsive[breakpoint] as T | undefined,
+      responsive[breakpoint] as ResponsiveBreakpointValue<T> | undefined,
       keys,
     );
 


### PR DESCRIPTION
## Summary

- `FormControlGroup` 컴포넌트 추가 — 여러 `FormControl`을 나열할 때 `labelWidth`로 `labelPlacement="leading"` 라벨 영역 폭을 통일 (CSS 변수 `--form-control-leading-label-width` 기반, 반응형 지원)
- `FormControlLabel` 텍스트를 최대 1줄(ellipsis)로 제한하고, required mark(`*`)는 줄바꿈되지 않도록 분리
- `size="medium"`일 때 leading 라벨 max-height를 40px로 조정 (`large`는 기존 48px 유지, CSS 변수 `--form-control-leading-label-max-height`로 전환)
- `splitResponsiveBreakpoints`가 브레이크포인트별 `sx`를 처리할 수 있도록 타입 정리, `FormControl`/`FormControlGroup` 반응형 스타일에 `sx` 반영
- 문서: form 유틸리티 페이지에 `Group` 섹션 및 데모 추가, selection-and-input 컴포넌트 문서에 `FormControlGroup` 항목 추가

## Jira

[WRP-1631](https://wantedlab.atlassian.net/browse/WRP-1631) — [Web] FormControlGroup 추가 및 라벨 1줄 제한

- Status: 열림
- Type: 하위 작업

## Test plan

- [ ] `FormControlGroup` + `labelPlacement="leading"` 조합에서 `labelWidth` 지정 시 하위 FormControl 라벨 폭이 통일되는지 확인
- [ ] `labelWidth` 미지정 시 기존 leading 레이아웃(`minmax(10px, auto) 1fr`)이 유지되는지 확인
- [ ] 긴 라벨 텍스트가 1줄 ellipsis 처리되고 required mark가 항상 표시되는지 확인
- [ ] `size="medium"` / `size="large"` 각각에서 leading 라벨 max-height(40px/48px) 확인
- [ ] 반응형 브레이크포인트별 `labelWidth`, `size`, `sx` 오버라이드 동작 확인
- [ ] visual regression 테스트 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-1631]: https://wantedlab.atlassian.net/browse/WRP-1631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 여러 폼 컨트롤을 그룹으로 묶어 배치하고, 선행 라벨의 너비·간격을 일관되게 조정할 수 있는 `FormControlGroup`을 추가했습니다.
  - 화면 크기별 반응형 폼 레이아웃 구성이 지원됩니다.

- **개선 사항**
  - 선행 라벨 배치의 너비/최대 높이 계산과 레이아웃이 개선되었고, 긴 라벨의 줄임 표시가 더 안정적으로 동작합니다.
  - 필수 표시와 라벨 콘텐츠의 정렬 및 줄바꿈/잘림 처리가 개선되었습니다.

- **문서**
  - `FormControlGroup` 사용 예시와 API 정보를 추가하고, 관련 폼 컨트롤 문서 목록을 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->