### PR TITLE
feat(core,eslint-plugin)!: segmented control variant 제거 및 icon only 모드 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "montage-web-migration",
       "source": "./.claude-plugin/montage-migration",
-      "description": "Migration tool for Wanted Lab Design System for Web"
+      "description": "Migrates consumer projects between major versions of Montage (Wanted Design System for Web)"
     }
   ]
 }

--- a/.claude-plugin/montage-migration/.claude-plugin/plugin.json
+++ b/.claude-plugin/montage-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "montage-web-migration",
   "version": "1.0.0",
-  "description": "Wanted Design System Migration Plugin",
+  "description": "Migrates consumer projects between major versions of Montage (Wanted Design System for Web)",
   "author": {
     "name": "Sh031224"
   },

--- a/.claude-plugin/montage-migration/README.ko.md
+++ b/.claude-plugin/montage-migration/README.ko.md
@@ -28,7 +28,8 @@ Montage(Wanted Design System for Web) 메이저 버전 간 마이그레이션을
 
 동작 방식:
 
-1. **사전 점검** — 버전 확인, git 클린 상태 확인, 대상 디렉토리 선택, 마이그레이션 상태 파일 생성.
+1. **사전 점검** — 마이그레이션 상태 파일을 가장 먼저 확인하고(재개를 신규 실행으로 오인하지
+   않도록), 이어서 버전 확인, git 클린 상태 확인, 대상 디렉토리 선택.
 2. **Codemod 단계** — 6개 v4 codemod를 **엄격한 순서로, 각각 정확히 한 번씩** 실행
    (`package-name-migration` → `semantic-token-migration` → `css-variable-migration` →
    `dom-identifier-migration` → `list-card-migration` → `form-control-migration`).
@@ -36,8 +37,8 @@ Montage(Wanted Design System for Web) 메이저 버전 간 마이그레이션을
    커밋), 이후 수동 마이그레이션 대상 스캔은 병렬로 수행됩니다.
 3. **수동 마이그레이션** — theme 토큰 `var(--...)` 산술 코드, package.json/설정 파일의
    패키지명 변경, semantic 토큰 후속 작업(foreground/surface 재분류, 삭제된 accent 토큰),
-   DOM 식별자 잔여물, Card/ListCard·FormControl 후속 작업, Modal/TextField/TextArea 동작
-   변경 대응.
+   DOM 식별자 잔여물, Card/ListCard·FormControl 후속 작업,
+   Modal/TextField/TextArea/SegmentedControl 동작 변경 대응, ThemeProvider 쿠키 저장소 전환.
 4. **최종 검증** — 잔여 패턴 grep, install/typecheck/lint/build/tests, 결과 요약.
 
 codemod는 순서에 민감하고 두 번 실행하면 안 됩니다(`form-control-migration` 재실행 시

--- a/.claude-plugin/montage-migration/README.md
+++ b/.claude-plugin/montage-migration/README.md
@@ -29,7 +29,8 @@ Trigger it by asking, for example:
 
 What it does:
 
-1. **Preflight** — version check, clean git tree, target selection, migration state file.
+1. **Preflight** — migration state file first (a resume must not be misread as a fresh
+   project), then version check, clean git tree, and target selection.
 2. **Codemod phase** — runs the 6 v4 codemods **strictly in sequence, each exactly once**
    (`package-name-migration` → `semantic-token-migration` → `css-variable-migration` →
    `dom-identifier-migration` → `list-card-migration` → `form-control-migration`),
@@ -39,7 +40,8 @@ What it does:
 3. **Manual migrations** — theme token `var(--...)` arithmetic, package.json/config
    renames, semantic token follow-ups (foreground/surface reclassification, deleted
    accent tokens), DOM identifier leftovers, Card/ListCard and FormControl follow-ups,
-   Modal/TextField/TextArea behavioral changes.
+   Modal/TextField/TextArea/SegmentedControl behavioral changes, ThemeProvider cookie
+   storage.
 4. **Verification** — leftover greps, install/typecheck/lint/build/tests, summary.
 
 The codemods are order-sensitive and must not run twice (re-running

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: montage-v3-to-v4
-description: This skill should be used when the user asks to migrate a project from Montage (WDS) v3 to v4, upgrade @wanteddev/wds to @montage-ui/* 4.x, run any Montage v4 codemod (package-name-migration, semantic-token-migration, css-variable-migration, dom-identifier-migration, list-card-migration, form-control-migration), or resume an in-progress v4 migration. Triggers include "montage v4 마이그레이션", "montage 4 적용해줘", "몬타지 v4로 올려줘", "wds 4.0으로 업그레이드", "디자인시스템 v4로 올려줘", "@montage-ui로 전환해줘", "마이그레이션 이어서 해줘", "form-control 코드모드만 돌려줘", "semantic 토큰 코드모드 돌려줘", "시멘틱 토큰 마이그레이션 해줘", "migrate to montage v4", "resume the montage migration", "run the form-control codemod", "run the semantic token codemod". Covers v3→v4 only (earlier migrations live in the wanteddev/montage-web repo's MIGRATION.md). Orchestrates the 6 codemods strictly in sequence with run-once protection, then guides the manual migrations.
+description: This skill should be used when the user asks to migrate a project from Montage (WDS) v3 to v4, upgrade @wanteddev/wds to @montage-ui/* 4.x, run any Montage v4 codemod (package-name-migration, semantic-token-migration, css-variable-migration, dom-identifier-migration, list-card-migration, form-control-migration), or resume an in-progress v4 migration. Triggers include "montage v4 마이그레이션", "montage 4 적용해줘", "몬타지 v4로 올려줘", "wds 4.0으로 업그레이드", "디자인시스템 v4로 올려줘", "@montage-ui로 전환해줘", "마이그레이션 이어서 해줘", "form-control 코드모드만 돌려줘", "semantic 토큰 코드모드 돌려줘", "시멘틱 토큰 마이그레이션 해줘", "패키지명 마이그레이션만 해줘", "css 변수 코드모드 돌려줘", "dom 식별자 코드모드만 돌려줘", "list-card 코드모드만 돌려줘", "migrate to montage v4", "resume the montage migration", "run the form-control codemod", "run the semantic token codemod". Covers v3→v4 only (earlier migrations live in the wanteddev/montage-web repo's MIGRATION.md). Orchestrates the 6 codemods strictly in sequence with run-once protection, then guides the manual migrations.
 ---
 
 # montage-v3-to-v4
@@ -26,34 +26,28 @@ by verification.
    hand-migrated files even on its first run.
 4. **Start from a clean git tree** and keep one commit per step so any step can be
    reverted in isolation.
-5. Run codemods through the CLI (`npx -y @montage-ui/codemod@<codemodVersion> <transform>
-<path>`; resolve the version at preflight, and on resume use the state file's recorded
+5. **The tree does not install / typecheck / build between step ① and M1.** Step ① rewrites
+   every import to `@montage-ui/*` while `package.json` still lists `@wanteddev/wds*` (M1
+   owns package.json and ends with the install). The six codemod commits are intentionally
+   non-building — do NOT try to fix resolution errors during the codemod phase, and expect
+   pre-commit hooks (`.husky/`, `core.hooksPath`, `lint-staged`) to fail: detect them at
+   preflight and agree with the user on `--no-verify` or disabling them for the phase.
+6. Run codemods through the CLI (`npx -y @montage-ui/codemod@<codemodVersion> <transform> <path>`;
+   resolve the version at preflight, and on resume use the state file's recorded
    `codemodVersion`), never raw jscodeshift — steps ②–④ rewrite stylesheets only via
    the CLI.
 
 ## Step 0 — Preflight
 
-Perform all checks before changing anything:
+Perform all checks before changing anything. **Read the state file (item 1) BEFORE the
+version check (item 2)** — the version check's branches describe a first run, and after M1
+rewrites `package.json` a resume looks exactly like "already migrated".
 
-1. **Version check.** Read the project's `package.json`:
-   - `@wanteddev/wds*` at 3.x → proceed.
-   - `@wanteddev/wds*` at 2.x or lower → stop; complete the v2→v3 migration first
-     (MIGRATION.md in the wanteddev/montage-web repo).
-   - Only `@montage-ui/*` 4.x present and no state file → likely already migrated; run
-     the leftover greps from `references/codemod-steps.md` plus every M-section scan
-     pattern from `references/manual-migrations.md` (steps and M-sections added after a
-     consumer finished migrating — e.g. step ② `semantic-token-migration`, M9, and M10 —
-     surface only through these scans) and report instead of migrating.
-   - BOTH `@wanteddev/wds*` and `@montage-ui/*` present → the project is partially
-     hand-migrated. Run the step ⑤/⑥ pre-checks from `references/codemod-steps.md` before
-     anything else and expect file exclusions in step ⑥.
-   - NEITHER package present → check nested/workspace `package.json` files; if still
-     absent, stop and tell the user this repo does not appear to use Montage/WDS.
-2. **State file.** Look for `.claude/montage-migration-v4.local.md` (format below). If it
+1. **State file.** Look for `.claude/montage-migration-v4.local.md` (format below). If it
    exists, this is a resume; apply these rules:
    - **Resume.** Skip every step marked `completed`, continue from the first `pending`
      step. A step or manual key missing from an older state file (e.g.
-     `semantic-token-migration`, `M9`, or `M10`, added after the file was created) is
+     `semantic-token-migration`, `M9`, `M10`, or `M11`, added after the file was created) is
      `pending` —
      add it to the file and run it. `semantic-token-migration` sits at position ② BEFORE
      steps an older migration may already have completed: it still runs, and running it
@@ -66,8 +60,19 @@ Perform all checks before changing anything:
      IN BOTH DIRECTIONS: a step marked `completed` but its renames absent from the tree
      (reverted commits), or a step marked `pending` whose renames are already present
      (hand-run between sessions — re-running step ⑥ over such a tree is the corruption
-     path). Spot-check `completed` MANUAL marks the same way: a fresh hit from a
-     completed M-section's scan patterns is equally a mismatch. On any mismatch, stop and
+     path). Spot-check `completed` MANUAL marks the same way, but using ONLY that section's
+     **[zero]** scan patterns, and only for hits that are Montage-related: a fresh
+     Montage-related [zero] hit is equally a mismatch, while an unrelated-consumer-code hit
+     is what the [zero] tag explicitly permits to remain (M4's `card-content`, M10's
+     `storageKey` …) — re-assess such a hit, do not treat it as evidence. [decision]
+     patterns match valid v4 code and keep hitting after the section is correctly done (every M2
+     pattern, M6's `variant="bottom"`, M9's `surface.brand.primary`, M10's
+     `<ThemeProvider` / `next-themes`, M11's `\bSegmentedControl(Item)?\b` …), so they are
+     never mismatch evidence. Detect the pending-but-already-applied direction with the
+     **presence greps** in `references/codemod-steps.md` — each step's verify grep is an
+     ABSENCE check that returns zero both when the codemod ran and when the repo never used
+     that API, so it cannot see this direction at all; new names present + old absent means
+     the step already ran. On any mismatch, stop and
      reconcile with the user; never re-run a marked step automatically. For the
      pending-but-applied direction: once the user confirms the codemod was hand-run, run
      that step's verification grep from `references/codemod-steps.md`, fix leftovers per
@@ -85,9 +90,55 @@ Perform all checks before changing anything:
      silently widen the `targets` arg.
    - **Version pin.** Read the recorded `codemodVersion` and pass it as the Workflow
      `codemodVersion` arg — the pin survives sessions only through this field. On a FIRST
-     run, resolve a CONCRETE version before writing the state file
-     (`npm view @montage-ui/codemod version`) — recording the literal dist-tag `latest`
-     would re-resolve on resume and silently break the same-build guarantee.
+     run, resolve a CONCRETE version before writing the state file with
+     `npm view '@montage-ui/codemod@^4' version --json | jq -r 'if type=="array" then .[-1] else . end'`.
+     The two shorter forms are both wrong: the plain `npm view @montage-ui/codemod version`
+     returns whatever `latest` points at (5.x once that ships, and this skill covers the 4.x
+     transforms only — the script rejects any other major), and the range form without
+     `--json` prints one line PER matching 4.x version. Recording the literal dist-tag
+     `latest` would re-resolve on resume and silently break the same-build guarantee.
+     **If resolution fails** (offline, proxy, or an `.npmrc` scoping `@montage-ui` to a
+     registry this session cannot reach): STOP and report the registry/auth blocker. Never
+     guess a plausible version and never fall back to `latest` — a wrong pin silently runs
+     the wrong transform build for the whole migration. Confirm reachability with
+     `npx -y @montage-ui/codemod@<resolved> --help` before step ①.
+   - **Excluded files.** Read the recorded `excludeFiles` list (empty by default). Pass it
+     back as the Workflow `excludeFiles` arg, and use it when judging step ⑥ hits at final
+     verification — without it, a later session cannot tell a ring-fenced hand-migrated file
+     from a genuine migration leftover and will "fix" code the user protected.
+2. **Version check.** Read the project's `package.json`. **If a state file exists, item 1's
+   resume rules govern** — use the version check only to confirm the recorded phase (pre-M1
+   expects `@wanteddev/wds*` 3.x, post-M1 expects `@montage-ui/*` 4.x) and report a
+   disagreement to the user; never reclassify a resume through the branches below. With NO
+   state file:
+   - `@wanteddev/wds*` at 3.x → proceed.
+   - `@wanteddev/wds*` at 2.x or lower → stop; complete the v2→v3 migration first
+     (MIGRATION.md in the wanteddev/montage-web repo).
+   - Only `@montage-ui/*` 4.x present → likely already migrated; run
+     the leftover greps from `references/codemod-steps.md` plus every M-section scan
+     pattern from `references/manual-migrations.md` (steps and M-sections added after a
+     consumer finished migrating — e.g. step ② `semantic-token-migration`, M9, M10, and
+     M11 — surface only through these scans) and report instead of migrating.
+   - BOTH `@wanteddev/wds*` and `@montage-ui/*` present → the project is partially
+     hand-migrated. Run the step ⑤/⑥ pre-checks from `references/codemod-steps.md` before
+     anything else and expect file exclusions in step ⑥.
+   - NEITHER package present → check nested/workspace `package.json` files; if still
+     absent, stop and tell the user this repo does not appear to use Montage/WDS.
+
+   Also check for commit hooks that would block the intentionally non-building codemod
+   commits (`.husky/`, `git config core.hooksPath`, `lint-staged` in package.json) and agree
+   with the user up front on how to handle them; and scan `.ts` files for legacy
+   angle-bracket casts, which the `tsx` parser cannot read (the file is skipped with a
+   transformation error while the rest of the run succeeds — a silent partial migration):
+   `grep -rnE '(=|\(|,|return) *<[A-Za-z_$][A-Za-z0-9_$.]*(\[\])?> *[A-Za-z_$(]' --include="*.ts" <targets>`
+   — convert the hits to `as` syntax in a preparatory commit before step ①.
+
+   Also read the project's `react` / `react-dom` versions: v4 peer-requires
+   `^18.0.0 || ^19.0.0` (same for `@types/react*` when TypeScript is used). On React 17 or
+   lower, STOP and report that the React upgrade must land first — every codemod and
+   M-section would otherwise run to completion and only fail at M1's closing install, with
+   the whole migration already applied.
+
 3. **Clean tree.** On a first run, `git status --porcelain` must be empty (the state file
    itself is the only allowed exception) — otherwise ask the user to commit/stash first.
    On a RESUME of an `autoCommit: true` run the tree must also be clean (completed steps
@@ -103,34 +154,54 @@ Perform all checks before changing anything:
    DOM identifiers, Card/Form identifiers) — anything unexplained goes to the user before
    proceeding (or offer to commit the consistent dirty set as a baseline).
 4. **Targets.** Identify source directories to transform (default `src`). Include
-   directories containing stylesheets that reference `--wds-*` or `--semantic-*`
-   variables — discover them with
-   `grep -rln --include="*.css" --include="*.scss" --include="*.sass" --include="*.less" -e "--wds-" -e "--semantic-" . | grep -v node_modules | xargs -n1 dirname | sort -u`
+   directories containing stylesheets that reference `--wds-*` / `--semantic-*` variables
+   OR `wds-*` DOM identifiers (step ④ rewrites those in stylesheets too, so a directory
+   whose only Montage references are selectors like `[wds-component="card"]` must be a
+   target as well) — discover them with
+   `grep -rln --include="*.css" --include="*.scss" --include="*.sass" --include="*.less" -e "--wds-" -e "--semantic-" -e "wds-component" -e "wds-ignore-" -e "wds-region-manager" . | grep -v node_modules | xargs -n1 dirname | sort -u`
    and merge the resulting directories into the target list (collapse into an existing
    target when one already contains them). Use plain directory paths — the codemod CLI
    takes exactly one path per invocation and does not expand globs; each step runs once
    per target directory. **Targets must be disjoint** — a target nested inside another
    (`src` + `src/features/forms`) runs every codemod twice over the nested subtree, the
-   run-once corruption path; the workflow script rejects nested targets. In a monorepo,
+   run-once corruption path; the workflow script rejects nested targets, and equally two
+   spellings of one tree (`src` + `./src` + `<repoRoot>/src`). In a monorepo,
    list ALL package source directories as targets of ONE migration (one state file) — do
    not run separate per-package migrations, or the run-once guarantee fragments per path.
 5. **Ask the user once, on a FIRST run only** (single `AskUserQuestion`): confirm the
    target directories, and whether to auto-commit after each step (recommended; enables
    safe rollback of a failed step). Do not ask again mid-migration. On a resume, do not
    re-ask — restate the `targets` and `autoCommit` recorded in the state file; a requested
-   change goes through the "new migration decision" path in item 2, never a silent
+   change goes through the "new migration decision" path in item 1, never a silent
    override.
 
 ### State file format
 
-Create `.claude/montage-migration-v4.local.md` before step ①, and ensure its path is in
-`.git/info/exclude` (repo-local ignore; append only if missing — step agents check this
-too) so per-step `git add -A` commits never include it
-(this template is kept in sync with `STATE_FILE_TEMPLATE` and `MANUAL_SCAN_SECTIONS` in
-`scripts/migration-workflow.js` — adding a step or M-section means updating all of them).
-The `targets` / `autoCommit` / `codemodVersion` values below are EXAMPLES — fill in the
-values confirmed in preflight (`codemodVersion` is always the concrete version resolved
-there, never a dist-tag):
+Create `.claude/montage-migration-v4.local.md` before step ① (`mkdir -p` its directory
+first — a consumer repo may have no `.claude/`, and a failed redirect leaves the migration
+with no state), and ensure its path is ignored
+so per-step `git add -A` commits never include it: resolve the repo-local exclude file with
+`git -C <repoRoot> rev-parse --git-path info/exclude` (never hardcode `.git/info/exclude` —
+in a linked worktree or submodule `.git` is a FILE and the literal path fails silently),
+append the entry only if missing, then confirm with `git -C <repoRoot> check-ignore -q
+<stateFile>`. Step agents repeat this check.
+
+Consistency surfaces (canonical list — the script's comments point here rather than
+re-enumerating). A new codemod step or M-section must be updated in ALL of these together:
+
+1. this state-file template,
+2. SKILL.md Critical rules item 2 (the ordered step list) and the frontmatter description,
+3. SKILL.md Step 2 decision bullets and Step 3 verification checklist,
+4. `references/codemod-steps.md` — step table, step section, presence grep, and the
+   "After all 6 steps" checklist,
+5. `references/manual-migrations.md` — the M-section and its scan patterns,
+6. `scripts/migration-workflow.js` — `CODEMOD_STEPS`, `MANUAL_SCAN_SECTIONS`,
+   `STATE_FILE_TEMPLATE`,
+7. the plugin `README.md` and `README.ko.md` (both hardcode the ordered 6-codemod list and
+   the manual-migration summary).
+   The `targets` / `autoCommit` / `codemodVersion` values below are EXAMPLES — fill in the
+   values confirmed in preflight (`codemodVersion` is always the concrete version resolved
+   there, never a dist-tag):
 
 ```markdown
 ---
@@ -139,6 +210,8 @@ targets:
   - src
 autoCommit: true
 codemodVersion: 4.0.0
+excludeFiles: [] # repo-relative; filled in when step ⑥ ran with user-confirmed exclusions
+# origin: single-codemod   # present only when created by the single-codemod path
 steps:
   package-name-migration: pending
   semantic-token-migration: pending
@@ -157,11 +230,17 @@ manual:
   M8: pending
   M9: pending
   M10: pending
+  M11: pending
 ---
 ```
 
-Mark each step `completed` immediately after it succeeds. Delete the file only after the
-final verification passes.
+Mark each step `completed` immediately after it succeeds, and each M-section `completed` as
+its manual phase finishes. On a resume, `manual:` marks follow the same rules as `steps:`:
+skip a `completed` section, work every `pending` one, treat a key missing from an older file
+as `pending`, and never downgrade a `completed` mark without explicit user confirmation.
+Unlike codemods, re-running an M-section is not corrupting — but it re-asks decisions the
+user already made, so the marks still govern. Delete the file only after the final
+verification passes.
 
 ## Step 1 — Codemod phase (use the Workflow tool)
 
@@ -171,15 +250,18 @@ aborts the chain) and runs the manual-migration scans in parallel afterwards:
 
 ```js
 Workflow({
-  scriptPath: "<this skill's base directory>/scripts/migration-workflow.js",
+  scriptPath:
+    '${CLAUDE_PLUGIN_ROOT}/skills/montage-v3-to-v4/scripts/migration-workflow.js',
   args: {
     repoRoot: '<absolute repo root>',
     targets: ['src'],
     stateFile: '<absolute path>/.claude/montage-migration-v4.local.md',
-    referencesDir: "<this skill's base directory>/references",
+    referencesDir: '${CLAUDE_PLUGIN_ROOT}/skills/montage-v3-to-v4/references',
     autoCommit: true,
     codemodVersion: '<concrete x.y.z resolved in preflight>',
     completedSteps: [], // step ids already marked completed in the state file
+    // excludeFiles: [], // optional; repo-relative paths, form-control-migration only —
+    //                   // set only on a re-run after step ⑥'s precheck reported them
   },
 });
 ```
@@ -188,12 +270,14 @@ Populate `completedSteps` from the state file read in preflight (empty on a firs
 the script skips those steps deterministically without spawning an agent, and each step
 agent re-checks the state file as a second layer.
 
-Resolve `<this skill's base directory>` from the "Base directory for this skill" line
-announced when this skill loaded. ALWAYS pass `codemodVersion` as the concrete version
+`${CLAUDE_PLUGIN_ROOT}` is the plugin root (`.claude-plugin/montage-migration`); expand it
+to an absolute path before passing it — the Workflow args must be literal paths. If the
+variable is unset in this environment, fall back to the "Base directory for this skill" line
+announced when the skill loaded, or to the directory of the loaded SKILL.md. ALWAYS pass `codemodVersion` as the concrete version
 resolved in preflight (first run) or read from the state file (resume) — the script
 rejects dist-tags, since the value is recorded in the state file and a dist-tag would
 re-resolve on resume and break the same-build guarantee. The workflow returns per-step results plus a
-`manualScan` report (assessed occurrences for manual steps M1–M10).
+`manualScan` report (assessed occurrences for manual steps M1–M11).
 
 - If the workflow reports `aborted`, surface the failed step's error to the user, fix the
   cause, and re-run the same Workflow invocation with `completedSteps` refreshed from the
@@ -219,10 +303,36 @@ re-resolve on resume and break the same-build guarantee. The workflow returns pe
     (a step agent staged but failed to commit): if the dirty files are exactly that step's
     transform output, commit them with that step's commit message
     (`chore(montage): v4 codemod — <step id>`) before re-running — do not stash.
-  - **A step report says the state file was recreated**: treat it as a user-confirmation
-    point — the recreated `targets` came from the invocation's args, not the lost
-    original; confirm with the user that they match the original migration before
-    continuing.
+  - **State file missing at a step's start**: the step agent reports `failed` rather than
+    assuming `pending`. Do not recreate the file silently — reconcile with the user first
+    (the recorded `targets` / `autoCommit` / `codemodVersion` cannot be recovered from args).
+  - **State-file `targets` disagree with the invocation `targets`**: surface BOTH lists to
+    the user and follow the target-lock/addition path in preflight item 1. Never re-run with
+    a widened list to "fix" it.
+  - **Step ⑥ reported an incomplete move-back** (non-empty hash diff, or files still in the
+    temp dir): the run keeps the recovery record and skips the state update and commit.
+    Surface the unrestored paths to the user and restore them before anything else — never
+    re-run step ⑥ over that tree.
+  - **Step ⑥ reported a stale or mismatched `excludeFiles` list** (a listed path does not
+    exist, or the precheck flagged a file the list omits): re-confirm the list with the user
+    and re-run with a corrected `excludeFiles`; a subset list silently under-excludes and a
+    stale path silently un-excludes a hand-migrated file.
+  - **Deletions in the dirty set together with a `.claude/montage-migration-v4.exclusions.json`
+    record**: a previous step-⑥ run died between its move-out and move-back. RECOVER FIRST —
+    restore every recorded path from the record's `excl` directory, verify each `hash`, then
+    delete the record. Never commit those deletions; they are the user's ring-fenced
+    hand-migrated files, and the generic dirty-tree bullet below would erase them.
+  - **Dirty tree with `autoCommit: true` at a step's start**: commit or reconcile the
+    unrelated changes with the user (never stash), then re-run.
+  - **State-file verification failed on a scan-only re-run** (`aborted:
+"state-file-verification"`, all 6 steps already completed): same two causes as above —
+    read `stateCheckError` in the result.
+- **Regardless of `aborted`, inspect every step's `verifyFindings` for a state-file
+  recreation report.** A recreation does NOT abort the run (the step still returns
+  `completed`), so it never reaches the list above. The recreated `targets`, `autoCommit`,
+  `codemodVersion` come from the invocation's args and every `manual:` mark was reset to
+  `pending` by the template — confirm all of it with the user, and restore the M-section
+  marks that were already `completed`, before continuing.
 - **Fallback without the Workflow tool:** execute the exact per-step procedure embedded in
   `scripts/migration-workflow.js` (read it) inline — one step at a time, same order, same
   state-file checks. Never parallelize the codemod steps. After all 6 steps, produce the
@@ -236,15 +346,19 @@ Details per step (commands, pre-checks, post-step verification greps, hazards):
 
 ### Running a single codemod
 
-When the user asks to run just one codemod (not the full migration): run preflight first
-(version check, state file, clean tree, targets). If no state file exists (no in-progress
-migration), CREATE it from the State file format template first — all steps `pending`,
-concrete `codemodVersion` resolved at preflight; the step procedure's missing-file
+When the user asks to run just one codemod (not the full migration): run preflight IN FULL
+— state file, version check, clean tree, targets, AND the one `AskUserQuestion` (item 5):
+the step procedure branches on `autoCommit` at every stage, so it cannot be invented. If no
+state file exists (no in-progress migration), CREATE it from the State file format template
+first — all steps `pending`, concrete `codemodVersion` resolved at preflight, plus
+`origin: single-codemod` so a later full migration surfaces the target list for
+re-confirmation instead of silently inheriting a list chosen for one step; the step procedure's missing-file
 failure applies only to resumes of a previously started migration. If earlier steps in
 the canonical order are not marked `completed` in the state file, surface that and get
 explicit user confirmation before running out of order — manual steps and later codemods assume
 post-codemod names. Then execute that one step exactly as the workflow's step agent would
-(its 11-step procedure is embedded in `scripts/migration-workflow.js`): state-file check,
+(its 12-step procedure, numbered 0–11, is embedded in `scripts/migration-workflow.js`):
+orphaned-exclusion check, state-file check,
 pre-check, run (with the state file's recorded `codemodVersion`, not a fresh `latest`),
 post-step verification grep from `references/codemod-steps.md`, mark the step
 `completed`. The run-once rule applies with full force — this ad-hoc path is exactly
@@ -252,17 +366,27 @@ where double-runs happen.
 
 ## Step 2 — Manual migrations
 
-Work through `references/manual-migrations.md` (M1–M10) using the workflow's `manualScan`
+Work through `references/manual-migrations.md` (M1–M11) using the workflow's `manualScan`
 hits as the worklist. On a resume where all 6 codemod steps are already `completed` but no
 workflow ran this session, there is no `manualScan` report — rebuild the worklist first:
 re-run the same Workflow invocation with `completedSteps` listing all 6 (every step is
-skipped deterministically; the run only regenerates the scans), or run each pending
+skipped deterministically; the run only regenerates the scans — but it still verifies the
+state file exists and its `targets` match, and aborts with `stateCheckError` otherwise), or run each pending
 M-section's scan patterns from `references/manual-migrations.md` yourself. Never work
 M-sections without a scan-derived worklist. Apply mechanical fixes directly; ask the user
 before behavioral decisions (the bullets below are decision summaries only —
 `references/manual-migrations.md` is the source of truth for the full fix rules; update
 both together when an M-section changes):
 
+- **M2 (theme tokens):** per occurrence — wrap the arithmetic in `calc()` on the `var()`
+  string, or import the raw value from `lightOriginTheme`; confirm which, since a raw import
+  bypasses the CSS-variable indirection (and thus runtime theme switching).
+- **M4 (cross-file Card/ListCard):** whether a shared child component is actually rendered
+  inside `ListCard` — the codemod defaults every undeterminable context to the Card family,
+  so switching it changes which component family renders; confirm before swapping.
+- **M5 (FormControl messages):** message typography moved `label2` → `caption1`; an explicit
+  `variant` / `weight` on a message component now fights the new default — per occurrence,
+  drop the override or keep it deliberately.
 - **M6 (Modal bottom sheet):** per occurrence — accept the new close-on-dismiss default
   (delete `onVisibilityChange` workarounds) or pin with `peekHeight`.
 - **M7 (TextField):** whether any field should adopt `size="medium"` (40px) now that the
@@ -271,6 +395,12 @@ both together when an M-section changes):
   uncontrolled TextArea to a controlled one and moving the counter UI from inside the
   field to the form-control message line — confirm per occurrence, and whether any
   TextArea should adopt `size="medium"`.
+- **M9 (Semantic tokens):** which `surface.*` token replaces a deleted accent token that
+  painted a background — the codemod's `foreground.*` replacement is the wrong intent
+  there, and the replacement values differ from the originals (visual change), so decide
+  per occurrence with the user. The `surface.brand.primary` → `foreground.brand.primary`
+  reclassification for text/icon usages is value-identical and mechanical once the usage
+  is confirmed.
 - **M10 (ThemeProvider cookie storage):** whether the app should share its theme with
   sibling subdomains (`cookie.domain`) or stay host-only, and whether to pass `nonce` under
   CSP. `storageKey` → `cookie.key` is mechanical. Direct `next-themes` `useTheme` calls are
@@ -281,12 +411,12 @@ both together when an M-section changes):
   End users' stored theme resets once on this release; that is expected, not a defect.
   If `domain` is adopted, confirm every app under that root domain uses the same `key` /
   `domain` / `path` — a mixed setup shadows the shared cookie and no scan catches it.
-- **M9 (Semantic tokens):** which `surface.*` token replaces a deleted accent token that
-  painted a background — the codemod's `foreground.*` replacement is the wrong intent
-  there, and the replacement values differ from the originals (visual change), so decide
-  per occurrence with the user. The `surface.brand.primary` → `foreground.brand.primary`
-  reclassification for text/icon usages is value-identical and mechanical once the usage
-  is confirmed.
+- **M11 (SegmentedControl):** `variant="outlined"` has no replacement — every occurrence
+  becomes the solid form (white sliding thumb, no dividers, no brand tint), so confirm the
+  visual change per occurrence. Icon-only usages need `iconOnly` on the root plus an
+  `aria-label` per item, and the root stops filling its parent's width (`fit-content`) —
+  decide where the width now comes from. `leadingContent` → `leadingIcon` is mechanical;
+  dropping `trailingContent` is not.
 
 M1 (package.json + configs) ends with a dependency install to refresh the lockfile.
 Mark each M-section `completed` in the state file as it finishes.
@@ -303,15 +433,25 @@ Mark each M-section `completed` in the state file as it finishes.
      during Step 2. NEVER edit valid v4 code just to force a count to zero.
    - The 6 codemod verify greps are zero-criterion WITH their documented exceptions
      (step ①: `@wanteddev/montage-mcp` hits are the correct post-migration name; step ⑥:
-     `FormControl` is the new root name). Step ② is different — its M9 classes
-     (group-level references, dynamic names, computed access) are NOT a permanent
-     exception: at final verification a step-② hit means M9 is incomplete — reopen M9
-     rather than accepting the hit. Re-read each step's verification note in
-     `references/codemod-steps.md` before judging its hits.
+     hits inside a file listed in the state file's `excludeFiles` — read it before judging
+     them. `FormControl` is NOT an exception to list here: step ⑥'s grep is
+     `\bForm(Field|Label|Message|ErrorMessage)`, which cannot match inside `FormControl*`
+     at all, so a `FormControl` "hit" never comes from it — old inner-slot `FormControl`
+     usages are covered by the separate namespace/subpath inspection in step ⑥).
+     Steps ②, ③ and ④ are different — their leftovers are M-section-owned (M9 for ②, M3
+     for ③/④), not permanent exceptions: a Montage-related hit at final verification means
+     that M-section is incomplete, so reopen it rather than accepting the hit. All three
+     share one carve-out: a hit assessed as non-Montage code — a false positive REVERTED
+     during that step's own diff review (steps ③/④ mandate reverting consumer-owned
+     `--wds-*` variables and non-identifier strings, so those names legitimately survive),
+     or unrelated consumer code — may remain and is listed in the final summary; only a
+     genuine Montage reference reopens M9/M3. Re-read each step's verification note
+     in `references/codemod-steps.md` before judging its hits.
 2. Project checks: install, typecheck, lint, build, unit tests — whatever the project
    defines.
-3. Remind the user to visually QA TextField / TextArea / bottom-sheet Modal / Card list
-   screens (v4 changed their rendering and behavior, not just names), plus screens that
+3. Remind the user to visually QA TextField / TextArea / bottom-sheet Modal / Card list /
+   SegmentedControl screens (v4 changed their rendering and behavior, not just names) —
+   former `variant="outlined"` SegmentedControls in particular (see M11) — plus screens that
    used the deleted accent tokens (their replacement values differ — see M9).
 4. Delete the state file, then summarize: steps run, commits created, manual fixes
    applied, items intentionally left (with reasons).
@@ -320,7 +460,7 @@ Mark each M-section `completed` in the state file as it finishes.
 
 - **`references/codemod-steps.md`** — the 6 codemods in order: exact commands,
   idempotency analysis, pre-checks, post-step verification greps, hazards.
-- **`references/manual-migrations.md`** — manual migrations M1–M10 with scan patterns and
+- **`references/manual-migrations.md`** — manual migrations M1–M11 with scan patterns and
   fix rules.
 - **`scripts/migration-workflow.js`** — Workflow-tool script for the codemod phase; also
   the canonical per-step procedure for inline fallback execution.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -502,14 +502,15 @@ EXCL=$(mktemp -d)
 #     inside one agent run, so a killed/timed-out agent would leave the user's
 #     hand-migrated files in an unrecorded /var/folders path, invisible to git.
 #     Reuse $HASHES from step 1 (never re-hash: a file touched between the two loops would
-#     record a hash that disagrees with the move-back check) and emit VALID json.
+#     record a hash that disagrees with the move-back check). Serialize with jq, never by
+#     interpolating paths into printf — a quote or backslash in a filename would corrupt
+#     the record, and a corrupted record is unreadable exactly when it is needed.
 mkdir -p .claude
-{
-  printf '{"excl":"%s","files":[' "$EXCL"
-  sep=''
-  while read -r path hash; do printf '%s{"path":"%s","hash":"%s"}' "$sep" "$path" "$hash"; sep=','; done < "$HASHES"
-  printf ']}\n'
-} > .claude/montage-migration-v4.exclusions.json
+# each $HASHES line is "<path> <40-char sha1>" — take the hash from the END so
+# paths containing spaces survive
+jq -Rn --arg excl "$EXCL" \
+  '{excl: $excl, files: [inputs | select(length > 41) | {path: .[:length-41], hash: .[length-40:]}]}' \
+  < "$HASHES" > .claude/montage-migration-v4.exclusions.json
 # add it to the resolved info/exclude alongside the state file — it must never be committed
 # HARD GATE: no mv may run unless the record was actually written (no `set -e` here, and a
 # missing .claude/ would otherwise leave the files in an unrecorded temp dir, unrecoverable)

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -11,8 +11,14 @@ npx -y @montage-ui/codemod@<codemodVersion> <transform> <target>
 
 - One transform per invocation — the CLI has no batch mode. Passing both the transform name
   and the path makes the run fully non-interactive.
-- Always run a CONCRETE version — resolve it once at preflight
-  (`npm view @montage-ui/codemod version`) and record it in the state file's
+- Always run a CONCRETE version — resolve it once at preflight with
+  `npm view '@montage-ui/codemod@^4' version --json | jq -r 'if type=="array" then .[-1] else . end'`.
+  This skill covers the 4.x transform line only (the workflow script rejects any other
+  major), and the two shorter forms both fail: the unscoped
+  `npm view @montage-ui/codemod version` returns the `latest` dist-tag (5.x the day that
+  ships), while the range form WITHOUT `--json` prints one `pkg@x.y.z 'x.y.z'` line per
+  matching version — verbatim it fails the script's exact-version guard, and taking the
+  first line pins the OLDEST 4.x for the rest of the migration. Record it in the state file's
   `codemodVersion`; on resume, use the recorded value. `npx -y ...@latest` executes
   whatever is published at that moment, so a dist-tag breaks the same-build guarantee
   across steps and sessions (the workflow script rejects dist-tags outright).
@@ -23,17 +29,35 @@ npx -y @montage-ui/codemod@<codemodVersion> <transform> <target>
   step — separate trees, so this does not violate the run-once rule, which is per-tree.
   For that reasoning to hold, **targets must be disjoint**: a target nested inside
   another (`src` and `src/features/forms`) makes the codemod run TWICE over the nested
-  subtree — the run-once corruption path. The workflow script rejects nested targets.
+  subtree — the run-once corruption path. The workflow script rejects nested targets, and
+  also two spellings of the SAME tree (`src` + `./src` + `src/` + `<repoRoot>/src`), which
+  would run every codemod twice just as surely; it canonicalizes to repo-relative paths and
+  rejects `..` segments before comparing.
 - jscodeshift processes `.tsx/.ts/.jsx/.js` and ignores `node_modules` / `.next` / `dist`.
   Steps 2, 3 and 4 additionally rewrite `.css/.scss/.sass/.less` files under the same path
   as plain text.
-- Always run through the CLI (`npx @montage-ui/codemod`), never raw jscodeshift — the
-  stylesheet text pass only runs via the CLI wrapper.
+- **Every transform parses with the `tsx` parser** (`api.jscodeshift.withParser('tsx')`, all
+  six), and the CLI passes `--extensions=tsx,ts,jsx,js` with no per-extension override. A
+  `.ts` file using legacy angle-bracket casts (`const y = <string>value;`) therefore fails to
+  parse — the CLI reports `Transformation error (Unterminated JSX contents…)` and leaves THAT
+  file untransformed while the rest of the run succeeds: a silent partial migration. Scan for
+  them at preflight and convert to `as` syntax in a preparatory commit before step ①:
+  `grep -rnE '(=|\(|,|return) *<[A-Za-z_$][A-Za-z0-9_$.]*(\[\])?> *[A-Za-z_$(]' --include="*.ts" <targets>`.
+  Treat any per-file transformation error in a step's output the same way: the step is NOT
+  complete until every reported file is either fixed and re-run, or hand-migrated.
+- Always run through the CLI (`npx -y @montage-ui/codemod@<codemodVersion> <transform> <target>`,
+  the exact shape at the top of this file), never raw jscodeshift — the stylesheet text pass
+  only runs via the CLI wrapper.
 - If stylesheets live outside the source target (e.g. a top-level `styles/` directory),
   add that directory to the target list AT PREFLIGHT, before step 1 runs, so steps 2–4
-  cover it (again: one invocation per directory). A directory discovered mid-migration
+  cover it (again: one invocation per directory). Discover them by BOTH the variable and the
+  DOM-identifier surface — `-e "--wds-" -e "--semantic-" -e "wds-component" -e "wds-ignore-"
+-e "wds-region-manager"` — because step ④ rewrites `wds-component` / `wds-ignore-*` /
+  `wds-region-manager` in stylesheets too, so a directory whose only Montage references are
+  DOM-identifier selectors (`[wds-component="card"]`, `#wds-region-manager`) is otherwise
+  never discovered and step ④ silently never runs on it. A directory discovered mid-migration
   must NOT be silently added to a running migration's `targets` — the state file's list is
-  locked; follow the target-addition path in SKILL.md's preflight item 2 (user
+  locked; follow the target-addition path in SKILL.md's preflight item 1 (user
   confirmation → run each already-completed step's codemod CLI directly on ONLY the new
   directory with the recorded `codemodVersion`, bypassing the skip-if-completed check —
   the `completed` mark is per-migration, not per-directory, and stays untouched → run
@@ -59,6 +83,47 @@ reference post-codemod names, so all 6 codemods run first, manual migrations aft
 (its `semantic.*` / `--semantic-*` namespace is disjoint from every other transform's
 inputs and outputs, and it is not import-gated) — its position follows the MIGRATION.md
 section order.
+
+## Presence greps — "was this step already run?"
+
+Every step's post-step verification is an ABSENCE check, so it returns zero both when the
+codemod ran and when the repo never used that API. That makes it useless for the
+`pending`-but-already-applied mismatch direction (SKILL.md preflight item 1) — the direction
+that walks into the step ⑥ double-swap. Pair it with the matching PRESENCE grep: new names
+present + old names absent means the transform already ran (by codemod or by hand).
+
+| Step | Presence grep (new names)                                                                                       |
+| ---- | --------------------------------------------------------------------------------------------------------------- |
+| ①    | `grep -rn "@montage-ui/" <targets>`                                                                             |
+| ②    | `grep -rnE -- "semantic\.(foreground\|surface\|effect)\.\|--semantic-(foreground\|surface\|effect)-" <targets>` |
+| ③    | `grep -rnE -- "--grid-(column\|row)-spacing" <targets>` (see the caveat below)                                  |
+| ④    | `grep -rn "data-component" <targets>`                                                                           |
+| ⑤    | `grep -rnE "\b(ListCard\|CardBody\|CardRow)" <targets>`                                                         |
+| ⑥    | `grep -rnE "\bFormControl(\b\|Field\|Label\|Message\|NegativeMessage\|PositiveMessage)" <targets>`              |
+
+Read the pair together, never either alone: both zero means the repo simply never used that
+API (nothing to conclude); new present + old present means a HALF-migrated tree — stop and
+reconcile with the user, never re-run the codemod over it.
+
+**Step ⑥ caveat — a bare `FormControl` is ambiguous.** A v3 tree using only the plain
+`FormField` root migrates to a plain `FormControl` with no sub-components, so BOTH step ⑥
+greps return zero on it — "both zero" therefore does NOT mean "never used that API" here.
+That is why the presence pattern includes bare `\bFormControl\b`; a bare hit can be the
+correct new root OR a surviving v3 inner slot, so the step-⑥ pre-check (not this table) is
+the authoritative test for the already-applied direction.
+
+**Step ③ caveat — the weakest signal of the six.** `css-variable-migration` covers the
+69 `KNOWN_WDS_VARIABLES`: 67 come out with the `--wds-` prefix simply stripped
+(`--modal-translate`, `--switch-width`, `--card-content-item-*`, …) and the remaining two,
+`--wds-column-spacing` / `--wds-row-spacing`, are renamed to `--grid-*-spacing`. Only
+`--grid-column-spacing` / `--grid-row-spacing` are unambiguous evidence; the stripped
+component names are indistinguishable from consumer-defined variables. If a repo never used
+the grid variables, step ③ has NO reliable presence signal — say so and fall back to the
+step-③ commit / `git log -S"--wds-"` rather than guessing. Do NOT use
+`--spacing-` / `--radius-` / `--dimension-` / `--zIndex-` / `--opacity-` / `--primitive-` /
+`--atomic-` here: those are the theme-token CSS variables emitted by the library build (the
+M2 topic), not codemod output, and `--atomic-*` / `--semantic-*` already exist in v3 — they
+would fire on a completely unmigrated tree.
 
 ## Step 1 — `package-name-migration`
 
@@ -143,7 +208,9 @@ grep -rnE "semantic\.(label|status|fill|material|inverse)\b|semantic\.interactio
 grep -rnE -- "--semantic-(label|status|fill|material|inverse|interaction|primary|accent|background-(normal|elevated|transparent|status)|line-(normal|solid|primary|status))" <targets>
 ```
 
-(The second grep includes stylesheets. Both patterns match no v4 name — the new structure
+(Both greps scan stylesheets too — neither carries an `--include` filter. A dot-path hit
+inside a stylesheet is an M9 item, because the CLI's stylesheet text pass renames only the
+`--semantic-*` variable form. Both patterns match no v4 name — the new structure
 has no top-level `label`/`status`/`fill`/`material`/`inverse`/`interaction`/`primary`/
 `accent` group, `background` keeps only `neutral`, and `line` keeps none of
 `normal`/`solid`/`primary`/`status`.) Remaining hits should only be group-level
@@ -162,7 +229,9 @@ Rewrites string literals and template literals in JS/TS plus stylesheets as text
 Cautions:
 
 - NOT import-gated — it renames ANY `--wds-*` token by prefix, including consumer-defined
-  variables that were never Montage's. Review the diff.
+  variables that were never Montage's. Review the diff and REVERT the rewrites of variables
+  the consumer clearly owns; route ambiguous namespaces to the user before this step's
+  commit. No later scan looks for them, and once committed the original names are gone.
 - The pattern is lowercase-only (`--wds-[a-z0-9-]+`): a camelCase custom property like
   `--wds-myVar` gets partially rewritten (`--myVar`). All shipped Montage variables are
   lowercase, but grep the diff for partially-rewritten camelCase properties
@@ -195,10 +264,17 @@ and stylesheets:
 Cautions:
 
 - Blind substring replacement over ANY string literal — unrelated strings containing a token
-  (analytics event names, doc strings) get rewritten too. Review the diff.
+  (analytics event names, doc strings) get rewritten too. Review the diff and REVERT
+  non-identifier rewrites: a renamed analytics event name is a silent production-behavior
+  change. Route ambiguous strings to the user before this step's commit — no later scan
+  covers them.
 - Renames attribute NAMES only, never VALUES: `wds-component="card-content"` becomes
   `data-component="card-content"`; the value rename `card-content` → `card-body` is manual
-  step M4 and therefore MUST come after this step.
+  step M4. Keep M4 after this step so the selectors you edit already carry the `data-`
+  prefix — a soft preference, not a hard constraint: the transform is a blind substring pass
+  over the attribute name and does not depend on the value, and M4's own scans (`card-content`,
+  `--card-content-item-`) match before and after. The one HARD constraint here is step 3
+  before M4's `--card-content-item-*` → `--card-row-*` rename.
 
 Post-step verification: `grep -rn -E "wds-(component|ignore-|region-manager)" <targets>` —
 remaining hits should only be dynamically-built strings (manual M3).
@@ -222,12 +298,17 @@ Cautions:
   child components (manual M4).
 - Half-hand-migrated files (importing BOTH an old name and its new name) can end up with a
   duplicate import specifier — check before running for files importing any old name
-  together with any new counterpart, using the FULL rename surface: every
+  together with any new counterpart, using the subset of the rename surface that can produce
+  a duplicate specifier: every
   `\bCard(List|Content)`-prefixed value or Props type (`CardContent`, `CardContentItem`,
   `CardListContent`, their `*Skeleton` and `*Props` forms, `CardList`,
   `CardListSkeleton`) against the new names (`ListCard*`, `CardBody*`, `CardRow*` and
-  their Props). The global renames hit ALL of these unconditionally, so any old/new pair
-  in one file produces a duplicate specifier. Clean them up first. Concrete two-pass
+  their Props). That subset is sufficient: the `CardThumbnail*` / `CardTitle*` /
+  `CardCaption*` family only renames when a `CardList` / `CardListSkeleton` import is
+  present, which the pattern already matches, so it is covered transitively. The nine
+  GLOBAL_RENAMES entries (`CardList*`, `CardContent*Props`) fire unconditionally; the
+  context-sensitive ones fire whenever their tree root is present — either way an old/new
+  pair in one file produces a duplicate specifier. Clean them up first. Concrete two-pass
   check (mirrors step 6's style):
 
   ```sh
@@ -243,6 +324,15 @@ Cautions:
   ```sh
   grep -rnE "\bCard(List|Content|Thumbnail|Title|Caption)\w* as \w+" <targets>
   ```
+
+  **False-positive triage before aborting.** Both greps are name-based, so they also match a
+  locally defined or third-party `CardBody` / `CardRow`, and hits in `.md` / `.snap` / `.css`
+  files. For each flagged file confirm that BOTH the old and the new name resolve to an
+  import from `@montage-ui/core` or `@wanteddev/wds`; if not, it is NOT a mixed file — drop
+  it from the list and note it. Skipping this triage deadlocks the phase: there is nothing to
+  clean up in a false positive, so every re-run aborts identically.
+  Abort on BOTH surviving classes — genuine old/new pairs AND same-old-name-twice
+  (plain + aliased) files: each needs its own cleanup (below) before the codemod may run.
 
   **Cleanup remediation**
   (when the pre-check aborts the workflow with a file list): for each flagged file, either
@@ -278,6 +368,52 @@ them by hand now, as part of this step. Before fixing a hit, confirm the identif
 actually comes from a montage source (a namespace/subpath/re-export of
 `@montage-ui/core` / `@wanteddev/wds`): a same-named identifier defined locally or
 imported from another library is NOT a migration leftover — leave it alone.
+
+### Rename tables (v3 → v4)
+
+Use these for every hand-fix in this step and for manual step M4 — the consumer repo has no
+other source for the mapping. They mirror the transform's three maps exactly.
+
+**Unconditional** (context-independent; components and Props types alike):
+
+| 기존                           | 변경                    |
+| ------------------------------ | ----------------------- |
+| `CardList`                     | `ListCard`              |
+| `CardListContent`              | `ListCardContent`       |
+| `CardListSkeleton`             | `ListCardSkeleton`      |
+| `CardListProps`                | `ListCardProps`         |
+| `CardListContentProps`         | `ListCardContentProps`  |
+| `CardListSkeletonProps`        | `ListCardSkeletonProps` |
+| `CardContentProps`             | `CardBodyProps`         |
+| `CardContentItemProps`         | `CardRowProps`          |
+| `CardContentItemSkeletonProps` | `CardRowSkeletonProps`  |
+
+**Inside a `Card` / `CardSkeleton` tree** (also the fallback when the context is
+undeterminable — including non-JSX identifier references):
+
+| 기존                      | 변경              |
+| ------------------------- | ----------------- |
+| `CardContent`             | `CardBody`        |
+| `CardContentItem`         | `CardRow`         |
+| `CardContentItemSkeleton` | `CardRowSkeleton` |
+
+**Inside a `CardList` / `CardListSkeleton` tree** (post-rename: a `ListCard` tree):
+
+| 기존                      | 변경                        |
+| ------------------------- | --------------------------- |
+| `CardThumbnail`           | `ListCardThumbnail`         |
+| `CardThumbnailContent`    | `ListCardThumbnailContent`  |
+| `CardThumbnailSkeleton`   | `ListCardThumbnailSkeleton` |
+| `CardContent`             | `ListCardBody`              |
+| `CardContentItem`         | `ListCardRow`               |
+| `CardContentItemSkeleton` | `ListCardRowSkeleton`       |
+| `CardTitle`               | `ListCardTitle`             |
+| `CardCaption`             | `ListCardCaption`           |
+| `CardTitleSkeleton`       | `ListCardTitleSkeleton`     |
+| `CardCaptionSkeleton`     | `ListCardCaptionSkeleton`   |
+
+`CardThumbnail*` / `CardTitle*` / `CardCaption*` are ALSO valid v4 Card-family names — they
+rename only in list context, which is why the verify grep cannot chase them to zero.
 
 ## Step 6 — `form-control-migration`
 
@@ -362,6 +498,23 @@ for f in <flagged files>; do echo "$f $(git hash-object "$f")"; done > "$HASHES"
 # 2. fresh temp dir (never reuse a fixed path — stale leftovers would be moved back in)
 EXCL=$(mktemp -d)
 
+# 2b. persist a recovery record BEFORE the first mv — $EXCL and $HASHES are shell locals
+#     inside one agent run, so a killed/timed-out agent would leave the user's
+#     hand-migrated files in an unrecorded /var/folders path, invisible to git.
+#     Reuse $HASHES from step 1 (never re-hash: a file touched between the two loops would
+#     record a hash that disagrees with the move-back check) and emit VALID json.
+mkdir -p .claude
+{
+  printf '{"excl":"%s","files":[' "$EXCL"
+  sep=''
+  while read -r path hash; do printf '%s{"path":"%s","hash":"%s"}' "$sep" "$path" "$hash"; sep=','; done < "$HASHES"
+  printf ']}\n'
+} > .claude/montage-migration-v4.exclusions.json
+# add it to the resolved info/exclude alongside the state file — it must never be committed
+# HARD GATE: no mv may run unless the record was actually written (no `set -e` here, and a
+# missing .claude/ would otherwise leave the files in an unrecorded temp dir, unrecoverable)
+[ -s .claude/montage-migration-v4.exclusions.json ] || exit 1
+
 # 3. move each flagged file out, preserving its relative path
 for f in <flagged files>; do
   mkdir -p "$EXCL/$(dirname "$f")"
@@ -382,7 +535,10 @@ Verify the moved-back files by re-running step 1's path+hash command and diffing
 the recording (`diff "$HASHES" <(for f in <flagged files>; do echo "$f $(git hash-object "$f")"; done)`
 — must be empty). Confirm the temp directory is empty before the move-out, and contains
 no files after the move-back (the directory skeleton remains):
-`[ -z "$(find "$EXCL" -type f)" ]`.
+`[ -z "$(find "$EXCL" -type f)" ]`. Only then delete
+`.claude/montage-migration-v4.exclusions.json`. If that file still exists at the start of
+any later run, a previous exclusion never completed: restore each recorded path from
+`excl` and verify its `hash` BEFORE doing anything else, and surface it to the user.
 
 Verification note: with `autoCommit: false` a plain `git status` no-diff check on the
 moved-back files is meaningless — they legitimately carry earlier steps' uncommitted
@@ -406,7 +562,17 @@ Post-step verification (expect zero hits):
 `grep -rn -E "\bForm(Field|Label|Message|ErrorMessage)" <targets>`
 (prefix pattern on purpose — a `\bFormField\b` form would miss `FormFieldProps` leftovers
 in gate-skipped files; the prefix form matches no new `FormControl*` name.)
-`FormControl` hits are EXPECTED — it is the new root name; do not "fix" them.
+This grep never matches a `FormControl*` name (`\bForm` has no word boundary inside
+`FormControlMessage`), so do not add them to it and do not treat "`FormControl` is expected"
+as an exception to a hit you actually see — old inner-slot `FormControl` usages are covered
+by the separate namespace/subpath inspection below, not by this grep.
+Hits inside the EXCLUDED files are EXPECTED: those files are
+hand-migrated, so their `FormField` / `FormLabel` / `FormMessage` mentions are comments,
+strings, or deliberate back-compat type aliases (`export type FormFieldProps =
+FormControlProps`) — the second pre-check flags exactly that shape. Report them and never
+edit an excluded file; "fixing" one silently rewrites code the user ring-fenced. The list
+lives in the state file's `excludeFiles:` key — read it before judging hits, including in a
+later session where the `excludeFiles` arg is no longer in scope.
 
 One residual the main grep cannot see (step 5 has the same class of acknowledgment): in
 gate-skipped files, an OLD inner-slot `FormControl` usage (e.g.
@@ -420,11 +586,21 @@ subpath imports for `.FormControl` member usages.
 
 ## After all 6 steps
 
-Proceed to `manual-migrations.md` (all M-sections, M1–M10), then final verification:
+Proceed to `manual-migrations.md` (all M-sections, M1–M11), then final verification:
 
-1. All leftover greps clean (see each step + M-sections).
+1. Each step's verify grep zero, with its documented exceptions (step ①:
+   `@wanteddev/montage-mcp`; step ⑥: hits inside the state file's `excludeFiles`).
+   Steps ②/③/④ are NOT plain zero-criterion: their leftovers are M-section-owned (M9 for ②,
+   M3 for ③/④), so a Montage-related hit means that section is incomplete — reopen it. All
+   three share one carve-out: a hit assessed as non-Montage code — a false positive REVERTED
+   during that step's own diff review (steps ③/④ mandate those reverts, so the original
+   `--wds-*` / `wds-*` names legitimately survive), or unrelated consumer code — may remain
+   and is listed in the summary. Every M-section **[zero]**
+   pattern zero for Montage-related hits; every **[decision]** hit assessed — [decision]
+   patterns match valid v4 code and never reach zero. SKILL.md Step 3 is the canonical
+   statement of these criteria; this list is a pointer, not a substitute.
 2. Dependency install with the renamed `@montage-ui/*` packages succeeded.
 3. Project typecheck / lint / build / tests pass.
-4. Visual QA on TextField / TextArea / Modal bottom-sheet / Card list screens and screens
-   that used the deleted accent tokens (behavioral
-   changes).
+4. Visual QA on TextField / TextArea / Modal bottom-sheet / Card list / SegmentedControl
+   screens (former `variant="outlined"` in particular, see M11) and screens that used the
+   deleted accent tokens (see M9) — behavioral and visual changes, not just renames.

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
@@ -5,8 +5,12 @@ completed (see `codemod-steps.md`). Each section lists scan patterns to locate a
 code — scan first, then apply fixes only where a real occurrence exists.
 
 Scan patterns use `grep -E` syntax with `\b`/`\s`/`\w` shorthands — supported by GNU grep,
-macOS BSD grep, and ripgrep alike (translate the shorthands to POSIX classes for busybox
-or other minimal greps). Patterns beginning with `-` (e.g. `--wds-`) must be passed after
+macOS BSD grep, and ripgrep alike, but ONLY OUTSIDE bracket expressions (translate the
+shorthands to POSIX classes for busybox or other minimal greps). **Inside `[...]` always use
+a POSIX class**: BSD/GNU `grep -E` treat `[\w.]` as the literal 3-character set
+`{backslash, w, dot}`, while ripgrep's Rust regex honors `\w` there — the same pattern
+silently yields different worklists per tool, which is how a scan comes back empty instead of
+failing. Write `[[:alnum:]_.]` instead. Patterns beginning with `-` (e.g. `--wds-`) must be passed after
 a `--` separator or via `-e` (`grep -rn -e "--wds-"`), or grep parses them as options and
 exits without scanning. The patterns are line-based heuristics: multi-line JSX props and
 non-literal forms (`variant={'bottom'}`, responsive objects) escape them, so treat a clean
@@ -44,7 +48,7 @@ Exception: `@wanteddev/wds-mcp` maps to `@wanteddev/montage-mcp` — it stays in
 
 Check and update:
 
-- `package.json` — `dependencies` / `devDependencies` / `peerDependencies` / `resolutions` / `overrides` / `pnpm.overrides`. Replace each `@wanteddev/wds*` entry with its `@montage-ui/*` counterpart at version `^4.0.0`, then run the project's package manager install to refresh the lockfile.
+- `package.json` — `dependencies` / `devDependencies` / `peerDependencies` / `resolutions` / `overrides` / `pnpm.overrides`. Replace each `@wanteddev/wds*` entry with its `@montage-ui/*` counterpart at version `^4.0.0`, then run the project's package manager install to refresh the lockfile. EXCEPTION: `@wanteddev/wds-mcp` → `@wanteddev/montage-mcp` keeps its OWN version line (it is not one of the `@montage-ui/*` packages and is published to the GitHub Package Registry) — resolve it separately against the GitHub Package Registry — `npm view @wanteddev/montage-mcp version --registry=https://npm.pkg.github.com/` with the project's `@wanteddev:registry` / auth token configured in `.npmrc`; the default registry 404s for it — instead of pinning it to `^4.0.0`, which would likely be unresolvable and fail the install.
 - Code the codemod cannot reach — these must already have been fixed during Step 1's
   post-step verification (they are code, not config); the scan here is a safety net, and
   any hit is a Step 1 escape:
@@ -100,12 +104,14 @@ Also review destructured/aliased usages the patterns above miss (e.g.
 destructuring sites with (**[decision]**, like every M2 pattern):
 
 ```
-const\s*\{[^}]*\b(spacing|radius|dimension|opacity|zIndex|primitive)\b[^}]*\}\s*=\s*[\w.]*[Tt]heme
+const\s*\{[^}]*\b(spacing|radius|dimension|opacity|zIndex|primitive)\b[^}]*\}\s*=\s*[[:alnum:]_.]*[Tt]heme
 ```
 
-(the `[\w.]*` tail also matches `props.theme`, `this.props.theme`, and `useTheme()`
-bases; an alias whose name does not end in `theme` still escapes — treat the scan as a
-heuristic) then inspect each file for arithmetic on the destructured names.
+(the POSIX `[[:alnum:]_.]*` tail — NOT `[\w.]*`, which BSD/GNU `grep -E` read as the literal
+set `{backslash, w, dot}` and which therefore matches only a bare `theme` base — also matches
+`props.theme`, `this.props.theme`, and `useTheme()` bases, verified under BSD grep; an alias
+whose name does not end in `theme` still escapes, so treat the scan as a heuristic) then
+inspect each file for arithmetic on the destructured names.
 
 Fixes:
 
@@ -128,10 +134,14 @@ Fixes:
 - Genuinely needs a JS number (measurements, non-CSS APIs, chart libs) → import raw values:
 
   ```ts
-  import { lightOriginTheme, darkOriginTheme } from '@montage-ui/core';
+  import { lightOriginTheme } from '@montage-ui/core';
 
   lightOriginTheme.spacing[16]; // '16px' — raw value
   ```
+
+  One import is enough: `lightOriginTheme` and `darkOriginTheme` share the exact same
+  `opacity` / `primitive` / `spacing` / `radius` / `dimension` / `zIndex` objects (only
+  `semantic` differs), so never branch on the active theme for these six groups.
 
 - `rgba(0, 0, 0, ${theme.opacity[43]})` and `addOpacity(color, theme.opacity[N])` keep
   working as-is — the alpha slot of `rgba()` resolves `var()` fine. No change needed.
@@ -151,6 +161,10 @@ literals, template literals, and stylesheets. They cannot rewrite:
   instead of `--grid-column-spacing` — review every dynamic construction site.
 - Selectors living outside the transformed directories: E2E specs (Playwright/Cypress),
   snapshot files, CSS-in-JS in other packages, HTML files, styled-components in `.md`/MDX.
+  The same out-of-target class exists for the IDENTIFIER renames of steps ⑤/⑥ (a `CardList`
+  or `FormField` reference in an E2E spec or snapshot outside `<targets>`): M4 owns the
+  Card/ListCard ones, M5 the Form ones — run those sections' scans over the whole repo, not
+  just the targets.
 - Dynamically built DOM-identifier strings whose static part stops short of a full token:
   `'wds-' + kind`, `` `wds-ignore-${x}` `` — review every dynamic construction site, same
   as the `--wds-` case above. The full-token [zero] scans below do not reach the
@@ -159,7 +173,14 @@ literals, template literals, and stylesheets. They cannot rewrite:
 - camelCase custom properties: the rename pattern is lowercase-only, so `--wds-myVar` comes
   out partially rewritten as `--myVar`. The diff review for these is owned by step 3's
   (`css-variable-migration`) post-step verification (where the diff is at hand); this note
-  is a safety net — if step 3's diff was never reviewed, grep it now.
+  is a safety net — if step 3's diff was never reviewed, grep it now. Because the partially
+  rewritten name no longer contains `wds`, none of the [zero] patterns below reach it; scan
+  the repo instead with **[decision]**: `--[a-z0-9-]*[A-Z]` (stylesheets and JS/TS; digits
+  included, since `--wds-my2Var` breaks the same way) and, for each hit, confirm the
+  declaration and every usage agree on one name. Expect heavy noise: the pattern matches
+  every legitimately camelCase custom property, Montage's own `--zIndex-*` theme variables
+  included. Only a name whose declaration and usages DISAGREE is a real hit — a consistent
+  camelCase variable is valid code and must not be renamed to force the scan quiet.
 
 False-positive review of the codemod diff (blind substring replacement rewrites unrelated
 strings — analytics event names, documentation strings, consumer-defined `--wds-*`
@@ -197,18 +218,27 @@ ancestor. Two classes of usage need manual review:
   maps of components): context cannot be inferred, so the codemod converts to the Card-family
   name (`CardBody`). If the value is actually rendered inside a `ListCard`, replace with the
   `ListCard*` equivalent (`ListCardBody`, `ListCardRow`, ...) by hand.
-  Scan **[decision]**: `Card(Body|Row|Title|Caption|Thumbnail)\w*` used outside JSX tags
-  in files that also render `ListCard`.
+  Scan **[decision]**: `\bCard(Body|Row|Title|Caption|Thumbnail)\w*` used outside JSX tags
+  in files that also render `ListCard`. The `\b` anchor is required — unanchored, the
+  pattern matches inside `ListCardBody` / `ListCardRow` too, so every correct
+  post-migration name in the scanned files comes back as a hit and buries the real ones.
 - **Cross-file context**: a child-component file that imports only Card sub-components (no
   `ListCard` import in the same file) is converted to Card-family names even when a parent
   file mounts it inside a `ListCard`. Review shared child components rendered inside
   `ListCard` and switch them to `ListCard*` names by hand. Concrete procedure
   (**[decision]**):
-  1. `grep -rlE '\bCard(Body|Row|Title|Caption|Thumbnail)' <targets>` minus the files that
-     also match `\bListCard` — these are Card-family-only files.
+  1. `grep -rlE '\bCard(Body|Row|Title|Caption|Thumbnail)'` over the whole repo (M-section
+     scans are repo-wide; `<targets>` would miss importers living outside the transformed
+     directories) minus the files that also match `\bListCard` — these are Card-family-only
+     files.
   2. For each such file's exported component, grep for its importers; flag any importer
      that renders `ListCard` around the imported component — those usages need the
      `ListCard*` names.
+
+  Use the **Rename tables (v3 → v4)** at the end of step 5 in `codemod-steps.md` for every
+  hand-rewrite here — the consumer repo has no other source for the old→new mapping, and
+  the Card-family and ListCard-family names differ per context.
+
 - **DOM identifiers of renamed sub-components** (selectors in CSS/tests/E2E):
 
   ```
@@ -221,11 +251,24 @@ ancestor. Two classes of usage need manual review:
   Scan patterns **[zero]**: `card-content` and `--card-content-item-` (`card-content` is
   a bare substring — consumer code coincidentally containing it is the unrelated-hit case
   the [zero] definition allows to remain).
+
+- **Old Card names outside the transformed directories** (E2E specs, snapshots, MDX,
+  CSS-in-JS in other packages): the codemod never saw them, so they still carry v3 names.
+  Scan **[zero]** over the WHOLE repo, not just `<targets>`: `\bCard(List|Content)` — the
+  same pattern step ⑤ verifies with, plus the montage-source confirmation caveat (a locally
+  defined or third-party name is not a leftover). Rewrite hits against the rename tables in
+  `codemod-steps.md` step 5.
   Note: after `dom-identifier-migration`, old `wds-component="card-content"` selectors have
   become `data-component="card-content"` — this step renames the _value_ part.
 
 ## M5. FormControl follow-ups
 
+- **Old Form names outside the transformed directories** (E2E specs, snapshots, MDX,
+  CSS-in-JS in other packages): the codemod never saw them.
+  Scan **[zero]** over the WHOLE repo, not just `<targets>`:
+  `\bForm(Field|Label|Message|ErrorMessage)` — step ⑥'s verify pattern, plus the
+  montage-source confirmation caveat. Apply the step ⑥ rename table by hand; never re-run
+  the codemod to reach them.
 - Message typography changed from `label2` to `caption1`. Code that passed explicit
   `variant` / `weight` to `FormMessage` / `FormErrorMessage` (now `FormControlMessage` /
   `FormControlNegativeMessage`) may fight the new default — review each occurrence.
@@ -280,8 +323,12 @@ For each bottom-sheet Modal, decide: default close-on-dismiss (delete workaround
 ## M8. TextArea changes
 
 - **`TextAreaContent` variant renames**: `variant="badge"` → `variant="content-badge"`,
-  `variant="chip"` → `variant="custom"`. New variants `primary-icon-button` and
-  `segmented-control` are available (informational).
+  `variant="chip"` → `variant="custom"`. The full v4 set is `custom` | `button` |
+  `content-badge` | `icon` | `icon-button` | `primary-icon-button` | `segmented-control`.
+  Only `content-badge`, `primary-icon-button` and `segmented-control` are NEW —
+  `custom` / `button` / `icon` / `icon-button` all existed in v3 (`icon-button` merely
+  became the default, see below), so seeing one in the codebase is not evidence of a
+  migration.
   Scan **[zero]**: `TextAreaContent[^>]*variant="(badge|chip)"`.
 - **`variant="characterCounter"` removed** — the character counter no longer renders
   inside the TextArea bottom area. Replace with `FormControlMessageAccessory` passed via
@@ -314,7 +361,7 @@ For each bottom-sheet Modal, decide: default close-on-dismiss (delete workaround
 ## M9. Semantic token follow-ups
 
 The `semantic-token-migration` codemod (step 2) rewrites every literal old-token
-reference in JS/TS plus the `--semantic-*` variable form in stylesheets, but five
+reference in JS/TS plus the `--semantic-*` variable form in stylesheets, but six
 classes of work remain. The full old→new rename tables are bundled at the end of this
 section — use them for every hand-rewrite (do not look for the design-system repo's
 MIGRATION.md; it does not exist in the consumer repo).
@@ -348,8 +395,10 @@ MIGRATION.md; it does not exist in the consumer repo).
   `const { label } = theme.semantic`) — the chain no longer passes through a `semantic`
   anchor at the usage site. Rewrite against the rename tables below.
   Scan **[zero]**: the two step-2 verification greps in `codemod-steps.md` (old dot-path
-  and old CSS-variable patterns) — after this section every remaining hit must be gone;
-  step 2's verification only REPORTS these, M9 owns the fix.
+  and old CSS-variable patterns) — after this section every Montage-token hit must be gone;
+  step 2's verification only REPORTS these, M9 owns the fix. Standard [zero] semantics apply:
+  a hit assessed as non-Montage code (a false positive reverted during step 2's diff review,
+  an unrelated object or string) may remain and is listed in the final summary.
   Scan **[decision]**: `\.semantic([^.[:alnum:]]|$)` — locates root-object aliasing and
   destructuring sites (`= theme.semantic;`, `(theme.semantic)`) without matching normal
   `theme.semantic.<group>` chains; trace each alias/destructured name to its leaf usages
@@ -365,6 +414,12 @@ MIGRATION.md; it does not exist in the consumer repo).
   the `--semantic-*` CSS-variable form; a `semantic.<old-path>` dot string inside
   `.css/.scss/.sass/.less` (rare — usually content/comments) is untouched and surfaces
   through the step-2 verification grep above. Fix per the rename tables below.
+- **Old tokens living outside the transformed directories** (mirrors M3's equivalent class):
+  E2E specs (Playwright/Cypress), snapshot files, CSS-in-JS in other packages, HTML files,
+  styled-components in `.md`/MDX. The codemod only touches the target directories, so these
+  keep their v3 names silently. Run the two step-2 greps over the WHOLE repo (minus
+  `.git`/node_modules/build output), not just `<targets>`, and rewrite the hits by hand
+  against the rename tables below.
 
 ### Rename tables (v3 → v4)
 
@@ -441,6 +496,12 @@ keeps working as-is. The items below are what does break, plus one new opportuni
     and map the fields: `resolvedTheme` → `theme` (resolved `'light' | 'dark'`), and the
     user's raw choice → `themeOriginValue` (`'light' | 'dark' | 'system' | undefined`).
     Note `setTheme` accepts only those three values in v4.
+    `useThemeControl()` returns EXACTLY `{ theme, themeOriginValue, setTheme }` — next-themes'
+    `systemTheme`, `themes`, and `forcedTheme` have no equivalent. A destructure of any of
+    them is a per-occurrence decision for the user, not a mechanical rewrite: `systemTheme`
+    can be re-derived from `window.matchMedia('(prefers-color-scheme: dark)')` (client-side
+    only), `themes` is the fixed `['light', 'dark']` list, and `forcedTheme` has no
+    replacement — an app relying on it must be reworked, not remapped.
   - Bound to the app's own `<NextThemeProvider>`, rendered independently of Montage → leave
     it alone. Those calls still work, and the `next-themes` dependency stays.
 
@@ -487,6 +548,47 @@ keeps working as-is. The items below are what does break, plus one new opportuni
   the first load after deploy to follow the system theme (or light when `enableDarkMode`
   is off).
 
+## M11. SegmentedControl changes
+
+- **`variant` prop removed** (was `"solid" | "outlined"`). Delete the prop — solid is the
+  only form. There is NO replacement for `outlined`: its transparent background + outer
+  border, per-item dividers, and brand-tinted active item are gone, and the active item now
+  renders the solid white thumb WITH the sliding animation `outlined` never had. Every
+  `outlined` occurrence is a visual change requiring QA, not a mechanical delete.
+  Scan **[zero]**: `SegmentedControl[^>]*variant=` (multi-line props escape it — pair with
+  the file-level scan below).
+- **`SegmentedControlItem` `leadingContent` → `leadingIcon`** (mechanical rename), and
+  **`trailingContent` removed** with no replacement — move that content into `children` or
+  drop it.
+  Scan **[zero]**: `SegmentedControlItem[^>]*(leadingContent|trailingContent)=`. Do NOT
+  scan the bare `leadingContent` / `trailingContent` substrings — TextField, TextArea, and
+  ListCell keep those props in v4, so bare hits are valid v4 code.
+  Scan **[decision]**: `\bSegmentedControl(Item)?\b` file-level, then review every JSX usage
+  for a `variant` / `leadingContent` / `trailingContent` prop the line greps missed. The
+  `(Item)?` group is required — `\bSegmentedControl\b` alone does NOT match
+  `SegmentedControlItem` (the trailing `\b` fails before `I`), so a file that renders only
+  items would be skipped entirely.
+- **`iconOnly` prop added** — the icon-only form is no longer "an item whose only child is
+  an icon". Usages that rendered icons without a text label must set `iconOnly` on the ROOT
+  and pass the icon as the item's `children`, plus an `aria-label` per item (the text
+  wrapper that carried the accessible name is not rendered in this mode). Root width also
+  becomes `fit-content` instead of `100%`, so a parent relying on the control filling its
+  width needs a width of its own.
+  When a `SegmentedControl` sits inside `TextAreaContent variant="segmented-control"`, that
+  variant injects no sizing of its own — `iconOnly` must be set explicitly.
+  Scan **[decision]**: `SegmentedControlItem[^>]*aria-label=` — an item with an aria-label
+  and no text is the icon-only pattern that now needs `iconOnly` on its root.
+- **`[data-role='segmented-control-item-text']` not rendered under `iconOnly`** — custom CSS
+  targeting it applies to labeled items only.
+  Scan **[decision]**: `segmented-control-item-text` (include stylesheets).
+- **Size details changed** (heights unchanged at 32 / 40 / 48px): root radius 8→10 / 10→12 /
+  12→14px, root padding 2→4 / 2→4 / 3→4px, item typography label2→caption1 /
+  body2→label1 / headline2→body2, item icon 14 (same) / 18→16 / 20→18px, item gap fixed 4px
+  → 4 / 6 / 6px, small item radius 6→8px. The thumb shadow now comes from
+  `semantic.elevation.shadow.normal.xsmall` (the white 28% overlay is gone). Nothing to
+  rewrite unless layout was tuned against the old numbers — item labels are one typography
+  step smaller, so fixed-width or `maxWidth`-capped controls need a visual check.
+
 ## Suggested commit boundary
 
 Manual fixes get their own commits, after the codemod phase — with the recommended
@@ -494,5 +596,6 @@ auto-commit flow the six codemod commits already exist by the time any M-section
 do not try to "group" a manual fix into a codemod step's commit (that would mean rewriting
 history and defeats per-step revertability). One commit per M-section (or per coherent
 group, e.g. M3+M4) keeps review and revert straightforward. Only in a non-auto-commit
-inline run, where nothing is committed until the end, may M1/M3/M4/M5 share a commit with
-their related codemod step.
+inline run, where nothing is committed until the end, may M1/M3/M4/M5/M9 share a commit with
+their related codemod step (M9 ↔ step ② `semantic-token-migration`, the same relationship as
+M1 ↔ ①, M3 ↔ ③/④, M4 ↔ ⑤, M5 ↔ ⑥).

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
@@ -578,6 +578,11 @@ keeps working as-is. The items below are what does break, plus one new opportuni
   variant injects no sizing of its own — `iconOnly` must be set explicitly.
   Scan **[decision]**: `SegmentedControlItem[^>]*aria-label=` — an item with an aria-label
   and no text is the icon-only pattern that now needs `iconOnly` on its root.
+  After M1 lands the v4 `@montage-ui/eslint-plugin`, its new
+  `segmented-control-item-uses-name` rule flags missing `aria-label` on items inside an
+  `iconOnly` root at lint time (`recommended`: warn, `strict`: error) — run the project's
+  lint as a second net once the rename phase is done; the line greps above remain the
+  primary scan (the rule only sees same-file roots and items).
 - **`[data-role='segmented-control-item-text']` not rendered under `iconOnly`** — custom CSS
   targeting it applies to labeled items only.
   Scan **[decision]**: `segmented-control-item-text` (include stylesheets).

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
@@ -343,7 +343,7 @@ Report structured data only, no prose.`,
           exists: { type: 'boolean' },
           targetsMatch: { type: 'boolean' },
           stateTargets: { type: 'array', items: { type: 'string' } },
-          autoCommit: { type: 'string' },
+          autoCommit: { type: ['boolean', 'string'] },
           codemodVersion: { type: 'string' },
           stepMarks: { type: 'object', additionalProperties: { type: 'string' } },
           manualMarks: { type: 'object', additionalProperties: { type: 'string' } },
@@ -353,12 +353,27 @@ Report structured data only, no prose.`,
     },
   )
 
-  if (!stateCheck || !stateCheck.exists || !stateCheck.targetsMatch) {
+  // scan-only is legitimate ONLY when the state file itself marks all 6 steps
+  // completed — a stale completedSteps arg alone must not skip a pending codemod.
+  const notCompleted = stateCheck?.stepMarks
+    ? CODEMOD_STEPS.map((s) => s.id).filter(
+        (id) => stateCheck.stepMarks[id] !== 'completed',
+      )
+    : null
+
+  if (
+    !stateCheck ||
+    !stateCheck.exists ||
+    !stateCheck.targetsMatch ||
+    (notCompleted && notCompleted.length > 0)
+  ) {
     stateCheckError = !stateCheck
       ? 'state-file verification agent returned nothing'
       : !stateCheck.exists
         ? `state file missing at ${args.stateFile} — reconcile with the user before recreating it; the recorded targets/autoCommit/codemodVersion cannot be recovered from args`
-        : `state file targets ${JSON.stringify(stateCheck.stateTargets)} disagree with the invocation targets ${targets} — surface both lists to the user and follow the target-lock/addition path in SKILL.md preflight item 1`
+        : !stateCheck.targetsMatch
+          ? `state file targets ${JSON.stringify(stateCheck.stateTargets)} disagree with the invocation targets ${targets} — surface both lists to the user and follow the target-lock/addition path in SKILL.md preflight item 1`
+          : `completedSteps claims all 6 steps are done, but the state file marks ${JSON.stringify(notCompleted)} as not completed — a stale completedSteps list would silently skip pending codemods; refresh it from the state file and re-run`
     aborted = 'state-file-verification'
     log(`Aborting before the scans — ${stateCheckError}`)
   } else {
@@ -419,7 +434,7 @@ Procedure (follow exactly, in order):
 1. Read the state file. If it does NOT exist, report status "failed" with reason "state file missing at step start" — do not assume pending; SKILL.md preflight creates the file before step 1, so a missing file means lost migration state that the orchestrator must reconcile with the user. If it marks steps.${step.id} as "completed", do NOTHING and report status "skipped". This is critical: running a codemod twice corrupts code (e.g. the form-control codemod renames FormControl → FormControlField on a second run). Also compare the state file's \`targets\` list with the targets above: on any mismatch, report status "failed" with BOTH lists — targets recorded in the state file are locked; a different list means completed steps never ran on the new directories (silent under-migration) or would re-run on migrated ones (corruption).
 2. If autoCommit is true, run \`git -C ${args.repoRoot} status --porcelain\` and confirm the working tree is clean apart from the state file. If it is dirty, report status "failed" with the reason — do not run the codemod on top of unrelated changes. If autoCommit is false, still record \`git status --porcelain\` now: the dirty set should consist of earlier completed steps' transform output (plus the state file). If ANY dirty path is not explainable by a completed step's rename surface, report status "failed" with those paths and do NOT run the codemod — the decision belongs to the user (SKILL.md preflight item 3), and running would transform unrelated edits and entangle them with migration changes beyond what the snapshot restore can separate.
 3. Pre-check: ${step.precheck}
-4. If the excluded-files list above is non-empty (only ever populated for form-control-migration), move those files out of the tree NOW — after step 2 has run (the clean-tree check when autoCommit is true, the status recording otherwise) — following the exclusion procedure in codemod-steps.md: record each file's path + content hash first into a temp file (\`echo "$f $(git hash-object "$f")"\` per file, per the procedure's step 1), then \`EXCL=$(mktemp -d)\`, run from the repo root with the repo-relative paths as listed, verify $EXCL is empty first. Before touching anything, verify EVERY listed path exists (\`[ -f "$f" ]\`) — a stale entry (renamed file, wrong-relative path, typo) makes \`git hash-object\` and \`mv\` fail while the codemod still runs over a hand-migrated file, the corruption path; report status "failed" with the missing paths instead. After the move-out, \`find "$EXCL" -type f | wc -l\` must equal the list length, or report "failed". ALSO persist a recovery record at \`${args.repoRoot}/.claude/montage-migration-v4.exclusions.json\` (create the directory first) holding the \`EXCL\` directory and each path with its hash — BEFORE the first \`mv\`: if this agent is killed or times out mid-procedure, that file is the only way to find the user's hand-migrated files again (\`EXCL\` is a shell local pointing into a temp dir nobody recorded). Delete it after the verified move-back in step 8. They are moved back in step 8 — before the state update and commit.
+4. If the excluded-files list above is non-empty (only ever populated for form-control-migration), move those files out of the tree NOW — after step 2 has run (the clean-tree check when autoCommit is true, the status recording otherwise) — following the exclusion procedure in codemod-steps.md: record each file's path + content hash first into a temp file (\`echo "$f $(git hash-object "$f")"\` per file, per the procedure's step 1), then \`EXCL=$(mktemp -d)\`, run from the repo root with the repo-relative paths as listed, verify $EXCL is empty first. Before touching anything, verify EVERY listed path exists (\`[ -f "$f" ]\`) — a stale entry (renamed file, wrong-relative path, typo) makes \`git hash-object\` and \`mv\` fail while the codemod still runs over a hand-migrated file, the corruption path; report status "failed" with the missing paths instead. After the move-out, \`find "$EXCL" -type f | wc -l\` must equal the list length, or report "failed". ALSO persist a recovery record at \`${args.repoRoot}/.claude/montage-migration-v4.exclusions.json\` (create the directory first) holding the \`EXCL\` directory and each path with its hash — BEFORE the first \`mv\`, serialized with the jq command in codemod-steps.md's exclusion procedure (NEVER by interpolating paths into printf/echo: a quote or backslash in a filename corrupts the record exactly when it is needed for recovery): if this agent is killed or times out mid-procedure, that file is the only way to find the user's hand-migrated files again (\`EXCL\` is a shell local pointing into a temp dir nobody recorded). Delete it after the verified move-back in step 8. They are moved back in step 8 — before the state update and commit.
 5. If autoCommit is false, record a pre-step snapshot: \`git -C ${args.repoRoot} stash create\` and note the printed hash (it captures the tree including earlier steps' uncommitted changes; if it prints nothing the tree is clean).
 6. For each element of the targets array, run:
    \`npx -y @montage-ui/codemod@${codemodVersion} ${step.id} <target>\`

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
@@ -17,9 +17,9 @@ export const meta = {
 //   stateFile:     absolute path of the migration state file
 //   referencesDir: absolute path of this skill's references/ directory
 //   autoCommit:    boolean — commit after each completed step
-//   codemodVersion: EXACT npm version (x.y.z) for @montage-ui/codemod, resolved at
-//                    preflight (npm view @montage-ui/codemod version) or read from the
-//                    state file on resume. Dist-tags and ranges are rejected: the value
+//   codemodVersion: EXACT npm version (x.y.z) for @montage-ui/codemod, 4.x only, resolved
+//                    at preflight (npm view '@montage-ui/codemod@^4' version --json → take
+//                    the LAST array element) or read from the state file on resume. Dist-tags and ranges are rejected: the value
 //                    is recorded in the state file, and anything non-exact would
 //                    re-resolve on resume, breaking the same-build guarantee.
 // Optional args:
@@ -32,6 +32,11 @@ export const meta = {
 //                   them; the step agent performs the move-out/move-back exclusion
 //                   procedure around the codemod run.
 
+// The precheck/verify prose below mirrors the per-step sections in
+// references/codemod-steps.md — these strings are what the step agent obeys, the reference
+// is what a human edits, and both carry the corruption warnings. Update them together.
+// Full list of surfaces to update with a step or M-section: SKILL.md → "State file format"
+// → Consistency surfaces (canonical; do not re-enumerate it here or it drifts).
 const CODEMOD_STEPS = [
   {
     id: 'package-name-migration',
@@ -52,20 +57,20 @@ const CODEMOD_STEPS = [
     title: 'CSS variable migration (--wds-* prefix removal)',
     precheck: 'None.',
     verify:
-      'grep for "--wds-" in the targets including .css/.scss/.sass/.less — remaining hits should only be dynamically-built names (template interpolation / string concat), which belong to manual step M3. Then skim the diff for false positives: the rename is a blind prefix substitution, so consumer-defined --wds-* variables were also renamed (declarations and usages stay consistent inside the targets, but note them in verifyFindings). Also grep the diff for partially-rewritten camelCase custom properties (the pattern is lowercase-only, so --wds-myVar comes out as --myVar; use git diff | grep -E "^\\+.*--[a-z0-9-]*[A-Z]" — digits included, --wds-my2Var breaks the same way) and REPAIR them in this step — rename the declaration and every usage consistently; this step owns that fix, M3 is only a safety net. Expect intermediate --card-content-item-* names in the output — they are handled later by manual step M4; do NOT revert them.',
+      'grep for "--wds-" in the targets including .css/.scss/.sass/.less — remaining hits should only be dynamically-built names (template interpolation / string concat), which belong to manual step M3. Then skim the diff for false positives: the rename is a blind prefix substitution, so consumer-defined --wds-* variables were also renamed (declarations and usages stay consistent inside the targets). Handle them like step 2 does: REVERT rewrites of variables the consumer clearly owns rather than leaving them silently renamed, and route ambiguous cases (a consumer namespace that may or may not be Montage-derived) to the user BEFORE this step\'s commit — no later scan looks for them, and after the commit the original names are gone from the tree. Also grep the diff for partially-rewritten camelCase custom properties (the pattern is lowercase-only, so --wds-myVar comes out as --myVar; use git diff | grep -E "^\\+.*--[a-z0-9-]*[A-Z]" — digits included, --wds-my2Var breaks the same way) and REPAIR them in this step — rename the declaration and every usage consistently; this step owns that fix, M3 is only a safety net. Expect intermediate --card-content-item-* names in the output — they are handled later by manual step M4; do NOT revert them.',
   },
   {
     id: 'dom-identifier-migration',
     title: 'DOM identifier migration (wds-component → data-component, region manager ids)',
     precheck: 'None.',
     verify:
-      'grep for "wds-component", "wds-ignore-", "wds-region-manager" in the targets including stylesheets — remaining hits should only be dynamically-built strings (manual step M3). Skim the diff for false positives: replacement is a blind substring pass over any string literal (analytics event names, doc strings). Attribute VALUES like data-component="card-content" are intentionally unchanged — manual step M4 handles them; do NOT rename values here.',
+      'grep for "wds-component", "wds-ignore-", "wds-region-manager" in the targets including stylesheets — remaining hits should only be dynamically-built strings (manual step M3). Skim the diff for false positives: replacement is a blind substring pass over any string literal (analytics event names, doc strings). REVERT rewrites of strings that are not Montage DOM identifiers — a renamed analytics event name is a silent production-behavior change — and route ambiguous ones to the user BEFORE this step\'s commit; no later scan covers them. Attribute VALUES like data-component="card-content" are intentionally unchanged — manual step M4 handles them; do NOT rename values here.',
   },
   {
     id: 'list-card-migration',
     title: 'Card / ListCard naming migration (CardList → ListCard, CardContent → CardBody/ListCardBody)',
     precheck:
-      'grep the targets for files importing BOTH an old Card name AND a new counterpart from @montage-ui/core or @wanteddev/wds, using the FULL rename surface: old = every \\bCard(List|Content)-prefixed value or Props type (CardContent, CardContentItem, CardListContent, *Skeleton and *Props forms, CardList, CardListSkeleton); new = ListCard*, CardBody*, CardRow* and their Props. The global renames hit all of these unconditionally, so any old/new pair in one file produces a duplicate import specifier — report such files as "failed" with the file list so they can be cleaned up first, unless there are none. Also flag files importing the SAME old name via two specifiers (plain + alias, e.g. `CardContent` and `CardContent as CC`; also the list-context names CardThumbnail*/CardTitle*/CardCaption* and Skeleton forms, where the leftover fails silently as a wrong-family name): the lookup checks @montage-ui/core before @wanteddev/wds and keeps only the last specifier in file order within the winning source, leaving the other one and its usages untouched, and a re-run mis-renames the leftovers — such files must be simplified to a single specifier first.',
+      'grep the targets for files importing BOTH an old Card name AND a new counterpart from @montage-ui/core or @wanteddev/wds, using the subset of the rename surface that can produce a duplicate specifier: old = every \\bCard(List|Content)-prefixed value or Props type (CardContent, CardContentItem, CardListContent, *Skeleton and *Props forms, CardList, CardListSkeleton); new = ListCard*, CardBody*, CardRow* and their Props. (The CardThumbnail*/CardTitle*/CardCaption* family renames only when a CardList/CardListSkeleton import is present, which \\bCard(List|Content) already matches, so the subset covers it transitively.) The global renames hit all of these unconditionally, so any old/new pair in one file produces a duplicate import specifier. Before reporting, inspect each flagged file: confirm BOTH the old and the new name resolve to an import from @montage-ui/core or @wanteddev/wds. A locally defined or third-party CardBody/CardRow, or a hit in a .md/.snap/.css file, is NOT a mixed file — drop it from the list and note it in verifyFindings. Report "failed" for BOTH surviving classes — files with a genuine montage old/new pair AND files importing the same old montage name via two specifiers — since each needs its own cleanup before the codemod may run. Apply the same false-positive triage to both, so a locally defined / third-party name or a .md/.snap/.css hit can never deadlock the phase (the orchestrator would otherwise re-run into the same abort forever); if nothing survives triage, proceed. Also flag files importing the SAME old name via two specifiers (plain + alias, e.g. `CardContent` and `CardContent as CC`; also the list-context names CardThumbnail*/CardTitle*/CardCaption* and Skeleton forms, where the leftover fails silently as a wrong-family name): the lookup checks @montage-ui/core before @wanteddev/wds and keeps only the last specifier in file order within the winning source, leaving the other one and its usages untouched, and a re-run mis-renames the leftovers — such files must be simplified to a single specifier first.',
     verify:
       'grep -E "\\bCard(List|Content)" over the targets — expect zero hits (prefix pattern: \\bCardContent\\b would miss CardContentProps/CardContentItemSkeleton leftovers; the prefix form matches no new name, ListCard* included). Remaining hits live in gate-skipped files (namespace imports, re-exports, deep/subpath imports — the codemod only transforms files importing from exactly @montage-ui/core or @wanteddev/wds) or duplicate-specifier files the pre-check missed (see codemod-steps.md step 5) — no M-section covers them; fix them by hand NOW as part of this step, never by re-running the codemod, but first confirm each hit actually comes from a montage source: a same-named identifier defined locally or imported from another library is NOT a migration leftover, leave it alone. Also grep for non-JSX identifier references (e.g. component={CardBody}) in files that render ListCard; report them in verifyFindings for manual step M4 review.',
   },
@@ -73,20 +78,20 @@ const CODEMOD_STEPS = [
     id: 'form-control-migration',
     title: 'Form Control naming migration (FormField → FormControl → FormControlField swap)',
     precheck:
-      'THIS CODEMOD CORRUPTS ALREADY-MIGRATED CODE. Find files referencing FormControl or FormControlProps WITHOUT also referencing FormField/FormFieldProps — two file-level greps, `\\bFormControl(Props)?\\b` minus `\\bFormField(Props)?\\b`, and diff the file lists (a single-line import-statement grep misses multi-line imports; the (Props)? alternates matter — `\\bFormControl\\b` alone misses a type-only FormControlProps import, which the codemod still corrupts to FormControlFieldProps; see the "Step 6 — form-control-migration" pre-check in the codemod-steps.md reference next to manual-migrations.md). Then run the SECOND pre-check from the same section — intersect (comm -12) files matching the new sub-component names `\\bFormControl(Field|Label|Message|NegativeMessage|PositiveMessage|MessageAccessory)` with files matching `\\bFormField(Props)?\\b`: a pure v3 file never references the new names, so every hit is mixed — half-migrated code must be reconciled to one API first; FormField appearing only in comments/strings means the file is hand-migrated and needs exclusion. Inspect each: if the file already uses the NEW v4 API (root <FormControl> wrapping <FormControlField>, imports ANY FormControl* sub-component — FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlPositiveMessage, FormControlMessageAccessory — or imports only the FormControlProps type with no JSX at all), it was hand-migrated and must be excluded via the move-out/move-back procedure (codemod-steps.md). Files already listed in the user-confirmed excluded-files list are handled in procedure step 4 — proceed. Any hand-migrated file NOT in that list: report "failed" with the file list so the orchestrator can confirm the exclusions with the user and re-run the workflow with excludeFiles set. A v3 file importing only the old FormControl slot (no other Form* imports, <FormControl> used inside another file\'s FormField) is safe.',
+      'THIS CODEMOD CORRUPTS ALREADY-MIGRATED CODE. Find files referencing FormControl or FormControlProps WITHOUT also referencing FormField/FormFieldProps — two file-level greps, `\\bFormControl(Props)?\\b` minus `\\bFormField(Props)?\\b`, and diff the file lists (a single-line import-statement grep misses multi-line imports; the (Props)? alternates matter — `\\bFormControl\\b` alone misses a type-only FormControlProps import, which the codemod still corrupts to FormControlFieldProps; see the "Step 6 — form-control-migration" pre-check in the codemod-steps.md reference next to manual-migrations.md). Then run the SECOND pre-check from the same section — intersect (comm -12) files matching the new sub-component names `\\bFormControl(Field|Label|Message|NegativeMessage|PositiveMessage|MessageAccessory)` with files matching `\\bFormField(Props)?\\b`: a pure v3 file never references the new names, so every hit is mixed — half-migrated code must be reconciled to one API first; FormField appearing only in comments/strings means the file is hand-migrated and needs exclusion. Inspect each: if the file already uses the NEW v4 API (root <FormControl> wrapping <FormControlField>, imports ANY FormControl* sub-component — FormControlField, FormControlLabel, FormControlMessage, FormControlNegativeMessage, FormControlPositiveMessage, FormControlMessageAccessory — or imports only the FormControlProps type with no JSX at all), it was hand-migrated and must be excluded via the move-out/move-back procedure (codemod-steps.md). For files already listed in the user-confirmed excluded-files list: reconcile rather than blanket-proceed — every file this precheck flags must appear in the supplied list, and every supplied path must exist on disk; report "failed" on either mismatch (a subset list silently under-excludes, a stale path silently un-excludes). Any hand-migrated file NOT in that list: report "failed" with the file list so the orchestrator can confirm the exclusions with the user and re-run the workflow with excludeFiles set. A v3 file importing only the old FormControl slot (no other Form* imports, <FormControl> used inside another file\'s FormField) is safe.',
     verify:
-      'grep -E "\\bForm(Field|Label|Message|ErrorMessage)" over the targets — expect zero hits (prefix pattern: \\bFormField\\b would miss FormFieldProps leftovers; the prefix form matches no FormControl* name). Remaining hits live in gate-skipped files (namespace imports like M.FormField, re-exports, subpath imports) — no M-section covers them; fix them by hand NOW as part of this step, WITHOUT re-running the codemod, but first confirm each hit actually comes from a montage source: a same-named identifier defined locally or imported from another library is NOT a migration leftover, leave it alone. NOTE: "FormControl" hits are EXPECTED after this step (it is the new root name); do not flag them and NEVER re-run this codemod to "fix" them. Residual the grep cannot see: in gate-skipped files (namespace/subpath imports) an OLD inner-slot FormControl survives under the same literal name but means the v4 field slot — additionally inspect namespace imports of montage sources (import * as X from @montage-ui/core or @wanteddev/wds) and subpath imports for .FormControl member usages, and rename true inner-slot usages to FormControlField by hand.',
+      'grep -E "\\bForm(Field|Label|Message|ErrorMessage)" over the targets — expect zero hits (prefix pattern: \\bFormField\\b would miss FormFieldProps leftovers; the prefix form matches no FormControl* name). Remaining hits live in gate-skipped files (namespace imports like M.FormField, re-exports, subpath imports) — no M-section covers them; fix them by hand NOW as part of this step, WITHOUT re-running the codemod, but first confirm each hit actually comes from a montage source: a same-named identifier defined locally or imported from another library is NOT a migration leftover, leave it alone. NOTE: this grep can never emit a FormControl hit (\\bForm has no word boundary inside FormControlMessage), so never treat "FormControl is expected" as a reason to dismiss something it reported. A FormControl occurrence you find by other means is either the correct new root or an old inner-slot usage in a gate-skipped file — see the namespace/subpath inspection below. NEVER re-run this codemod over either. Hits inside the user-confirmed excluded files are EXPECTED too — those files are hand-migrated, so their Form* mentions are comments, strings, or deliberate back-compat type aliases; report them in verifyFindings and NEVER edit an excluded file. Residual the grep cannot see: in gate-skipped files (namespace/subpath imports) an OLD inner-slot FormControl survives under the same literal name but means the v4 field slot — additionally inspect namespace imports of montage sources (import * as X from @montage-ui/core or @wanteddev/wds) and subpath imports for .FormControl member usages, and rename true inner-slot usages to FormControlField by hand.',
   },
 ]
 
-// Kept in sync with the M-sections in references/manual-migrations.md, the state-file
-// templates in SKILL.md and STATE_FILE_TEMPLATE below — update all of them together.
+// Kept in sync with the M-sections in references/manual-migrations.md and STATE_FILE_TEMPLATE
+// below — see SKILL.md → "State file format" → Consistency surfaces for the canonical list.
 const MANUAL_SCAN_SECTIONS = [
   { id: 'M1', title: 'Package references outside import declarations' },
   { id: 'M2', title: 'Theme tokens now return var(--...) strings (JS arithmetic breakage)' },
-  { id: 'M3', title: 'CSS variable / DOM identifier leftovers (dynamic names, E2E, configs)' },
-  { id: 'M4', title: 'Card / ListCard follow-ups (non-JSX refs, data-component values)' },
-  { id: 'M5', title: 'FormControl follow-ups (message typography variant/weight)' },
+  { id: 'M3', title: 'CSS variable / DOM identifier leftovers (dynamic names, out-of-target files such as E2E specs and snapshots, camelCase safety net)' },
+  { id: 'M4', title: 'Card / ListCard follow-ups (non-JSX refs, cross-file context, data-component values, old Card names outside the targets)' },
+  { id: 'M5', title: 'FormControl follow-ups (message typography variant/weight, old Form names outside the targets)' },
   { id: 'M6', title: 'Modal bottom sheet behavior change (onVisibilityChange removal, peekHeight)' },
   { id: 'M7', title: 'TextField changes (size, TextFieldButton variant, wrapper DOM)' },
   {
@@ -103,6 +108,11 @@ const MANUAL_SCAN_SECTIONS = [
     id: 'M10',
     title:
       'ThemeProvider cookie storage (storageKey → cookie.key, direct next-themes usage, cookie.domain for subdomain sharing)',
+  },
+  {
+    id: 'M11',
+    title:
+      'SegmentedControl changes (variant removed incl. outlined, leadingContent → leadingIcon, trailingContent removed, iconOnly for icon-only usages)',
   },
 ]
 
@@ -153,7 +163,12 @@ const SCAN_RESULT_SCHEMA = {
 const codemodVersion = args.codemodVersion
 if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(String(codemodVersion))) {
   throw new Error(
-    `codemodVersion must be an exact x.y.z version (got ${JSON.stringify(codemodVersion)}) — resolve dist-tags/ranges at preflight (npm view @montage-ui/codemod version) or read the state file's recorded value on resume`,
+    `codemodVersion must be an exact x.y.z version (got ${JSON.stringify(codemodVersion)}) — resolve at preflight with \`npm view '@montage-ui/codemod@^4' version --json\` and take the LAST element of the returned array — the unscoped \`npm view @montage-ui/codemod version\` returns the \`latest\` dist-tag (wrong major once 5.x ships) and the un-jsonned range form prints one \`pkg@x.y.z 'x.y.z'\` line PER matching version — or read the state file's recorded value on resume`,
+  )
+}
+if (Number(String(codemodVersion).split('.')[0]) !== 4) {
+  throw new Error(
+    `codemodVersion ${codemodVersion} is outside the 4.x line this skill covers — the v3→v4 transforms ship in @montage-ui/codemod 4.x (a 3.x CLI rejects every transform name with "Invalid transform choice"; a 5.x CLI carries no guarantee these transform names still exist or behave identically). Resolve with \`npm view '@montage-ui/codemod@^4' version\` at preflight`,
   )
 }
 if (!Array.isArray(args.targets) || args.targets.length === 0) {
@@ -166,17 +181,59 @@ for (const t of args.targets) {
     )
   }
 }
-{
-  // Nested targets make every codemod run twice over the nested subtree — the exact
-  // run-once corruption path (form-control-migration would double-swap there).
-  const normalized = args.targets.map((t) => String(t).replace(/\/+$/, ''))
-  for (const a of normalized) {
-    for (const b of normalized) {
-      if (a !== b && (b + '/').startsWith(a + '/')) {
-        throw new Error(
-          `targets must be disjoint directories — ${JSON.stringify(b)} is nested inside ${JSON.stringify(a)}, so each codemod would run twice over the nested subtree (the run-once corruption path); keep only the outer directory`,
-        )
-      }
+// Canonicalize targets BEFORE the disjointness check: 'src', './src', 'src/', and
+// '<repoRoot>/src' are the same tree, and a duplicate spelling would run every codemod
+// twice over it — the same run-once corruption path as a nested target. Workflow scripts
+// have no path module, so normalize by string.
+const canonicalTargets = (() => {
+  const repoRootNormalized = String(args.repoRoot || '').replace(/\/+$/, '')
+  const seen = new Map()
+
+  for (const raw of args.targets) {
+    let t = String(raw).replace(/\/{2,}/g, '/').replace(/\/+$/, '')
+
+    if (t.split('/').includes('..')) {
+      throw new Error(
+        `target ${JSON.stringify(raw)} contains a ".." segment — it may point outside the migrated tree; pass a plain path inside the repo`,
+      )
+    }
+
+    t = t.replace(/^\.\//, '')
+
+    if (repoRootNormalized && (t === repoRootNormalized || t.startsWith(repoRootNormalized + '/'))) {
+      t = t.slice(repoRootNormalized.length + 1)
+    }
+
+    if (t === '' || t === '.') {
+      t = '.'
+    }
+
+    if (t.startsWith('/') || /^[A-Za-z]:[\\/]/.test(t)) {
+      throw new Error(
+        `target ${JSON.stringify(raw)} resolves outside repoRoot ${JSON.stringify(args.repoRoot)} — every codemod must run inside the migrated repo, or a failed step cannot be restored with \`git -C <repoRoot> checkout\` and the tree is left half-transformed (the corruption path)`,
+      )
+    }
+
+    const previous = seen.get(t)
+    if (previous !== undefined) {
+      throw new Error(
+        `duplicate targets point at the same tree — ${JSON.stringify(previous)} and ${JSON.stringify(raw)} both resolve to ${JSON.stringify(t)}, so each codemod would run twice over it (the run-once corruption path); list each directory exactly once`,
+      )
+    }
+    seen.set(t, raw)
+  }
+
+  return [...seen.keys()]
+})()
+
+for (const a of canonicalTargets) {
+  for (const b of canonicalTargets) {
+    // Nested targets make every codemod run twice over the nested subtree — the exact
+    // run-once corruption path (form-control-migration would double-swap there).
+    if (a !== b && (b + '/').startsWith(a === '.' ? '' : a + '/')) {
+      throw new Error(
+        `targets must be disjoint directories — ${JSON.stringify(b)} is nested inside ${JSON.stringify(a)}, so each codemod would run twice over the nested subtree (the run-once corruption path); keep only the outer directory`,
+      )
     }
   }
 }
@@ -198,19 +255,27 @@ for (const f of excludeFilesInput) {
       `excludeFiles entry ${JSON.stringify(f)} must be a repo-relative path — the move-out/move-back procedure runs from the repo root, and an absolute path would be restored to the wrong location`,
     )
   }
+  if (String(f).split('/').includes('..')) {
+    throw new Error(
+      `excludeFiles entry ${JSON.stringify(f)} contains a ".." segment — it points outside the migrated tree, and the move-out/move-back procedure would restore it to the wrong location`,
+    )
+  }
 }
 
-const targets = JSON.stringify(args.targets)
+// Canonical targets, never args.targets: the raw list may carry duplicate spellings of one
+// tree, and the step agents must receive the same list the disjointness check validated.
+const targets = JSON.stringify(canonicalTargets)
 const excludeFilesJson = JSON.stringify(excludeFilesInput)
 
-// Kept in sync with the templates in SKILL.md ("State file format") and the M-list in
-// MANUAL_SCAN_SECTIONS above — adding a step or M-section means updating all three.
+// Kept in sync with the template in SKILL.md ("State file format") and MANUAL_SCAN_SECTIONS
+// above — see that section's Consistency surfaces list for every surface to update.
 const STATE_FILE_TEMPLATE = `---
 migration: montage-v3-to-v4
 targets:
-${args.targets.map((t) => '  - ' + t).join('\n')}
+${canonicalTargets.map((t) => '  - ' + t).join('\n')}
 autoCommit: ${args.autoCommit}
 codemodVersion: ${codemodVersion}
+excludeFiles:${excludeFilesInput.length ? '\n' + excludeFilesInput.map((f) => '  - ' + f).join('\n') : ' []'}
 steps:
   package-name-migration: pending
   semantic-token-migration: pending
@@ -229,14 +294,83 @@ manual:
   M8: pending
   M9: pending
   M10: pending
+  M11: pending
 ---`
 
-const completedSteps = args.completedSteps || []
+if (args.completedSteps !== undefined && !Array.isArray(args.completedSteps)) {
+  throw new Error(
+    'completedSteps must be an array of step ids — a string would substring-match through .includes() and skip steps that were never completed',
+  )
+}
+// Deduplicated on read: the all-completed gate below compares LENGTH against
+// CODEMOD_STEPS, so a list with repeats would satisfy it without covering every step.
+const completedSteps = [...new Set(args.completedSteps || [])]
+{
+  const knownStepIds = new Set(CODEMOD_STEPS.map((s) => s.id))
+  for (const id of completedSteps) {
+    if (!knownStepIds.has(id)) {
+      throw new Error(
+        `completedSteps contains unknown step id ${JSON.stringify(id)} — a typo silently skips nothing and lets a completed step re-run (the corruption path); use the exact ids: ${[...knownStepIds].join(', ')}`,
+      )
+    }
+  }
+}
 
 const stepResults = []
 let aborted = null
+let stateCheckReport = null
+let stateCheckError = null
+
+// Every step being skipped means no step agent runs, so nothing would verify the state
+// file or the targets it records — the scan-only re-run path in SKILL.md Step 2 lands here.
+// Spend one cheap agent on that verification instead of proceeding blind.
+if (completedSteps.length === CODEMOD_STEPS.length) {
+  const stateCheck = await agent(
+    `Read-only verification (do not edit any file, do not run any codemod).
+
+1. Read the migration state file at ${args.stateFile}. If it does not exist, report exists: false and stop.
+2. Compare its \`targets:\` list with this invocation's targets ${targets} (already canonicalized: no trailing slashes, no './' prefix, repo-relative to ${args.repoRoot}). Report targetsMatch and both lists.
+3. Report the recorded \`autoCommit\`, \`codemodVersion\`, every \`steps:\` mark, and every \`manual:\` mark verbatim.
+
+Report structured data only, no prose.`,
+    {
+      label: 'verify:state-file',
+      phase: 'Codemods',
+      schema: {
+        type: 'object',
+        required: ['exists', 'targetsMatch', 'notes'],
+        properties: {
+          exists: { type: 'boolean' },
+          targetsMatch: { type: 'boolean' },
+          stateTargets: { type: 'array', items: { type: 'string' } },
+          autoCommit: { type: 'string' },
+          codemodVersion: { type: 'string' },
+          stepMarks: { type: 'object', additionalProperties: { type: 'string' } },
+          manualMarks: { type: 'object', additionalProperties: { type: 'string' } },
+          notes: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+  )
+
+  if (!stateCheck || !stateCheck.exists || !stateCheck.targetsMatch) {
+    stateCheckError = !stateCheck
+      ? 'state-file verification agent returned nothing'
+      : !stateCheck.exists
+        ? `state file missing at ${args.stateFile} — reconcile with the user before recreating it; the recorded targets/autoCommit/codemodVersion cannot be recovered from args`
+        : `state file targets ${JSON.stringify(stateCheck.stateTargets)} disagree with the invocation targets ${targets} — surface both lists to the user and follow the target-lock/addition path in SKILL.md preflight item 1`
+    aborted = 'state-file-verification'
+    log(`Aborting before the scans — ${stateCheckError}`)
+  } else {
+    stateCheckReport = stateCheck
+    log('state file verified (targets match, all 6 steps completed) — running scans only')
+  }
+}
 
 for (const step of CODEMOD_STEPS) {
+  // A failed state-file verification must never be followed by a codemod invocation.
+  if (aborted) break
+
   if (completedSteps.includes(step.id)) {
     // Deterministic orchestrator-level skip. The step agent's own state-file check
     // (procedure step 1) stays as the second layer, guarding runs launched with a
@@ -281,22 +415,23 @@ User-confirmed excluded files (form-control-migration only; repo-relative): ${st
 
 Procedure (follow exactly, in order):
 
+0. Check for \`.claude/montage-migration-v4.exclusions.json\` (relative to ${args.repoRoot}). If it EXISTS, a previous step-⑥ run died between its move-out and move-back: the user's hand-migrated files are sitting in the recorded \`excl\` temp directory and the working tree shows them as DELETED. Restore every recorded path from \`excl\`, verify each file's \`git hash-object\` against the recorded \`hash\`, delete the record, and report status "failed" with the recovery outcome in verifyFindings. Do NOT run any codemod in that run, and never let the deletions reach a commit — the generic dirty-tree handling in step 2 would otherwise commit away files the user explicitly ring-fenced.
 1. Read the state file. If it does NOT exist, report status "failed" with reason "state file missing at step start" — do not assume pending; SKILL.md preflight creates the file before step 1, so a missing file means lost migration state that the orchestrator must reconcile with the user. If it marks steps.${step.id} as "completed", do NOTHING and report status "skipped". This is critical: running a codemod twice corrupts code (e.g. the form-control codemod renames FormControl → FormControlField on a second run). Also compare the state file's \`targets\` list with the targets above: on any mismatch, report status "failed" with BOTH lists — targets recorded in the state file are locked; a different list means completed steps never ran on the new directories (silent under-migration) or would re-run on migrated ones (corruption).
-2. If autoCommit is true, run \`git -C ${args.repoRoot} status --porcelain\` and confirm the working tree is clean apart from the state file. If it is dirty, report status "failed" with the reason — do not run the codemod on top of unrelated changes. If autoCommit is false, still record \`git status --porcelain\` now: the dirty set should consist of earlier completed steps' transform output (plus the state file); report anything unexplained in verifyFindings BEFORE running — the codemod would transform unrelated edits and entangle them with migration changes.
+2. If autoCommit is true, run \`git -C ${args.repoRoot} status --porcelain\` and confirm the working tree is clean apart from the state file. If it is dirty, report status "failed" with the reason — do not run the codemod on top of unrelated changes. If autoCommit is false, still record \`git status --porcelain\` now: the dirty set should consist of earlier completed steps' transform output (plus the state file). If ANY dirty path is not explainable by a completed step's rename surface, report status "failed" with those paths and do NOT run the codemod — the decision belongs to the user (SKILL.md preflight item 3), and running would transform unrelated edits and entangle them with migration changes beyond what the snapshot restore can separate.
 3. Pre-check: ${step.precheck}
-4. If the excluded-files list above is non-empty (only ever populated for form-control-migration), move those files out of the tree NOW — after step 2 has run (the clean-tree check when autoCommit is true, the status recording otherwise) — following the exclusion procedure in codemod-steps.md: record each file's path + content hash first into a temp file (\`echo "$f $(git hash-object "$f")"\` per file, per the procedure's step 1), then \`EXCL=$(mktemp -d)\`, run from the repo root with the repo-relative paths as listed, verify $EXCL is empty first. They are moved back in step 8 — before the state update and commit.
+4. If the excluded-files list above is non-empty (only ever populated for form-control-migration), move those files out of the tree NOW — after step 2 has run (the clean-tree check when autoCommit is true, the status recording otherwise) — following the exclusion procedure in codemod-steps.md: record each file's path + content hash first into a temp file (\`echo "$f $(git hash-object "$f")"\` per file, per the procedure's step 1), then \`EXCL=$(mktemp -d)\`, run from the repo root with the repo-relative paths as listed, verify $EXCL is empty first. Before touching anything, verify EVERY listed path exists (\`[ -f "$f" ]\`) — a stale entry (renamed file, wrong-relative path, typo) makes \`git hash-object\` and \`mv\` fail while the codemod still runs over a hand-migrated file, the corruption path; report status "failed" with the missing paths instead. After the move-out, \`find "$EXCL" -type f | wc -l\` must equal the list length, or report "failed". ALSO persist a recovery record at \`${args.repoRoot}/.claude/montage-migration-v4.exclusions.json\` (create the directory first) holding the \`EXCL\` directory and each path with its hash — BEFORE the first \`mv\`: if this agent is killed or times out mid-procedure, that file is the only way to find the user's hand-migrated files again (\`EXCL\` is a shell local pointing into a temp dir nobody recorded). Delete it after the verified move-back in step 8. They are moved back in step 8 — before the state update and commit.
 5. If autoCommit is false, record a pre-step snapshot: \`git -C ${args.repoRoot} stash create\` and note the printed hash (it captures the tree including earlier steps' uncommitted changes; if it prints nothing the tree is clean).
 6. For each element of the targets array, run:
    \`npx -y @montage-ui/codemod@${codemodVersion} ${step.id} <target>\`
    from ${args.repoRoot}. The command is non-interactive when both the transform name and the path are passed. Capture the output; jscodeshift prints per-file errors — treat any "ERR" as a failure.
 7. If the codemod failed partway, NEVER leave a half-transformed tree (re-running a codemod over one is the documented corruption path for steps 5–6 — list-card-migration and form-control-migration — and excluding the partially-transformed files later is the WRONG fix): when autoCommit is true (tree was clean at step start), restore with \`git -C ${args.repoRoot} checkout -- <each target>\`; when autoCommit is false, restore the targets from the snapshot recorded in step 5 (\`git -C ${args.repoRoot} checkout <snapshot-hash> -- <each target>\` — this reverts only this step's changes; earlier steps' uncommitted work is inside the snapshot; if no hash was printed the tree was clean, so plain \`git checkout -- <each target>\` is equivalent). Move any excluded files back per step 8, then report status "failed" with the error.
-8. If files were moved out in step 4: move each back to its exact original path, re-run the path+hash command and diff against the recording from step 4 — must be empty (do NOT rely on a plain \`git status\` no-diff check — it is only meaningful when autoCommit is true; with autoCommit false the excluded files legitimately carry earlier steps' uncommitted changes and show as modified), and confirm the temp dir is empty. Do this BEFORE the state update and commit — a commit must never contain their deletions.
-9. Post-step verification: ${step.verify} Record findings in verifyFindings; apply only the fixes the verification instructions explicitly assign to this step — leave everything marked M1–M10 to the manual phase.
-10. Update the state file: set steps.${step.id} to "completed". If the file is missing, recreate it from the template below FIRST — but set every step in this list to "completed" before writing (they all ran, either in earlier sessions or earlier in THIS run; an all-pending file would trigger corrupting re-runs on a later resume): ${stepsDoneByNow}. Report the recreation AND the recreated targets list in verifyFindings — the targets come from this invocation's args, not the lost original, so the orchestrator must confirm them with the user. Ensure the file's path is present in .git/info/exclude (append only if missing) so it never enters commits. Template:
+8. If files were moved out in step 4: move each back to its exact original path, re-run the path+hash command and diff against the recording from step 4 — must be empty (do NOT rely on a plain \`git status\` no-diff check — it is only meaningful when autoCommit is true; with autoCommit false the excluded files legitimately carry earlier steps' uncommitted changes and show as modified), and confirm the temp dir is empty. If the hash diff is NON-empty, or \`find "$EXCL" -type f\` still lists files, STOP: report status "failed" with the unrestored paths, KEEP the recovery record, do NOT update the state file and do NOT commit — the orchestrator must surface this to the user. Only on a clean move-back, delete the \`.claude/montage-migration-v4.exclusions.json\` recovery record from step 4. Do this BEFORE the state update and commit — a commit must never contain their deletions.
+9. Post-step verification: ${step.verify} Record findings in verifyFindings; apply only the fixes the verification instructions explicitly assign to this step — leave everything marked M1–M11 to the manual phase.
+10. Update the state file: set steps.${step.id} to "completed", and — for form-control-migration with a non-empty excluded-files list — write that list to the state file\'s \`excludeFiles:\` key, so later sessions can tell a ring-fenced file from a migration leftover (the final verification depends on it). If the file is missing, recreate it from the template below FIRST — but set every step in this list to "completed" before writing (they all ran, either in earlier sessions or earlier in THIS run; an all-pending file would trigger corrupting re-runs on a later resume): ${stepsDoneByNow}. Report the recreation in verifyFindings together with the recreated \`targets\`, \`autoCommit\`, \`codemodVersion\` AND the fact that every \`manual:\` mark was reset to "pending" — all of it comes from this invocation's args and the template, not the lost original, so the orchestrator must confirm each with the user (a finished M-section silently reset to pending is as damaging as a wrong targets list). Ensure the file's path is ignored so it never enters commits: resolve the exclude file with \`git -C ${args.repoRoot} rev-parse --git-path info/exclude\` (in a linked worktree or submodule \`.git\` is a FILE, so a literal .git/info/exclude path fails), append the entry only if missing — do the same for \`.claude/montage-migration-v4.exclusions.json\`, the step-⑥ recovery record, which must never enter a commit either — then confirm both with \`git -C ${args.repoRoot} check-ignore -q <path>\`. Template:
 ${STATE_FILE_TEMPLATE}
-11. If autoCommit is true: \`git -C ${args.repoRoot} add -A && git -C ${args.repoRoot} commit -m "chore(montage): v4 codemod — ${step.id}"\` and record the commit hash. The state file is excluded via .git/info/exclude, so it must not appear in the commit.
+11. Refuse to commit while \`${args.repoRoot}/.claude/montage-migration-v4.exclusions.json\` exists — its presence means excluded files are still moved out, and \`git add -A\` would commit their deletion. If autoCommit is true: \`git -C ${args.repoRoot} add -A && git -C ${args.repoRoot} commit -m "chore(montage): v4 codemod — ${step.id}"\` and record the commit hash. The state file is ignored via the resolved \`info/exclude\` path from step 10, so it must not appear in the commit — if \`git check-ignore\` there reported it as NOT ignored, fix the ignore entry before committing rather than committing the state file.
 
-Report filesChanged from \`git diff --stat\` (or the commit stat). Your final output is structured data for the orchestrator, not prose.`,
+Report filesChanged for THIS step only: with autoCommit true, use the commit stat; with autoCommit false, diff against the step-5 snapshot (\`git -C ${args.repoRoot} diff --stat <snapshot-hash> -- <each target>\`) — a plain \`git diff --stat\` there also counts every earlier step's uncommitted output and would report an inflated, cumulative number. Your final output is structured data for the orchestrator, not prose.`,
     { label: `codemod:${step.id}`, phase: 'Codemods', schema: STEP_RESULT_SCHEMA },
   )
 
@@ -320,7 +455,7 @@ if (!aborted) {
 
 Section: ${section.id} — ${section.title}
 
-1. Read the file preamble (everything before the first "## M" heading) AND the section "${section.id}" in ${args.referencesDir}/manual-migrations.md — the preamble holds operational caveats (patterns starting with "-" must be passed via \`--\` or -e, portability notes) without which some scans silently fail.
+1. Read the file preamble (everything before the first "## M" heading) AND the section "${section.id}" in ${args.referencesDir}/manual-migrations.md — the preamble holds operational caveats (patterns starting with "-" must be passed via \`--\` or -e, portability notes) without which some scans silently fail. If the section defines a pattern BY REFERENCE to another file (M9's [zero] scan cites the two step-2 verification greps; M3's camelCase note points at step 3's diff review, and M4/M5 reuse step ⑤/⑥'s verify patterns for their out-of-target scans), also read the referenced step section in ${args.referencesDir}/codemod-steps.md and use the verbatim patterns from there — a by-reference pattern you do not fetch is a scan silently not run.
 2. Run the section's scan patterns over the repo. Scan the WHOLE repo (configs, E2E tests, stylesheets), not just source targets, but skip .git, node_modules, .next, dist, build output, and lockfiles.
 3. For each hit, assess it against the fix rules: does it actually need the manual migration, or is it a false positive (e.g. theme token used inside a CSS template literal is fine)? Record file, line, a one-line snippet, and your assessment.
 4. Do not fix anything. Your final output is structured data for the orchestrator.`,
@@ -332,6 +467,8 @@ Section: ${section.id} — ${section.title}
 
 return {
   aborted,
+  stateCheck: stateCheckReport,
+  stateCheckError,
   steps: stepResults.filter(Boolean),
   manualScan: scanResults.filter(Boolean),
 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -582,6 +582,8 @@ Figma 스펙에 맞춰 `variant`가 제거되고 아이콘 전용 모드(`iconOn
 
 `TextAreaContent`의 `variant="segmented-control"`도 내부에서 별도 스타일을 주입하지 않으므로, TextArea 안에 배치하는 `SegmentedControl`에는 `iconOnly`를 직접 지정해야 합니다.
 
+`aria-label` 누락은 `@montage-ui/eslint-plugin`에 새로 추가된 `segmented-control-item-uses-name` 규칙이 잡아줍니다. `recommended` 설정에서는 warn, `strict` 설정에서는 error로 동작하므로, v4 플러그인으로 업그레이드하면 기존 코드에서 새 경고·에러가 발생할 수 있습니다.
+
 #### 사이즈·토큰 변경
 
 루트 요소 — 높이는 그대로이고 radius와 padding이 변경되었습니다.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -543,6 +543,75 @@ const [value, setValue] = useState('');
 
 하단 영역의 DOM 구조가 재구성되었고, character counter 관련 `data-role`(`text-area-content-character-counter-length` / `-divider` / `-max-length`)이 제거되었습니다. 해당 `data-role`이나 `[data-role='text-area-bottom-area']` 내부 구조를 직접 타겟해 커스텀했다면 새 구조에 맞게 수정해야 합니다.
 
+### SegmentedControl
+
+Figma 스펙에 맞춰 `variant`가 제거되고 아이콘 전용 모드(`iconOnly`)가 추가되었습니다. 하위 컴포넌트의 콘텐츠 prop도 정리되었으며, 사이즈별 세부 수치가 토큰 기반으로 변경되었습니다.
+
+#### `variant` prop 제거
+
+`variant="solid" | "outlined"` 중 `outlined`가 제거되고 solid 단일 형태로 통일되어 `variant` prop이 제거되었습니다.
+
+- AS-IS: `<SegmentedControl variant="solid">` / `<SegmentedControl variant="outlined">`
+- TO-BE: `<SegmentedControl>` — `variant` 속성을 제거하세요.
+
+`outlined`를 대체하는 값은 없습니다. `outlined` 전용으로 렌더되던 스타일(투명 배경 + 외곽선, 아이템 사이 구분선, 선택 항목의 brand 톤 배경·테두리)이 모두 제거되고, 선택 항목은 solid와 동일하게 흰색 thumb으로 표시됩니다. 또한 `outlined`에서는 동작하지 않았던 thumb 이동 애니메이션이 적용됩니다. 시각적 변화가 크므로 `outlined`를 사용했던 화면은 QA가 필요합니다.
+
+#### `SegmentedControlItem`의 `leadingContent` → `leadingIcon`, `trailingContent` 제거
+
+- AS-IS: `<SegmentedControlItem leadingContent={<IconList />} trailingContent={<IconBlank />}>`
+- TO-BE: `<SegmentedControlItem leadingIcon={<IconList />}>`
+
+`trailingContent`는 대체 prop 없이 제거되었습니다. 뒤쪽 콘텐츠가 필요하다면 children 안에 직접 배치해야 합니다.
+
+#### `iconOnly` prop 추가
+
+텍스트 없이 아이콘만 노출하는 모드가 추가되었습니다. `iconOnly`를 지정하면 아이콘을 `SegmentedControlItem`의 children으로 전달하며, 텍스트가 없으므로 각 아이템에 `aria-label`을 직접 지정해야 합니다.
+
+```tsx
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0" aria-label="Board view">
+    <IconColumn />
+  </SegmentedControlItem>
+  <SegmentedControlItem value="1" aria-label="List view">
+    <IconList />
+  </SegmentedControlItem>
+</SegmentedControl>
+```
+
+`iconOnly`일 때는 루트 너비가 `100%`가 아닌 `fit-content`로 렌더되고, 텍스트 래퍼(`[data-role='segmented-control-item-text']`)가 렌더되지 않습니다. 기존에 `leadingContent`에 아이콘만 넣거나 children에 아이콘만 넣어 아이콘 전용처럼 사용했다면 `iconOnly`로 전환하세요.
+
+`TextAreaContent`의 `variant="segmented-control"`도 내부에서 별도 스타일을 주입하지 않으므로, TextArea 안에 배치하는 `SegmentedControl`에는 `iconOnly`를 직접 지정해야 합니다.
+
+#### 사이즈·토큰 변경
+
+루트 요소 — 높이는 그대로이고 radius와 padding이 변경되었습니다.
+
+| 속성          | Small       | Medium      | Large       |
+| ------------- | ----------- | ----------- | ----------- |
+| 높이          | 32px (유지) | 40px (유지) | 48px (유지) |
+| Border radius | 8px → 10px  | 10px → 12px | 12px → 14px |
+| Padding       | 2px → 4px   | 2px → 4px   | 3px → 4px   |
+| Thumb radius  | 6px → 8px   | 8px (유지)  | 10px (유지) |
+
+아이템 — typography가 한 단계씩 작아졌습니다.
+
+| 속성          | Small                         | Medium                     | Large                         |
+| ------------- | ----------------------------- | -------------------------- | ----------------------------- |
+| Typography    | label2(13px) → caption1(12px) | body2(15px) → label1(14px) | headline2(17px) → body2(15px) |
+| Border radius | 6px → 8px                     | 8px (유지)                 | 10px (유지)                   |
+| Padding       | 5px 6px → 4px 6px             | 7px 8px → 6px 8px          | 9px 8px (유지)                |
+| Icon size     | 14px (유지)                   | 18px → 16px                | 20px → 18px                   |
+| Gap           | 4px (유지)                    | 4px → 6px                  | 4px → 6px                     |
+
+`iconOnly` 아이템은 별도 수치를 사용합니다(신규).
+
+| 속성      | Small   | Medium  | Large     |
+| --------- | ------- | ------- | --------- |
+| Padding   | 4px 5px | 7px 8px | 10px 11px |
+| Icon size | 16px    | 18px    | 20px      |
+
+선택된 항목의 thumb 그림자는 하드코딩된 값과 white 28% 오버레이 대신 `semantic.elevation.shadow.normal.xsmall` 토큰을 사용합니다. 텍스트 크기가 줄어 아이템 폭 계산이 달라지므로, 폭을 고정하거나 `maxWidth`로 제한해 사용하던 화면은 확인이 필요합니다.
+
 ### ThemeProvider 테마 저장소 변경 (localStorage → Cookie)
 
 `ThemeProvider`가 `next-themes` 의존을 걷어내고 자체 쿠키 기반 구현으로 교체되었습니다. localStorage는 origin 단위로 격리되어 서브도메인 간 테마 공유가 불가능했기 때문입니다. 쿠키에 저장하되 읽기는 기존과 동일하게 first paint 이전 blocking inline script에서 처리하므로, SSG/SSR 렌더링 전략과 no-flash 동작은 그대로입니다.

--- a/docs/data/components/selection-and-input/segmented-control/config.js
+++ b/docs/data/components/selection-and-input/segmented-control/config.js
@@ -7,13 +7,6 @@ module.exports = {
     icons: ['IconList'],
     variants: [
       {
-        key: 'Variant',
-        options: [
-          { label: 'Solid', value: {} },
-          { label: 'Outlined', value: {} },
-        ],
-      },
-      {
         key: 'Icon',
         options: [
           { label: 'False', value: {} },
@@ -22,18 +15,17 @@ module.exports = {
       },
     ],
     render: (value) => {
-      const variant = value['Variant'].toLowerCase();
-      const leadingContent = value['Icon'] === 'True' ? '<IconList />' : 'null';
+      const leadingIcon = value['Icon'] === 'True' ? '<IconList />' : 'null';
 
       return `
-        <SegmentedControl value="active" variant="${variant}" sx={{maxWidth: 335}}>
-          <SegmentedControlItem value="active" leadingContent={${leadingContent}}>
+        <SegmentedControl value="active" sx={{maxWidth: 335}}>
+          <SegmentedControlItem value="active" leadingIcon={${leadingIcon}}>
             Active
           </SegmentedControlItem>
-          <SegmentedControlItem value="inactive1" leadingContent={${leadingContent}}>
+          <SegmentedControlItem value="inactive1" leadingIcon={${leadingIcon}}>
             Inactive
           </SegmentedControlItem>
-          <SegmentedControlItem value="inactive2" leadingContent={${leadingContent}}>
+          <SegmentedControlItem value="inactive2" leadingIcon={${leadingIcon}}>
             Inactive
           </SegmentedControlItem>
         </SegmentedControl>

--- a/docs/data/components/selection-and-input/segmented-control/config.js
+++ b/docs/data/components/selection-and-input/segmented-control/config.js
@@ -35,11 +35,11 @@ module.exports = {
   hierarchy: [
     {
       components: ['SegmentedControl', 'SegmentedControlItem'],
-      render: `<SegmentedControl value="active" variant="solid" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`,
+      render: `<SegmentedControl value="active" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`,
     },
     {
       components: ['SegmentedControl', 'SegmentedControlItem'],
-      render: `<SegmentedControl value="active" variant="outlined" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`,
+      render: `<SegmentedControl value="active" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`,
     },
   ],
   accessibility: [

--- a/docs/data/components/selection-and-input/segmented-control/design.mdx
+++ b/docs/data/components/selection-and-input/segmented-control/design.mdx
@@ -20,31 +20,23 @@ updatedAt: 2026-02-01
   components={['SegmentedControl', 'SegmentedControlItem']}
   icons={['IconList']}
   render={(value) => {
-      const variant = value['Variant'].toLowerCase();
-      const leadingContent = value['Icon'] === 'True' ? '<IconList />' : 'null';
+      const leadingIcon = value['Icon'] === 'True' ? '<IconList />' : 'null';
 
       return `
-        <SegmentedControl value="active" variant="${variant}" sx={{maxWidth: 335}}>
-          <SegmentedControlItem value="active" leadingContent={${leadingContent}}>
+        <SegmentedControl value="active" sx={{maxWidth: 335}}>
+          <SegmentedControlItem value="active" leadingIcon={${leadingIcon}}>
             Active
           </SegmentedControlItem>
-          <SegmentedControlItem value="inactive1" leadingContent={${leadingContent}}>
+          <SegmentedControlItem value="inactive1" leadingIcon={${leadingIcon}}>
             Inactive
           </SegmentedControlItem>
-          <SegmentedControlItem value="inactive2" leadingContent={${leadingContent}}>
+          <SegmentedControlItem value="inactive2" leadingIcon={${leadingIcon}}>
             Inactive
           </SegmentedControlItem>
         </SegmentedControl>
       `;
     }}
   variants={[
-    {
-      key: 'Variant',
-      options: [
-        { label: 'Solid', value: {} },
-        { label: 'Outlined', value: {} }
-      ]
-    },
     {
       key: 'Icon',
       options: [

--- a/docs/data/components/selection-and-input/segmented-control/design.mdx
+++ b/docs/data/components/selection-and-input/segmented-control/design.mdx
@@ -101,7 +101,7 @@ updatedAt: 2026-02-01
   "SegmentedControl",
   "SegmentedControlItem"
 ]}
-    render={`<SegmentedControl value="active" variant="solid" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`}
+    render={`<SegmentedControl value="active" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`}
   />
   <SectionHierarchyItem
     description={`Level.1 → 일정 영역에 대한 뷰 값을 컨트롤 합니다.`}
@@ -109,7 +109,7 @@ updatedAt: 2026-02-01
   "SegmentedControl",
   "SegmentedControlItem"
 ]}
-    render={`<SegmentedControl value="active" variant="outlined" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`}
+    render={`<SegmentedControl value="active" sx={{width:180}}><SegmentedControlItem value="active">Active</SegmentedControlItem><SegmentedControlItem value="inactive">Inactive</SegmentedControlItem></SegmentedControl>`}
   />
 </SectionHierarchy>
 

--- a/docs/data/components/selection-and-input/segmented-control/web.mdx
+++ b/docs/data/components/selection-and-input/segmented-control/web.mdx
@@ -45,7 +45,7 @@ export default Demo;`}
 
 const Demo = () => {
   return (
-    <FlexBox flexDirection="Column" gap="12px" sx={{ width: '40%', minWidth: 260 }}>
+    <FlexBox flexDirection="column" gap="12px" sx={{ width: '40%', minWidth: 260 }}>
       <SegmentedControl size="small" defaultValue="0">
         <SegmentedControlItem value="0">
           Board
@@ -92,7 +92,7 @@ import { IconColumn, IconList } from '@montage-ui/icon';
 
 const Demo = () => {
   return (
-    <FlexBox flexDirection="Column" gap="12px" sx={{ width: '40%', minWidth: 260 }}>
+    <FlexBox flexDirection="column" gap="12px" sx={{ width: '40%', minWidth: 260 }}>
       <SegmentedControl size="small" defaultValue="0">
         <SegmentedControlItem value="0" leadingIcon={<IconColumn />}>
           Board
@@ -141,7 +141,7 @@ import { IconColumn, IconList } from '@montage-ui/icon';
 
 const Demo = () => {
   return (
-    <FlexBox flexDirection="Column" gap="12px" alignItems="center">
+    <FlexBox flexDirection="column" gap="12px" alignItems="center">
       <SegmentedControl size="small" iconOnly defaultValue="0">
         <SegmentedControlItem value="0" aria-label="Apply filter to board">
           <IconColumn />

--- a/docs/data/components/selection-and-input/segmented-control/web.mdx
+++ b/docs/data/components/selection-and-input/segmented-control/web.mdx
@@ -6,11 +6,7 @@ createdAt: 2025-05-12
 
 ## Basic segmented control
 
-`SegmentedControl` 은 2가지 variant 를 사용할 수 있습니다.
-- solid (default)
-- outlined
-
-### Solid
+여러 항목 중 하나를 선택하여 보기 방식이나 필터를 변경할 때 사용합니다.
 
 <Demo code={`import {
   SegmentedControl,
@@ -19,7 +15,7 @@ createdAt: 2025-05-12
 
 const Demo = () => {
   return (
-    <SegmentedControl variant="solid" defaultValue="0">
+    <SegmentedControl defaultValue="0" sx={{ width: '40%', minWidth: 260 }}>
       <SegmentedControlItem value="0">
         Board
       </SegmentedControlItem>
@@ -33,28 +29,6 @@ const Demo = () => {
 export default Demo;`}
 />
 
-### Outlined
-
-<Demo code={`import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@montage-ui/core';
-
-const Demo = () => {
-  return (
-    <SegmentedControl variant="outlined" defaultValue="0">
-      <SegmentedControlItem value="0">
-        Board
-      </SegmentedControlItem>
-     <SegmentedControlItem value="1">
-        List
-      </SegmentedControlItem>
-    </SegmentedControl>
-  )
-}
-
-export default Demo;`}
-/>
 
 ## Sizes
 
@@ -71,52 +45,30 @@ export default Demo;`}
 
 const Demo = () => {
   return (
-    <FlexBox flexDirection="Column" gap="12px" sx={{ width: '100%' }}>
-      <SegmentedControl variant="solid" size="small" defaultValue="0">
+    <FlexBox flexDirection="Column" gap="12px" sx={{ width: '40%', minWidth: 260 }}>
+      <SegmentedControl size="small" defaultValue="0">
         <SegmentedControlItem value="0">
           Board
         </SegmentedControlItem>
-      <SegmentedControlItem value="1">
+        <SegmentedControlItem value="1">
           List
         </SegmentedControlItem>
       </SegmentedControl>
-      <SegmentedControl variant="solid" size="medium" defaultValue="0">
+
+      <SegmentedControl size="medium" defaultValue="0">
         <SegmentedControlItem value="0">
           Board
         </SegmentedControlItem>
-      <SegmentedControlItem value="1">
+        <SegmentedControlItem value="1">
           List
         </SegmentedControlItem>
       </SegmentedControl>
-      <SegmentedControl variant="solid" size="large" defaultValue="0">
+
+      <SegmentedControl size="large" defaultValue="0">
         <SegmentedControlItem value="0">
           Board
         </SegmentedControlItem>
-      <SegmentedControlItem value="1">
-          List
-        </SegmentedControlItem>
-      </SegmentedControl>
-      <SegmentedControl variant="outlined" size="small" defaultValue="0">
-        <SegmentedControlItem value="0">
-          Board
-        </SegmentedControlItem>
-      <SegmentedControlItem value="1">
-          List
-        </SegmentedControlItem>
-      </SegmentedControl>
-      <SegmentedControl variant="outlined" size="medium" defaultValue="0">
-        <SegmentedControlItem value="0">
-          Board
-        </SegmentedControlItem>
-      <SegmentedControlItem value="1">
-          List
-        </SegmentedControlItem>
-      </SegmentedControl>
-      <SegmentedControl variant="outlined" size="large" defaultValue="0">
-        <SegmentedControlItem value="0">
-          Board
-        </SegmentedControlItem>
-      <SegmentedControlItem value="1">
+        <SegmentedControlItem value="1">
           List
         </SegmentedControlItem>
       </SegmentedControl>
@@ -129,24 +81,94 @@ export default Demo;`}
 
 ## With icon
 
-`leadingContent` prop 을 사용하면 앞쪽에 아이콘을 추가할 수 있습니다.
+`leadingIcon` prop 을 사용하면 앞쪽에 아이콘을 추가할 수 있습니다.
 
 <Demo code={`import {
   SegmentedControl,
   SegmentedControlItem,
+  FlexBox,
 } from '@montage-ui/core';
 import { IconColumn, IconList } from '@montage-ui/icon';
 
 const Demo = () => {
   return (
-    <SegmentedControl defaultValue="0">
-      <SegmentedControlItem value="0"  leadingContent={<IconColumn />}>
-        Board
-      </SegmentedControlItem>
-     <SegmentedControlItem value="1" leadingContent={<IconList />}>
-        List
-      </SegmentedControlItem>
-    </SegmentedControl>
+    <FlexBox flexDirection="Column" gap="12px" sx={{ width: '40%', minWidth: 260 }}>
+      <SegmentedControl size="small" defaultValue="0">
+        <SegmentedControlItem value="0" leadingIcon={<IconColumn />}>
+          Board
+        </SegmentedControlItem>
+        <SegmentedControlItem value="1" leadingIcon={<IconList />}>
+          List
+        </SegmentedControlItem>
+      </SegmentedControl>
+
+      <SegmentedControl size="medium" defaultValue="0">
+        <SegmentedControlItem value="0" leadingIcon={<IconColumn />}>
+          Board
+        </SegmentedControlItem>
+        <SegmentedControlItem value="1">
+          List
+        </SegmentedControlItem>
+      </SegmentedControl>
+
+      <SegmentedControl size="large" defaultValue="0">
+        <SegmentedControlItem value="0" leadingIcon={<IconColumn />}>
+          Board
+        </SegmentedControlItem>
+        <SegmentedControlItem value="1" leadingIcon={<IconList />}>
+          List
+        </SegmentedControlItem>
+      </SegmentedControl>
+    </FlexBox>
+  )
+}
+
+export default Demo;`}
+/>
+
+## Icon only
+
+`iconOnly` prop 을 사용하면 텍스트 대신 아이콘만 표시할 수 있습니다.
+
+`aria-label`을 통해 적절한 라벨을 주입해야 합니다.
+
+<Demo code={`import {
+  SegmentedControl,
+  SegmentedControlItem,
+  FlexBox,
+} from '@montage-ui/core';
+import { IconColumn, IconList } from '@montage-ui/icon';
+
+const Demo = () => {
+  return (
+    <FlexBox flexDirection="Column" gap="12px" alignItems="center">
+      <SegmentedControl size="small" iconOnly defaultValue="0">
+        <SegmentedControlItem value="0" aria-label="Apply filter to board">
+          <IconColumn />
+        </SegmentedControlItem>
+        <SegmentedControlItem value="1" aria-label="Apply filter to list">
+            <IconList />
+        </SegmentedControlItem>
+      </SegmentedControl>
+
+      <SegmentedControl size="medium" iconOnly defaultValue="0">
+        <SegmentedControlItem value="0" aria-label="Apply filter to board">
+          <IconColumn />
+        </SegmentedControlItem>
+        <SegmentedControlItem value="1" aria-label="Apply filter to list">
+            <IconList />
+        </SegmentedControlItem>
+      </SegmentedControl>
+
+      <SegmentedControl size="large" iconOnly defaultValue="0">
+        <SegmentedControlItem value="0" aria-label="Apply filter to board">
+          <IconColumn />
+        </SegmentedControlItem>
+        <SegmentedControlItem value="1" aria-label="Apply filter to list">
+          <IconList />
+        </SegmentedControlItem>
+      </SegmentedControl>
+    </FlexBox>
   )
 }
 

--- a/docs/data/components/selection-and-input/text-area/web.mdx
+++ b/docs/data/components/selection-and-input/text-area/web.mdx
@@ -235,7 +235,7 @@ const Demo = () => {
         placeholder="Segmented control"
         leadingContent={(
           <TextAreaContent variant="segmented-control">
-            <SegmentedControl size="small" defaultValue="1">
+            <SegmentedControl size="small" iconOnly defaultValue="1">
               <SegmentedControlItem value="1" aria-label="Item 1">
                 <IconBlank />
               </SegmentedControlItem>
@@ -247,7 +247,7 @@ const Demo = () => {
         )}
         trailingContent={(
           <TextAreaContent variant="segmented-control">
-            <SegmentedControl size="small" defaultValue="1">
+            <SegmentedControl size="small" iconOnly defaultValue="1">
               <SegmentedControlItem value="1" aria-label="Item 1">
                 <IconBlank />
               </SegmentedControlItem>

--- a/packages/core/src/components/segmented-control/contexts.ts
+++ b/packages/core/src/components/segmented-control/contexts.ts
@@ -7,9 +7,9 @@ import type { SegmentedControlProps } from './types';
 export type SegmentedControlContextType = {
   value?: string;
   onValueChange: (value: string) => void;
-  variant: Exclude<SegmentedControlProps['variant'], undefined>;
   size: Exclude<SegmentedControlProps['size'], undefined>;
   responsive?: Pick<SegmentedControlProps, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>;
+  iconOnly?: boolean;
   name?: string;
 };
 

--- a/packages/core/src/components/segmented-control/index.tsx
+++ b/packages/core/src/components/segmented-control/index.tsx
@@ -57,8 +57,8 @@ const SegmentedControl = forwardRef<
       value: valueProp,
       onValueChange,
       children,
-      variant = 'solid',
       size = 'medium',
+      iconOnly,
       name,
       xs,
       sm,
@@ -97,13 +97,6 @@ const SegmentedControl = forwardRef<
         `[data-component="segmented-control-item"][data-value="${value}"]`,
       );
 
-      if (variant === 'outlined') {
-        setMotionStyleProperties((prev) => ({ ...prev, display: 'none' }));
-        currentElement?.removeAttribute('data-ssr-motion');
-
-        return;
-      }
-
       if (!parentElement || !targetElement || !nextElement) {
         setMotionStyleProperties((prev) => ({ ...prev, display: 'none' }));
         return;
@@ -125,7 +118,7 @@ const SegmentedControl = forwardRef<
       requestAnimationFrame(() => {
         currentElement?.removeAttribute('data-ssr-motion');
       });
-    }, [node, variant, value, isValueChanged, prevValue]);
+    }, [node, value, isValueChanged, prevValue]);
 
     useResizeObserver(node, handleResize);
 
@@ -145,9 +138,9 @@ const SegmentedControl = forwardRef<
       <SegmentedControlProvider
         value={value}
         onValueChange={setValue}
-        variant={variant}
         size={size}
         name={name}
+        iconOnly={iconOnly}
         responsive={{
           xs,
           sm,
@@ -164,7 +157,7 @@ const SegmentedControl = forwardRef<
             {...props}
             data-component="segmented-control"
             sx={[
-              segmentedControlStyle({ variant, size, xs, sm, md, lg, xl }),
+              segmentedControlStyle({ iconOnly, size, xs, sm, md, lg, xl }),
               props.sx,
             ]}
           >
@@ -191,8 +184,7 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
       children,
       value,
       disabled,
-      leadingContent,
-      trailingContent,
+      leadingIcon,
       as,
       ...props
     }: PolymorphicPropsInternal<SegmentedControlItemProps, T>,
@@ -206,7 +198,7 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
       setNode as ForwardedRef<T>,
     );
 
-    const { size, variant, responsive, name, ...context } =
+    const { size, iconOnly, responsive, name, ...context } =
       useSegmentedControlContext(SEGMENTED_CONTROL_ITEM_NAME);
 
     const active = context.value === value;
@@ -240,7 +232,6 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
           flex="1 1 0"
           alignItems="center"
           justifyContent="center"
-          gap="4px"
           data-value={value}
           role="radio"
           aria-disabled={disabled}
@@ -253,9 +244,9 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
           data-ssr-motion={active}
           sx={[
             segmentedControlItemStyle({
+              iconOnly,
               size,
               active,
-              variant,
               disabled,
               ...responsive,
             }),
@@ -279,25 +270,42 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
             }
           })}
         >
-          {leadingContent}
-          <span
-            data-role="segmented-control-item-text"
-            aria-selected={active}
-            aria-disabled={disabled}
-            id={id}
-          >
-            {isFormControl && (
-              <VirtualCheckboxInput
-                type="radio"
-                name={name}
-                value={value}
-                checked={active}
-                disabled={disabled}
-              />
-            )}
-            {children}
-          </span>
-          {trailingContent}
+          {iconOnly ? (
+            <>
+              {children}
+              {isFormControl && (
+                <VirtualCheckboxInput
+                  type="radio"
+                  name={name}
+                  value={value}
+                  checked={active}
+                  disabled={disabled}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              {leadingIcon}
+
+              <span
+                data-role="segmented-control-item-text"
+                aria-selected={active}
+                aria-disabled={disabled}
+                id={id}
+              >
+                {isFormControl && (
+                  <VirtualCheckboxInput
+                    type="radio"
+                    name={name}
+                    value={value}
+                    checked={active}
+                    disabled={disabled}
+                  />
+                )}
+                {children}
+              </span>
+            </>
+          )}
         </FlexBox>
       </RovingFocusGroup.Item>
     );

--- a/packages/core/src/components/segmented-control/index.tsx
+++ b/packages/core/src/components/segmented-control/index.tsx
@@ -236,7 +236,7 @@ const SegmentedControlItem = forwardRef<any, SegmentedControlItemProps>(
           role="radio"
           aria-disabled={disabled}
           aria-checked={active}
-          aria-labelledby={id}
+          aria-labelledby={iconOnly ? undefined : id}
           {...props}
           disabled={disabled}
           data-component="segmented-control-item"

--- a/packages/core/src/components/segmented-control/style.ts
+++ b/packages/core/src/components/segmented-control/style.ts
@@ -1,99 +1,65 @@
 import { css } from '@montage-ui/engine';
 
-import {
-  addOpacity,
-  ellipsisTypographyStyle,
-  typographyStyle,
-} from '../../utils';
+import { ellipsisTypographyStyle, typographyStyle } from '../../utils';
 import { createResponsiveStyle } from '../../utils/internal/responsive-props';
 
 import type { SegmentedControlProps } from './types';
 import type { Theme } from '@montage-ui/engine';
 
 export const segmentedControlStyle =
-  ({ variant, size, xs, sm, md, lg, xl }: SegmentedControlProps) =>
+  ({ size, iconOnly, xs, sm, md, lg, xl }: SegmentedControlProps) =>
   (theme: Theme) => css`
     position: relative;
-    width: 100%;
+    width: ${iconOnly ? 'fit-content' : '100%'};
+    background-color: ${theme.semantic.surface.neutral.secondary};
 
-    ${segmentedControlSizeStyle({ size, variant })}
-    ${segmentedControlVariantStyle({ variant }, theme)}
+    ${segmentedControlSizeStyle({ size }, theme)}
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
       theme,
     )(
       (params) => css`
-        ${segmentedControlSizeStyle({ variant, size: params?.size })}
+        ${segmentedControlSizeStyle({ size: params?.size }, theme)}
         ${params?.sx}
       `,
     )}
   `;
 
-const segmentedControlVariantStyle = (
-  { variant }: SegmentedControlProps,
+const segmentedControlSizeStyle = (
+  { size }: SegmentedControlProps,
   theme: Theme,
 ) => {
-  switch (variant) {
-    case 'outlined':
-      return css`
-        background-color: transparent;
-        box-shadow: inset 0 0 0 1px ${theme.semantic.line.neutral.primary};
-      `;
-    case 'solid':
-    default:
-      return css`
-        background-color: ${theme.semantic.surface.neutral.secondary};
-      `;
-  }
-};
-
-const segmentedControlSizeStyle = ({
-  size,
-  variant,
-}: SegmentedControlProps) => {
   switch (size) {
     case 'large':
       return css`
-        border-radius: 12px;
-        height: 48px;
+        border-radius: ${theme.radius[14]};
+        height: ${theme.dimension[48]};
+        padding: ${theme.spacing[4]};
 
-        ${variant === 'solid' &&
-        css`
-          padding: 3px;
-
-          [data-role='segmented-control-motion'] {
-            border-radius: 10px;
-          }
-        `}
+        [data-role='segmented-control-motion'] {
+          border-radius: ${theme.radius[10]};
+        }
       `;
     case 'medium':
       return css`
-        border-radius: 10px;
-        height: 40px;
+        border-radius: ${theme.radius[12]};
+        height: ${theme.dimension[40]};
+        padding: ${theme.spacing[4]};
 
-        ${variant === 'solid' &&
-        css`
-          padding: 2px;
-
-          [data-role='segmented-control-motion'] {
-            border-radius: 8px;
-          }
-        `}
+        [data-role='segmented-control-motion'] {
+          border-radius: ${theme.radius[8]};
+        }
       `;
     case 'small':
       return css`
-        border-radius: 8px;
-        height: 32px;
+        border-radius: ${theme.radius[10]};
+        height: ${theme.dimension[32]};
+        padding: ${theme.spacing[4]};
 
-        ${variant === 'solid' &&
-        css`
-          padding: 2px;
-
-          [data-role='segmented-control-motion'] {
-            border-radius: 6px;
-          }
-        `}
+        [data-role='segmented-control-motion'] {
+          border-radius: ${theme.radius[8]};
+        }
       `;
   }
 };
@@ -101,36 +67,21 @@ const segmentedControlSizeStyle = ({
 export const motionThumbStyle = (theme: Theme) => css`
   position: absolute;
   background-color: ${theme.semantic.surface.elevated.primary};
-  box-shadow: 0px 0px 4px 0px
-    ${addOpacity(theme.semantic.static.black, theme.opacity[8])};
-
-  &::before {
-    content: '';
-    width: 100%;
-    height: 100%;
-    left: 0px;
-    top: 0px;
-    position: absolute;
-    border-radius: inherit;
-    background-color: ${addOpacity(
-      theme.semantic.static.white,
-      theme.opacity[28],
-    )};
-  }
+  box-shadow: ${theme.semantic.elevation.shadow.normal.xsmall};
 `;
 
 type SegmentedControlItemStyleProps = {
   active?: boolean;
   disabled?: boolean;
-  variant?: SegmentedControlProps['variant'];
   size?: SegmentedControlProps['size'];
+  iconOnly?: boolean;
 } & Pick<SegmentedControlProps, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>;
 
 export const segmentedControlItemStyle =
   ({
+    iconOnly,
     size,
     disabled,
-    variant,
     xs,
     sm,
     md,
@@ -139,11 +90,9 @@ export const segmentedControlItemStyle =
   }: SegmentedControlItemStyleProps) =>
   (theme: Theme) => css`
     position: relative;
-    padding: 0px 16px;
     height: 100%;
     cursor: pointer;
     box-shadow: none;
-    border-radius: 0px;
     min-width: 0;
 
     [data-role='segmented-control-item-text'] {
@@ -161,186 +110,108 @@ export const segmentedControlItemStyle =
       cursor: initial;
     `}
 
-    ${segmentedControlItemActiveStyle({ variant }, theme)}
-    ${segmentedControlItemSizeStyle({ size, variant })}
+    color: ${theme.semantic.foreground.neutral.tertiary};
+    background-color: transparent;
+    box-shadow: none;
+    transition: color 0.2s;
+
+    &[data-active='true'] {
+      color: ${theme.semantic.foreground.neutral.primary};
+
+      &[data-ssr-motion='true'] {
+        & > * {
+          z-index: 1;
+        }
+
+        position: relative;
+        box-shadow: ${theme.semantic.elevation.shadow.normal.xsmall};
+        background-color: ${theme.semantic.surface.elevated.primary};
+      }
+    }
+
+    ${segmentedControlItemSizeStyle({ size, iconOnly }, theme)}
 
     ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
       theme,
     )(
       (params) => css`
-        ${segmentedControlItemSizeStyle({ size: params?.size, variant })}
+        ${segmentedControlItemSizeStyle(
+          { size: params?.size, iconOnly },
+          theme,
+        )}
       `,
     )}
   `;
 
-const segmentedControlItemSizeStyle = ({
-  size,
-  variant,
-}: SegmentedControlItemStyleProps) => {
+const segmentedControlItemSizeStyle = (
+  { size, iconOnly }: SegmentedControlItemStyleProps,
+  theme: Theme,
+) => {
+  if (iconOnly) {
+    switch (size) {
+      case 'large':
+        return css`
+          padding: ${theme.spacing[10]} 11px;
+          border-radius: ${theme.radius[10]};
+
+          svg {
+            font-size: ${theme.dimension[20]};
+          }
+        `;
+      case 'medium':
+        return css`
+          padding: 7px ${theme.spacing[8]};
+          border-radius: ${theme.radius[8]};
+
+          svg {
+            font-size: ${theme.dimension[18]};
+          }
+        `;
+      case 'small':
+        return css`
+          padding: ${theme.spacing[4]} 5px;
+          border-radius: ${theme.radius[8]};
+
+          svg {
+            font-size: ${theme.dimension[16]};
+          }
+        `;
+    }
+  }
+
   switch (size) {
     case 'large':
       return css`
-        ${typographyStyle('headline2', 'medium')}
-        padding: 12px 8px;
+        ${typographyStyle('body2', 'medium')}
+        border-radius: ${theme.radius[10]};
+        padding: 9px ${theme.spacing[8]};
+        gap: ${theme.spacing[6]};
 
         svg {
-          font-size: 20px;
+          font-size: ${theme.dimension[18]};
         }
-
-        ${variant === 'solid'
-          ? css`
-              border-radius: 10px;
-              padding: 9px 8px;
-            `
-          : css`
-              &:first-of-type {
-                border-radius: 12px 0px 0px 12px;
-              }
-
-              &:last-of-type {
-                border-radius: 0px 12px 12px 0px;
-              }
-            `}
       `;
     case 'medium':
       return css`
-        ${typographyStyle('body2', 'medium')}
-        padding: 9px 8px;
+        ${typographyStyle('label1', 'medium')}
+        border-radius: ${theme.radius[8]};
+        padding: ${theme.spacing[6]} ${theme.spacing[8]};
+        gap: ${theme.spacing[6]};
 
         svg {
-          font-size: 18px;
+          font-size: ${theme.dimension[16]};
         }
-
-        ${variant === 'solid'
-          ? css`
-              border-radius: 8px;
-              padding: 7px 8px;
-            `
-          : css`
-              &:first-of-type {
-                border-radius: 10px 0px 0px 10px;
-              }
-
-              &:last-of-type {
-                border-radius: 0px 10px 10px 0px;
-              }
-            `}
       `;
     case 'small':
       return css`
-        ${typographyStyle('label2', 'medium')}
-        padding: 7px 6px;
+        ${typographyStyle('caption1', 'medium')}
+        border-radius: ${theme.radius[8]};
+        padding: ${theme.spacing[4]} ${theme.spacing[6]};
+        gap: ${theme.spacing[4]};
 
         svg {
-          font-size: 14px;
-        }
-
-        ${variant === 'solid'
-          ? css`
-              border-radius: 6px;
-              padding: 5px 6px;
-            `
-          : css`
-              &:first-of-type {
-                border-radius: 8px 0px 0px 8px;
-              }
-              &:last-of-type {
-                border-radius: 0px 8px 8px 0px;
-              }
-            `}
-      `;
-  }
-};
-
-const segmentedControlItemActiveStyle = (
-  { variant }: SegmentedControlItemStyleProps,
-  theme: Theme,
-) => {
-  switch (variant) {
-    case 'solid':
-      return css`
-        color: ${theme.semantic.foreground.neutral.tertiary};
-        background-color: transparent;
-        box-shadow: none;
-        transition: color 0.2s;
-
-        &[data-active='true'] {
-          color: ${theme.semantic.foreground.neutral.primary};
-
-          &[data-ssr-motion='true'] {
-            & > * {
-              z-index: 1;
-            }
-
-            box-shadow: 0px 0px 4px 0px
-              ${addOpacity(theme.semantic.static.black, theme.opacity[8])};
-            position: relative;
-            background-color: ${theme.semantic.surface.elevated.primary};
-
-            &::before {
-              content: '';
-              width: 100%;
-              height: 100%;
-              left: 0px;
-              top: 0px;
-              position: absolute;
-              border-radius: inherit;
-              background-color: ${addOpacity(
-                theme.semantic.static.white,
-                theme.opacity[28],
-              )};
-            }
-          }
-        }
-      `;
-    case 'outlined':
-      return css`
-        color: ${theme.semantic.foreground.neutral.tertiary};
-        background-color: transparent;
-        box-shadow: none;
-        border: 1px solid transparent;
-        transition: none;
-
-        &::after {
-          content: '';
-          width: calc(100% + 1px);
-          height: 100%;
-          left: 0px;
-          top: 0px;
-          position: absolute;
-          border-radius: inherit;
-          border-right: 1px solid ${theme.semantic.line.neutral.primary};
-          box-sizing: content-box;
-        }
-
-        &:last-of-type {
-          &::after {
-            border-color: transparent;
-          }
-        }
-
-        &:has(+ [data-active='true']) {
-          &::after {
-            border-color: transparent;
-          }
-        }
-
-        &[data-active='true'] {
-          background-color: ${addOpacity(
-            theme.semantic.surface.brand.primary,
-            theme.opacity[5],
-          )};
-          color: ${theme.semantic.foreground.brand.primary};
-          border: 1px solid
-            ${addOpacity(
-              theme.semantic.surface.brand.primary,
-              theme.opacity[43],
-            )};
-
-          &::after {
-            border: none;
-          }
+          font-size: ${theme.dimension[14]};
         }
       `;
   }

--- a/packages/core/src/components/segmented-control/types.ts
+++ b/packages/core/src/components/segmented-control/types.ts
@@ -8,12 +8,12 @@ export type SegmentedControlDefaultProps = WithSxProps<{
   value?: string;
   /** Callback function when the value changes. */
   onValueChange?: (tab: string) => void;
-  /** The variant of the segmented control. */
-  variant?: 'solid' | 'outlined';
   /** The size of the segmented control. */
   size?: 'large' | 'medium' | 'small';
   /** The children of the segmented control. */
   children?: ReactNode;
+  /** Whether to show only the icon. If `iconOnly` is enabled, you must provide an icon component as the SegmentedControlItem's `children`. */
+  iconOnly?: boolean;
   /** The name of the segmented control. */
   name?: string;
 }>;
@@ -28,10 +28,8 @@ export type SegmentedControlProps = Merge<
 >;
 
 export type SegmentedControlItemProps = WithSxProps<{
-  /** The leading content of the segmented control item. */
-  leadingContent?: ReactNode;
-  /** The trailing content of the segmented control item. */
-  trailingContent?: ReactNode;
+  /** The leading icon of the segmented control item. */
+  leadingIcon?: ReactNode;
   /** Whether the segmented control item is disabled. */
   disabled?: boolean;
   /** The value of the segmented control item. */

--- a/packages/core/src/components/text-area/index.tsx
+++ b/packages/core/src/components/text-area/index.tsx
@@ -343,31 +343,6 @@ const TextAreaContent = forwardRef<
         </FlexBox>
       );
     case 'segmented-control':
-      return (
-        <FlexBox
-          data-component="text-area-content"
-          ref={ref}
-          sx={[
-            textAreaContentStyle,
-            {
-              ['[data-component="segmented-control"]']: {
-                width: '60px',
-              },
-              ['[data-component="segmented-control-item"]']: {
-                alignItems: 'center',
-                justifyContent: 'center',
-                ['& > [data-role="segmented-control-item-text"]']: {
-                  display: 'inline-flex',
-                },
-              },
-            },
-            sx,
-          ]}
-          {...props}
-        >
-          {children}
-        </FlexBox>
-      );
     case 'custom':
     default:
       return (

--- a/packages/eslint-plugin/README.ko.md
+++ b/packages/eslint-plugin/README.ko.md
@@ -74,6 +74,42 @@ export default [montagePlugin.flatConfig.strict];
 </Button>
 ```
 
+### segmented-control-item-uses-name
+
+`SegmentedControl`이 `iconOnly`일 때 각 `SegmentedControlItem`에 `aria-label`(또는 `aria-labelledby`) 속성을 지정해야 합니다.
+
+```tsx
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0">
+    <IconColumn />
+  </SegmentedControlItem>
+</SegmentedControl>
+```
+
+`iconOnly` 모드에서는 아이템의 텍스트 래퍼가 렌더되지 않아, 해당 속성이 없으면 스크린리더가 각 세그먼트가 무엇을 선택하는지 알 수 없습니다.
+
+```tsx
+// good
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0" aria-label="보드 보기">
+    <IconColumn />
+  </SegmentedControlItem>
+  <SegmentedControlItem value="1" aria-label="목록 보기">
+    <IconList />
+  </SegmentedControlItem>
+</SegmentedControl>
+
+// bad
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0">
+    <IconColumn />
+  </SegmentedControlItem>
+  <SegmentedControlItem value="1">
+    <IconList />
+  </SegmentedControlItem>
+</SegmentedControl>
+```
+
 ### image-uses-alt
 
 아바타, 썸네일 등 시각적 이미지는 스크린리더를 위한 `alt` 속성을 반드시 제공해야 합니다.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -74,6 +74,42 @@ Without this attribute, screen readers cannot identify the purpose of the button
 </Button>
 ```
 
+### segmented-control-item-uses-name
+
+When a `SegmentedControl` is `iconOnly`, each `SegmentedControlItem` must specify the `aria-label` (or `aria-labelledby`) attribute.
+
+```tsx
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0">
+    <IconColumn />
+  </SegmentedControlItem>
+</SegmentedControl>
+```
+
+In `iconOnly` mode the item's text wrapper is not rendered, so without this attribute screen readers cannot identify what each segment selects.
+
+```tsx
+// good
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0" aria-label="Board view">
+    <IconColumn />
+  </SegmentedControlItem>
+  <SegmentedControlItem value="1" aria-label="List view">
+    <IconList />
+  </SegmentedControlItem>
+</SegmentedControl>
+
+// bad
+<SegmentedControl iconOnly defaultValue="0">
+  <SegmentedControlItem value="0">
+    <IconColumn />
+  </SegmentedControlItem>
+  <SegmentedControlItem value="1">
+    <IconList />
+  </SegmentedControlItem>
+</SegmentedControl>
+```
+
 ### image-uses-alt
 
 Visual images such as avatars and thumbnails must provide an `alt` attribute for screen readers.

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,11 +7,13 @@ import type { ESLint, Linter } from 'eslint';
 const recommendedRules = {
   '@montage-ui/icon-button-uses-name': 'warn',
   '@montage-ui/image-uses-alt': 'warn',
+  '@montage-ui/segmented-control-item-uses-name': 'warn',
 } satisfies Record<`@montage-ui/${keyof typeof rules}`, Linter.RuleEntry>;
 
 const strictRules = {
   '@montage-ui/icon-button-uses-name': 'error',
   '@montage-ui/image-uses-alt': 'error',
+  '@montage-ui/segmented-control-item-uses-name': 'error',
 } satisfies Record<`@montage-ui/${keyof typeof rules}`, Linter.RuleEntry>;
 
 const configs = {

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,11 +1,13 @@
 import iconButtonUsesName from './icon-button-uses-name';
 import imageUsesAlt from './image-uses-alt';
+import segmentedControlItemUsesName from './segmented-control-item-uses-name';
 
 import type { ESLint } from 'eslint';
 
 const rules = {
   'image-uses-alt': imageUsesAlt,
   'icon-button-uses-name': iconButtonUsesName,
+  'segmented-control-item-uses-name': segmentedControlItemUsesName,
 } satisfies ESLint.Plugin['rules'];
 
 export default rules;

--- a/packages/eslint-plugin/src/rules/segmented-control-item-uses-name/index.test.ts
+++ b/packages/eslint-plugin/src/rules/segmented-control-item-uses-name/index.test.ts
@@ -1,0 +1,153 @@
+import { run } from 'eslint-vitest-rule-tester';
+
+import segmentedControlItemUsesNameRule from '.';
+
+run({
+  name: 'segmented-control-item-uses-name',
+  rule: segmentedControlItemUsesNameRule,
+
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  valid: [
+    {
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly defaultValue="0">
+          <SegmentedControlItem value="0" aria-label="Board view" />
+          <SegmentedControlItem value="1" aria-label="List view" />
+        </SegmentedControl>
+      `,
+    },
+    {
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly defaultValue="0">
+          <SegmentedControlItem value="0" aria-labelledby="board-label" />
+        </SegmentedControl>
+      `,
+    },
+    {
+      // not iconOnly — the item text provides the accessible name
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl defaultValue="0">
+          <SegmentedControlItem value="0">Board</SegmentedControlItem>
+        </SegmentedControl>
+      `,
+    },
+    {
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly={false} defaultValue="0">
+          <SegmentedControlItem value="0">Board</SegmentedControlItem>
+        </SegmentedControl>
+      `,
+    },
+    {
+      // dynamic iconOnly value — not statically knowable, skip
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly={props.iconOnly} defaultValue="0">
+          <SegmentedControlItem value="0">Board</SegmentedControlItem>
+        </SegmentedControl>
+      `,
+    },
+    {
+      // item outside any SegmentedControl (composed elsewhere) — out of scope
+      code: `
+        import { SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControlItem value="0" />
+      `,
+    },
+    {
+      // non-montage components with the same names
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from 'other-library';
+
+        <SegmentedControl iconOnly defaultValue="0">
+          <SegmentedControlItem value="0" />
+        </SegmentedControl>
+      `,
+    },
+    {
+      // map-rendered items with aria-label
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly defaultValue="0">
+          {items.map((item) => (
+            <SegmentedControlItem key={item.value} value={item.value} aria-label={item.label} />
+          ))}
+        </SegmentedControl>
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly defaultValue="0">
+          <SegmentedControlItem value="0" />
+          <SegmentedControlItem value="1" />
+        </SegmentedControl>
+      `,
+      errors: 2,
+    },
+    {
+      code: `
+        import * as montage from '@montage-ui/core';
+
+        <montage.SegmentedControl iconOnly defaultValue="0">
+          <montage.SegmentedControlItem value="0" />
+        </montage.SegmentedControl>
+      `,
+      errors: 1,
+    },
+    {
+      // aliased import
+      code: `
+        import { SegmentedControl as Control, SegmentedControlItem as Item } from '@montage-ui/core';
+
+        <Control iconOnly defaultValue="0">
+          <Item value="0" />
+        </Control>
+      `,
+      errors: 1,
+    },
+    {
+      // map-rendered items without aria-label are still inside the iconOnly root
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly defaultValue="0">
+          {items.map((item) => (
+            <SegmentedControlItem key={item.value} value={item.value} />
+          ))}
+        </SegmentedControl>
+      `,
+      errors: 1,
+    },
+    {
+      code: `
+        import { SegmentedControl, SegmentedControlItem } from '@montage-ui/core';
+
+        <SegmentedControl iconOnly={true} defaultValue="0">
+          <SegmentedControlItem value="0" />
+        </SegmentedControl>
+      `,
+      errors: 1,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/segmented-control-item-uses-name/index.ts
+++ b/packages/eslint-plugin/src/rules/segmented-control-item-uses-name/index.ts
@@ -1,0 +1,111 @@
+import { elementType, getLiteralPropValue, getProp } from 'jsx-ast-utils';
+
+import { WdsImportParser } from '../../helpers/ast';
+import { isHidden, isPresentationRole } from '../../helpers/accessibility';
+
+import type { Node } from 'estree';
+import type { JSXElement, JSXOpeningElement } from 'estree-jsx';
+import type { Rule } from 'eslint';
+
+const ROOT_COMPONENT = 'SegmentedControl';
+const ITEM_COMPONENT = 'SegmentedControlItem';
+
+export default {
+  meta: {
+    docs: {
+      url: 'https://github.com/wanteddev/montage-web/tree/main/packages/eslint-plugin/README.md#segmented-control-item-uses-name',
+      description:
+        'Required aria-label prop for SegmentedControlItem inside an iconOnly SegmentedControl',
+    },
+    messages: {
+      error:
+        'For accessibility, please provide an aria-label attribute — the item text is not rendered when the SegmentedControl is iconOnly.',
+    },
+  },
+
+  create: (context) => {
+    const importParser = new WdsImportParser();
+    // Tracks nesting inside iconOnly <SegmentedControl> elements. A stack (not a
+    // flag) so items inside a nested non-iconOnly control are judged against the
+    // NEAREST root, and map-rendered items are still covered (AST traversal keeps
+    // the stack alive through arbitrary expression nesting).
+    const iconOnlyStack: Array<boolean> = [];
+
+    const isSegmentedControlRoot = (node: JSXElement) => {
+      const name = importParser.getComponentName(node.openingElement as Node);
+
+      return (
+        importParser.isWdsComponent(name) &&
+        importParser.resolveImportedName(name) === ROOT_COMPONENT
+      );
+    };
+
+    return {
+      ImportDeclaration(node) {
+        importParser.saveImportDeclaration(node);
+      },
+      JSXElement: (estreeNode: Node) => {
+        const node = estreeNode as unknown as JSXElement;
+
+        if (!isSegmentedControlRoot(node)) {
+          return;
+        }
+
+        const iconOnlyProp = getProp(
+          node.openingElement.attributes,
+          'iconOnly',
+        );
+        const iconOnlyValue = iconOnlyProp
+          ? getLiteralPropValue(iconOnlyProp)
+          : null;
+
+        iconOnlyStack.push(iconOnlyValue === true);
+      },
+      'JSXElement:exit': (estreeNode: Node) => {
+        const node = estreeNode as unknown as JSXElement;
+
+        if (isSegmentedControlRoot(node)) {
+          iconOnlyStack.pop();
+        }
+      },
+      JSXOpeningElement: (node: Node) => {
+        if (iconOnlyStack[iconOnlyStack.length - 1] !== true) {
+          return;
+        }
+
+        const name = importParser.getComponentName(node);
+
+        if (
+          !importParser.isWdsComponent(name) ||
+          importParser.resolveImportedName(name) !== ITEM_COMPONENT
+        ) {
+          return;
+        }
+
+        const element = node as JSXOpeningElement;
+
+        if (
+          isHidden(elementType(element), element.attributes) ||
+          isPresentationRole(element.attributes)
+        ) {
+          return;
+        }
+
+        const ariaLabelProp = getProp(element.attributes, 'aria-label');
+        const ariaLabelledByProp = getProp(
+          element.attributes,
+          'aria-labelledby',
+        );
+
+        if (Boolean(ariaLabelProp) || Boolean(ariaLabelledByProp)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'error',
+        });
+      },
+    };
+  },
+} satisfies Rule.RuleModule;


### PR DESCRIPTION
## Summary

- `SegmentedControl`의 `variant` prop 제거 — `outlined`가 삭제되고 solid 단일 형태로 통일. 대체 값이 없으며, `outlined` 전용 스타일(투명 배경 + 외곽선, 아이템 구분선, brand 톤 선택 상태)이 모두 사라지고 thumb 이동 애니메이션이 적용됩니다.
- `SegmentedControlItem`의 `leadingContent` → `leadingIcon` 이름 변경, `trailingContent` 제거(대체 없음).
- `iconOnly` prop 추가 — 아이콘을 children으로 전달하는 아이콘 전용 모드. 루트 너비가 `fit-content`가 되고 텍스트 래퍼가 렌더되지 않으므로 아이템마다 `aria-label`이 필요합니다.
- 사이즈 체계 토큰화 — 루트 radius 8/10/12 → 10/12/14px, padding 통일(4px), 아이템 typography 한 단계 축소(label2/body2/headline2 → caption1/label1/body2), icon size·gap 조정, thumb 그림자를 `semantic.elevation.shadow.normal.xsmall` 토큰으로 교체.
- `TextAreaContent`의 `variant="segmented-control"`이 내부 스타일을 주입하지 않도록 정리 — TextArea 안에 넣는 `SegmentedControl`에 `iconOnly`를 직접 지정합니다.
- `MIGRATION.md` 4.0.0에 SegmentedControl 가이드 추가, v3→v4 마이그레이션 스킬에 M11 섹션 반영.
- 마이그레이션 스킬 검증에서 드러난 기존 결함 수정 — target 중복/외부 경로 미검출로 codemod가 두 번 도는 경로, BSD grep에서 무력화되던 M2 스캔 패턴, 누락된 Card/ListCard 리네임 표(22개), step ⑤ precheck 데드락, step ⑥ 제외 파일 손실 경로, codemod 버전 해석 명령 오류 등.

## Jira

[WRP-1627](https://wantedlab.atlassian.net/browse/WRP-1627) — [WDS] Segmented Control 업데이트

- Status: 진행 중
- Type: 하위 작업

Figma 0 Component 브랜치 및 개선-Components 상세 내역 기준으로 Segmented Control을 업데이트합니다.

## Test plan

- [ ] Small / Medium / Large 각 사이즈에서 선택 이동 애니메이션과 thumb 위치 확인
- [ ] `iconOnly` 모드 — 아이콘 크기·padding, 루트가 `fit-content`로 렌더되는지, 스크린리더에서 `aria-label`이 읽히는지 확인
- [ ] `leadingIcon`을 쓴 경우 텍스트와의 gap(4/6/6px) 및 ellipsis 동작 확인
- [ ] TextArea leading/trailing content에 넣은 `SegmentedControl`(`size="small" iconOnly`) 레이아웃 확인
- [ ] 반응형 `size` prop이 breakpoint별로 적용되는지 확인
- [ ] 기존 `variant="outlined"` 사용처의 시각 변화 QA (대체 없음 — solid로 렌더)

[WRP-1627]: https://wantedlab.atlassian.net/browse/WRP-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - `SegmentedControl`의 아이콘 전용 모드(`iconOnly`) 추가, 아이콘은 `leadingIcon` 기반으로 구성됩니다.
  - 아이콘 전용에서는 접근성 이름(`aria-label`/`aria-labelledby`) 제공을 요구하며, ESLint 규칙으로 점검합니다.
- **변경 사항**
  - `SegmentedControl`의 `variant(solid/outlined)` 및 `trailingContent` 지원이 제거되고, 아이콘 전용 여부에 따라 스타일/렌더링이 재정리됩니다.
  - 관련 문서 데모와 `TextArea` 내 예제가 아이콘 전용 방식으로 업데이트되었습니다.
- **문서/가이드**
  - Montage v3→v4 마이그레이션 문서의 절차·범위가 보강되었습니다.
- **테스트**
  - 접근성 규칙(`iconOnly` 누락 점검) 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->