### PR TITLE
feat(*): typography 토큰을 css variable로 전환

### DIFF
--- a/packages/core/scripts/build.mjs
+++ b/packages/core/scripts/build.mjs
@@ -61,6 +61,7 @@ const themeInvariant = [
   ...objectToCssKey(lightOriginTheme.spacing, 'spacing'),
   ...objectToCssKey(lightOriginTheme.radius, 'radius'),
   ...objectToCssKey(lightOriginTheme.dimension, 'dimension'),
+  ...objectToCssKey(lightOriginTheme.typography, 'typography'),
   ...objectToCssKey(lightOriginTheme.zIndex, 'zIndex'),
 ].flat(Infinity);
 const light = [

--- a/packages/core/src/components/typography/style.test.ts
+++ b/packages/core/src/components/typography/style.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { lightOriginTheme } from '@montage-ui/engine';
+
+import { getWeightMap, variantMap } from './style';
+
+import type { TypographyVariant } from './types';
+
+const VARIANTS: Array<TypographyVariant> = [
+  'display1',
+  'display2',
+  'display3',
+  'title1',
+  'title2',
+  'title3',
+  'heading1',
+  'heading2',
+  'headline1',
+  'headline2',
+  'body1',
+  'body1-reading',
+  'body2',
+  'body2-reading',
+  'label1',
+  'label1-reading',
+  'label2',
+  'caption1',
+  'caption2',
+];
+
+/** Variants whose `bold` weight is 700 rather than 600. */
+const HEAVY_BOLD_VARIANTS: Array<TypographyVariant> = [
+  'display1',
+  'display2',
+  'display3',
+  'title1',
+  'title2',
+  'title3',
+];
+
+/** `body1-reading` (public variant name) -> `body1Reading` (theme token key) */
+const toTokenKey = (variant: TypographyVariant) =>
+  variant.replace(/-(\w)/g, (_match: string, char: string) =>
+    char.toUpperCase(),
+  ) as keyof typeof lightOriginTheme.typography;
+
+describe('variantMap', () => {
+  it('is keyed by the kebab-case public variant name, not the camelCase token key', () => {
+    expect(Object.keys(variantMap).sort()).toEqual([...VARIANTS].sort());
+  });
+
+  it('references the css variables of the matching camelCase token', () => {
+    expect(variantMap['body2-reading'].styles).toContain(
+      'font-size: var(--typography-body2Reading-fontSize)',
+    );
+    expect(variantMap['body2-reading'].styles).toContain(
+      'line-height: var(--typography-body2Reading-lineHeight)',
+    );
+    expect(variantMap['body2-reading'].styles).toContain(
+      'letter-spacing: var(--typography-body2Reading-letterSpacing)',
+    );
+  });
+
+  it('keeps digits attached to the variant name', () => {
+    expect(variantMap.display1.styles).toContain(
+      'var(--typography-display1-fontSize)',
+    );
+  });
+});
+
+describe('getWeightMap', () => {
+  it.each(VARIANTS)(
+    'resolves every weight of %s to its own token',
+    (variant) => {
+      const tokenKey = toTokenKey(variant);
+      const weightMap = getWeightMap(variant);
+
+      expect(weightMap.regular.styles).toContain(
+        `var(--typography-${tokenKey}-weight-regular)`,
+      );
+      expect(weightMap.medium.styles).toContain(
+        `var(--typography-${tokenKey}-weight-medium)`,
+      );
+      expect(weightMap.bold.styles).toContain(
+        `var(--typography-${tokenKey}-weight-bold)`,
+      );
+    },
+  );
+});
+
+describe('bold weight tokens', () => {
+  it.each(HEAVY_BOLD_VARIANTS)('resolves %s bold to 700', (variant) => {
+    expect(lightOriginTheme.typography[toTokenKey(variant)].weight.bold).toBe(
+      700,
+    );
+  });
+
+  it.each(VARIANTS.filter((v) => !HEAVY_BOLD_VARIANTS.includes(v)))(
+    'resolves %s bold to 600',
+    (variant) => {
+      expect(lightOriginTheme.typography[toTokenKey(variant)].weight.bold).toBe(
+        600,
+      );
+    },
+  );
+});

--- a/packages/core/src/components/typography/style.ts
+++ b/packages/core/src/components/typography/style.ts
@@ -1,131 +1,51 @@
-import { css } from '@montage-ui/engine';
+import { css, typographyVar } from '@montage-ui/engine';
 
 import { type TypographyVariant, type TypographyWeight } from './types';
 
 import type { SerializedStyles } from '@montage-ui/engine';
 
-export const variantMap: {
+/** `body1Reading` (theme token key) -> `body1-reading` (public variant name) */
+const toVariantName = (key: string) =>
+  key.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+
+const tokenEntries = Object.entries(typographyVar);
+
+export const variantMap = Object.fromEntries(
+  tokenEntries.map(([key, token]) => [
+    toVariantName(key),
+    css`
+      font-size: ${token.fontSize};
+      line-height: ${token.lineHeight};
+      letter-spacing: ${token.letterSpacing};
+    `,
+  ]),
+) as {
   [key in TypographyVariant]: SerializedStyles;
-} = {
-  display1: css`
-    font-size: 3.5rem;
-    line-height: 4.5rem;
-    letter-spacing: -0.0319em;
-  `,
-  display2: css`
-    font-size: 2.5rem;
-    line-height: 3.25rem;
-    letter-spacing: -0.0282em;
-  `,
-  display3: css`
-    font-size: 2.25rem;
-    line-height: 3rem;
-    letter-spacing: -0.027em;
-  `,
-  title1: css`
-    font-size: 2rem;
-    line-height: 2.75rem;
-    letter-spacing: -0.0253em;
-  `,
-  title2: css`
-    font-size: 1.75rem;
-    line-height: 2.375rem;
-    letter-spacing: -0.0236em;
-  `,
-  title3: css`
-    font-size: 1.5rem;
-    line-height: 2rem;
-    letter-spacing: -0.023em;
-  `,
-  heading1: css`
-    font-size: 1.375rem;
-    line-height: 1.875rem;
-    letter-spacing: -0.0194em;
-  `,
-  heading2: css`
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-    letter-spacing: -0.012em;
-  `,
-  headline1: css`
-    font-size: 1.125rem;
-    line-height: 1.625rem;
-    letter-spacing: -0.002em;
-  `,
-  headline2: css`
-    font-size: 1.0625rem;
-    line-height: 1.5rem;
-    letter-spacing: 0em;
-  `,
-  body1: css`
-    font-size: 1rem;
-    line-height: 1.5rem;
-    letter-spacing: 0.0057em;
-  `,
-  'body1-reading': css`
-    font-size: 1rem;
-    line-height: 1.625rem;
-    letter-spacing: 0.0057em;
-  `,
-  body2: css`
-    font-size: 0.9375rem;
-    line-height: 1.375rem;
-    letter-spacing: 0.0096em;
-  `,
-  'body2-reading': css`
-    font-size: 0.9375rem;
-    line-height: 1.5rem;
-    letter-spacing: 0.0096em;
-  `,
-  label1: css`
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    letter-spacing: 0.0145em;
-  `,
-  'label1-reading': css`
-    font-size: 0.875rem;
-    line-height: 1.375rem;
-    letter-spacing: 0.0145em;
-  `,
-  label2: css`
-    font-size: 0.8125rem;
-    line-height: 1.125rem;
-    letter-spacing: 0.0194em;
-  `,
-  caption1: css`
-    font-size: 0.75rem;
-    line-height: 1rem;
-    letter-spacing: 0.0252em;
-  `,
-  caption2: css`
-    font-size: 0.6875rem;
-    line-height: 0.875rem;
-    letter-spacing: 0.0311em;
-  `,
-} as const;
+};
+
+const weightMap = Object.fromEntries(
+  tokenEntries.map(([key, token]) => [
+    toVariantName(key),
+    {
+      regular: css`
+        font-weight: ${token.weight.regular};
+      `,
+      medium: css`
+        font-weight: ${token.weight.medium};
+      `,
+      bold: css`
+        font-weight: ${token.weight.bold};
+      `,
+    },
+  ]),
+) as {
+  [variant in TypographyVariant]: {
+    [weight in TypographyWeight]: SerializedStyles;
+  };
+};
 
 export const getWeightMap = (
   variant: TypographyVariant,
 ): {
   [key in TypographyWeight]: SerializedStyles;
-} => ({
-  regular: css`
-    font-weight: 400;
-  `,
-  medium: css`
-    font-weight: 500;
-  `,
-  bold:
-    variant === 'display1' ||
-    variant === 'display2' ||
-    variant === 'display3' ||
-    variant === 'title1' ||
-    variant === 'title2' ||
-    variant === 'title3'
-      ? css`
-          font-weight: 700;
-        `
-      : css`
-          font-weight: 600;
-        `,
-});
+} => weightMap[variant];

--- a/packages/core/src/components/typography/types.ts
+++ b/packages/core/src/components/typography/types.ts
@@ -2,32 +2,13 @@ import type {
   Merge,
   ResponsiveProps,
   ThemeColorsToken,
+  TypographyVariant,
+  TypographyWeight,
   WithSxProps,
 } from '@montage-ui/engine';
 import type { CSSProperties, ReactNode } from 'react';
 
-export type TypographyVariant =
-  | 'display1'
-  | 'display2'
-  | 'display3'
-  | 'title1'
-  | 'title2'
-  | 'title3'
-  | 'heading1'
-  | 'heading2'
-  | 'headline1'
-  | 'headline2'
-  | 'body1'
-  | 'body1-reading'
-  | 'body2'
-  | 'body2-reading'
-  | 'label1'
-  | 'label1-reading'
-  | 'label2'
-  | 'caption1'
-  | 'caption2';
-
-export type TypographyWeight = 'regular' | 'medium' | 'bold';
+export type { TypographyVariant, TypographyWeight };
 
 export type TypographyDefaultProps = WithSxProps<{
   variant?: TypographyVariant;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export type {
   ThemeSpacingToken,
   ThemeDimensionToken,
   ThemeRadiusToken,
+  ThemeTypographyToken,
   ThemeZIndexToken,
   ThemeToken,
   CacheOptions,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,6 +2,7 @@ export {
   theme,
   lightOriginTheme,
   darkOriginTheme,
+  typographyVar,
   getColorByToken,
   addHexOpacity,
 } from '@montage-ui/theme';

--- a/packages/engine/src/types/index.ts
+++ b/packages/engine/src/types/index.ts
@@ -20,7 +20,11 @@ export {
   type ThemeSpacingToken,
   type ThemeDimensionToken,
   type ThemeRadiusToken,
+  type ThemeTypographyToken,
   type ThemeZIndexToken,
+  type TypographyVariant,
+  type TypographyVariantKey,
+  type TypographyWeight,
 } from '@montage-ui/theme';
 export type {
   EmotionCache,

--- a/packages/theme/src/theme/index.ts
+++ b/packages/theme/src/theme/index.ts
@@ -6,6 +6,7 @@ import opacity from './opacity';
 import primitive from './primitive';
 import radius from './radius';
 import spacing from './spacing';
+import typography from './typography';
 import zIndex from './z-index';
 import atomic from './atomic';
 import * as semantic from './semantic';
@@ -32,6 +33,7 @@ export const lightOriginTheme = {
   spacing,
   radius,
   dimension,
+  typography,
   zIndex,
 };
 
@@ -57,6 +59,7 @@ export const darkOriginTheme = {
   spacing,
   radius,
   dimension,
+  typography,
   zIndex,
 };
 
@@ -98,6 +101,16 @@ const dimensionVar = addVarPrefix(
 ) as typeof dimension;
 const zIndexVar = addVarPrefix(zIndex, 'zIndex', true) as typeof zIndex;
 
+/**
+ * Typography tokens as css variable references. Exported on its own because
+ * typography is theme invariant, so consumers can read it without a theme.
+ */
+export const typographyVar = addVarPrefix(
+  typography,
+  'typography',
+  true,
+) as typeof typography;
+
 export const lightTheme = {
   ...lightOriginTheme,
   atomic: addVarPrefix(atomic, 'atomic') as typeof atomic,
@@ -118,6 +131,7 @@ export const lightTheme = {
   spacing: spacingVar,
   radius: radiusVar,
   dimension: dimensionVar,
+  typography: typographyVar,
   zIndex: zIndexVar,
 };
 
@@ -141,6 +155,7 @@ export const darkTheme = {
   spacing: spacingVar,
   radius: radiusVar,
   dimension: dimensionVar,
+  typography: typographyVar,
   zIndex: zIndexVar,
 };
 

--- a/packages/theme/src/theme/typography/index.ts
+++ b/packages/theme/src/theme/typography/index.ts
@@ -1,0 +1,122 @@
+/**
+ * Keys are camelCase (`body1Reading`); the public `variant` name is the
+ * kebab-case form of the key (`body1-reading`).
+ */
+const typography = {
+  display1: {
+    fontSize: '3.5rem',
+    lineHeight: '4.5rem',
+    letterSpacing: '-0.0319em',
+    weight: { regular: 400, medium: 500, bold: 700 },
+  },
+  display2: {
+    fontSize: '2.5rem',
+    lineHeight: '3.25rem',
+    letterSpacing: '-0.0282em',
+    weight: { regular: 400, medium: 500, bold: 700 },
+  },
+  display3: {
+    fontSize: '2.25rem',
+    lineHeight: '3rem',
+    letterSpacing: '-0.027em',
+    weight: { regular: 400, medium: 500, bold: 700 },
+  },
+  title1: {
+    fontSize: '2rem',
+    lineHeight: '2.75rem',
+    letterSpacing: '-0.0253em',
+    weight: { regular: 400, medium: 500, bold: 700 },
+  },
+  title2: {
+    fontSize: '1.75rem',
+    lineHeight: '2.375rem',
+    letterSpacing: '-0.0236em',
+    weight: { regular: 400, medium: 500, bold: 700 },
+  },
+  title3: {
+    fontSize: '1.5rem',
+    lineHeight: '2rem',
+    letterSpacing: '-0.023em',
+    weight: { regular: 400, medium: 500, bold: 700 },
+  },
+  heading1: {
+    fontSize: '1.375rem',
+    lineHeight: '1.875rem',
+    letterSpacing: '-0.0194em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  heading2: {
+    fontSize: '1.25rem',
+    lineHeight: '1.75rem',
+    letterSpacing: '-0.012em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  headline1: {
+    fontSize: '1.125rem',
+    lineHeight: '1.625rem',
+    letterSpacing: '-0.002em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  headline2: {
+    fontSize: '1.0625rem',
+    lineHeight: '1.5rem',
+    letterSpacing: '0em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  body1: {
+    fontSize: '1rem',
+    lineHeight: '1.5rem',
+    letterSpacing: '0.0057em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  body1Reading: {
+    fontSize: '1rem',
+    lineHeight: '1.625rem',
+    letterSpacing: '0.0057em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  body2: {
+    fontSize: '0.9375rem',
+    lineHeight: '1.375rem',
+    letterSpacing: '0.0096em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  body2Reading: {
+    fontSize: '0.9375rem',
+    lineHeight: '1.5rem',
+    letterSpacing: '0.0096em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  label1: {
+    fontSize: '0.875rem',
+    lineHeight: '1.25rem',
+    letterSpacing: '0.0145em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  label1Reading: {
+    fontSize: '0.875rem',
+    lineHeight: '1.375rem',
+    letterSpacing: '0.0145em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  label2: {
+    fontSize: '0.8125rem',
+    lineHeight: '1.125rem',
+    letterSpacing: '0.0194em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  caption1: {
+    fontSize: '0.75rem',
+    lineHeight: '1rem',
+    letterSpacing: '0.0252em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+  caption2: {
+    fontSize: '0.6875rem',
+    lineHeight: '0.875rem',
+    letterSpacing: '0.0311em',
+    weight: { regular: 400, medium: 500, bold: 600 },
+  },
+} as const;
+
+export default typography;

--- a/packages/theme/src/types/index.ts
+++ b/packages/theme/src/types/index.ts
@@ -36,8 +36,36 @@ export type ThemeColorsToken =
       'semantic.platform.ios.navigation' | ThemeShadowToken
     >;
 export type ThemeOpacityToken = ObjectToNestedKeys<Pick<Theme, 'opacity'>>;
+export type ThemeTypographyToken = ObjectToNestedKeys<
+  Pick<Theme, 'typography'>
+>;
 export type ThemePrimitiveToken = ObjectToNestedKeys<Pick<Theme, 'primitive'>>;
 export type ThemeSpacingToken = ObjectToNestedKeys<Pick<Theme, 'spacing'>>;
 export type ThemeDimensionToken = ObjectToNestedKeys<Pick<Theme, 'dimension'>>;
 export type ThemeRadiusToken = ObjectToNestedKeys<Pick<Theme, 'radius'>>;
 export type ThemeZIndexToken = ObjectToNestedKeys<Pick<Theme, 'zIndex'>>;
+
+/**
+ * Converts a camelCase key into its kebab-case form.
+ * The uppercase-and-lowercase branch keeps digits from gaining a separator,
+ * so `display1` stays `display1` instead of becoming `display-1`.
+ *
+ * @example
+ * type A = KebabCase<'body2Reading'>; // 'body2-reading'
+ */
+type KebabCase<S extends string> = S extends `${infer Head}${infer Tail}`
+  ? Head extends Uppercase<Head>
+    ? Head extends Lowercase<Head>
+      ? `${Head}${KebabCase<Tail>}`
+      : `-${Lowercase<Head>}${KebabCase<Tail>}`
+    : `${Head}${KebabCase<Tail>}`
+  : S;
+
+/** camelCase key of a typography token, e.g. `body2Reading`. */
+export type TypographyVariantKey = keyof Theme['typography'];
+
+/** Public `variant` name, e.g. `body2-reading`. */
+export type TypographyVariant = KebabCase<TypographyVariantKey>;
+
+export type TypographyWeight =
+  keyof Theme['typography'][TypographyVariantKey]['weight'];


### PR DESCRIPTION
## Summary

- 타이포그래피 값(`font-size` / `line-height` / `letter-spacing` / `font-weight`)을 `packages/theme`의 토큰으로 올리고, 빌드 시 `theme.css`에 CSS variable 114개(19 variant × 6)로 발행합니다.
- variant별 bold weight가 토큰 데이터가 되면서 `getWeightMap`의 display/title 분기가 사라졌습니다. 시그니처는 그대로라 호출부는 변경이 없습니다.
- 공개 variant 이름은 kebab(`body2-reading`)으로 유지하고, 토큰 키와 CSS variable만 camelCase(`body2Reading`)로 분리했습니다.
- `TypographyVariant` / `TypographyWeight`를 theme에서 파생시켜 손으로 관리하던 19줄 유니온을 제거했습니다.
- `style.ts` 131줄 → 49줄.

## Jira

[WRP-2012](https://wantedlab.atlassian.net/browse/WRP-2012) — [WDS] 타이포그래피 CSS Variable 변경

- Status: 진행 중
- Type: 작업

## 배경

타이포그래피 값이 core의 `variantMap`에만 있어 CSS로 재정의할 수 없었고, variant별 bold weight(display/title 700, 그 외 600)가 JS 분기로 하드코딩돼 있었습니다. 값을 theme 토큰으로 올리면 이 규칙이 코드 분기가 아니라 데이터가 됩니다.

## 토큰 구조

모든 variant가 동일한 모양을 갖도록 weight를 variant 안에 대칭으로 넣었습니다.

```ts
// packages/theme/src/theme/typography/index.ts
body2Reading: {
  fontSize: '0.9375rem',
  lineHeight: '1.5rem',
  letterSpacing: '0.0096em',
  weight: { regular: 400, medium: 500, bold: 600 },
}
```

발행되는 변수:

```css
--typography-body2Reading-fontSize: 0.9375rem;
--typography-body2Reading-lineHeight: 1.5rem;
--typography-body2Reading-letterSpacing: 0.0096em;
--typography-body2Reading-weight-regular: 400;
--typography-body2Reading-weight-medium: 500;
--typography-body2Reading-weight-bold: 600;
```

`regular: 400` / `medium: 500`이 19번 반복되어 중복 변수 38개가 생기지만, 동일 문자열 반복이라 gzip 이후 비용은 사실상 없고 variant 하나만 특별 취급하는 비대칭을 피할 수 있습니다.

## 네이밍

`KebabCase<keyof Theme['typography']>`로 공개 이름을 파생시킵니다. 런타임 변환은 맵을 만들 때 camel → kebab 한 방향으로만 일어납니다.

| 항목 | 값 |
| --- | --- |
| 공개 `variant` prop | `body2-reading` (변경 없음) |
| theme 토큰 키 / CSS variable | `body2Reading` |

`display1`이 `display-1`로 깨지지 않도록 숫자 분기를 넣었고, 파생된 유니온이 기존 수동 유니온과 **완전히 동일**함을 타입 단언으로 검증했습니다.

## 호환성

공개 API 변경은 없습니다.

- `TypographyVariant` / `TypographyWeight` 유니온 동일
- `variantMap` / `getWeightMap`은 내부 모듈이라 미공개
- `typographyStyle('body2-reading', ...)` 등 기존 사용처(text-area, fallback-view, section-message, modal, list) 전부 무변경
- 추가 export: `typographyVar`, `ThemeTypographyToken`

렌더링이 리터럴 값에서 `var()` 참조로 바뀌므로 `@montage-ui/core/theme.css`(또는 `global.css`) 로드가 필요합니다. 4.0.0에서 다른 토큰 그룹이 이미 var화되어 동일 요건이 걸려 있으므로 새로 생기는 제약은 아닙니다. 별도 마이그레이션 항목은 두지 않았습니다.

## Test plan

- [x] `pnpm build` — 11개 패키지 통과
- [x] `pnpm test:unit` — 349개 통과 (신규 `style.test.ts` 41개 포함)
- [x] `pnpm lint` — 통과
- [x] `theme.css` 산출물에 typography 변수 114개 발행 확인
- [x] 빌드 산출물 직접 실행해 `variantMap` 키가 kebab 19개이고 camelCase 토큰 변수를 참조하는 것 확인
- [x] 변경 전 `variantMap` 리터럴과 대조 — 19개 variant × 6개 속성(114개) 값 전부 일치, `var()`를 theme.css 값으로 해석한 뒤 선언 76블록(variant 19 + weight 57)의 속성명·값·순서까지 완전 동일
- [ ] CI 시각 회귀 테스트 — 값은 동일하고 `var()` 한 겹만 끼는 변경이라 렌더링은 같아야 합니다. 스냅샷은 CI에서만 생성하는 정책이라 로컬에서 갱신하지 않았습니다.

[WRP-2012]: https://wantedlab.atlassian.net/browse/WRP-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 타이포그래피 토큰과 스타일 변수가 테마에 추가되었습니다.
  * 다양한 타이포그래피 변형 및 글꼴 굵기 설정이 테마 토큰을 기반으로 자동 적용됩니다.
  * 라이트·다크 테마의 CSS 변수에 타이포그래피 관련 값이 포함됩니다.
  * 타이포그래피 변형, 토큰, 굵기 타입이 공개 API에 추가되었습니다.

* **테스트**
  * 타이포그래피 변형 및 굵기 매핑에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
