### PR TITLE
fix(wds): slider thumb이 겹칠 때 조작과 완료 콜백이 끊기는 문제 수정

### DIFF
--- a/packages/wds/src/components/slider/helpers.ts
+++ b/packages/wds/src/components/slider/helpers.ts
@@ -30,5 +30,18 @@ export const getClosestThumbIndex = (
   if (values.length === 1) return 0;
   const distances = values.map((value) => Math.abs(value - nextValue));
   const closestDistance = Math.min(...distances);
-  return distances.indexOf(closestDistance);
+
+  const firstIndex = distances.indexOf(closestDistance);
+  const lastIndex = distances.lastIndexOf(closestDistance);
+
+  /**
+   * When thumbs sit on the exact same value, `indexOf` always resolves to the
+   * leftmost one. Pick the thumb on the side being dragged instead, otherwise
+   * stacked thumbs can no longer be pulled apart.
+   */
+  if (firstIndex !== lastIndex && values[firstIndex] === values[lastIndex]) {
+    return nextValue > values[firstIndex]! ? lastIndex : firstIndex;
+  }
+
+  return firstIndex;
 };

--- a/packages/wds/src/components/slider/index.test.tsx
+++ b/packages/wds/src/components/slider/index.test.tsx
@@ -312,6 +312,14 @@ describe('when operating a slider with the keyboard', () => {
     expect(getValues(container)).toEqual(['55']);
   });
 
+  it('should scale a custom step by ten for skip keys', () => {
+    const { container } = setup({ step: 2 });
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'PageUp' });
+
+    expect(getValues(container)).toEqual(['70']);
+  });
+
   it('should jump to the bounds on Home and End', () => {
     const { container } = setup();
     const thumb = focusThumb(container, 0);
@@ -826,24 +834,14 @@ describe.skip('when submitting an uncontrolled range slider', () => {
 });
 
 /**
- * `snapToStep` computes `((next - min) / step) * step`, where `step` cancels
- * itself out — so pointer positions never snap to the step grid and fractional
- * steps are rounded to whole numbers. Enable these once the formula is fixed to
- * `Math.round((next - min) / step) * step + min`.
+ * `step` is the keyboard travel distance, and whole-number steps work. But
+ * `snapToStep` reduces to `Math.round(nextValue)` — the `((next - min) / step) *
+ * step` factor cancels itself out — so a fractional step is rounded to the
+ * nearest integer: `0.5` travels a whole 1, and `0.1` never moves at all.
+ * Enable once the rounding respects `step`.
  */
-describe.skip('when given a slider with a coarse step', () => {
-  it('should snap a pointer position onto the step grid', () => {
-    const { container } = render(
-      <Slider min={0} max={100} step={5} defaultValue={[0]} />,
-    );
-    stubTrackRect(container);
-
-    dragThumb(container, 0, 13);
-
-    expect(getValues(container)).toEqual(['15']);
-  });
-
-  it('should support fractional steps', () => {
+describe.skip('when given a slider with a fractional step', () => {
+  it('should travel by the fractional step', () => {
     const { container } = render(
       <Slider min={0} max={10} step={0.5} defaultValue={[0]} />,
     );
@@ -851,5 +849,15 @@ describe.skip('when given a slider with a coarse step', () => {
     fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
 
     expect(getValues(container)).toEqual(['0.5']);
+  });
+
+  it('should move even when the step is smaller than one', () => {
+    const { container } = render(
+      <Slider min={0} max={10} step={0.1} defaultValue={[0]} />,
+    );
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(getValues(container)).toEqual(['0.1']);
   });
 });

--- a/packages/wds/src/components/slider/index.test.tsx
+++ b/packages/wds/src/components/slider/index.test.tsx
@@ -1,0 +1,855 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+
+import {
+  clamp,
+  convertValueToPercentage,
+  getClosestThumbIndex,
+  linearScale,
+} from './helpers';
+
+import { Slider } from '.';
+
+const TRACK_WIDTH = 100;
+
+/**
+ * jsdom does not implement Pointer Capture, and its `PointerEvent` drops the
+ * coordinates `fireEvent.pointerMove` passes in — dispatch a `MouseEvent` so
+ * `clientX` survives.
+ */
+const firePointer = (
+  element: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  clientX: number,
+) => {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+  });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  fireEvent(element, event);
+};
+
+const getTrack = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>(
+    '[data-role="slider-progress-wrapper"]',
+  )!;
+
+const getThumbs = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>('[data-role="slider-thumb"]'),
+  );
+
+const getValues = (container: HTMLElement) =>
+  getThumbs(container).map((thumb) => thumb.getAttribute('aria-valuenow'));
+
+const getProgress = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('[data-role="slider-progress"]')!;
+
+/** `min` 0 / `max` 100 기준으로 clientX 가 곧 값이 되도록 트랙 크기를 고정한다. */
+const stubTrackRect = (container: HTMLElement) => {
+  vi.spyOn(getTrack(container), 'getBoundingClientRect').mockReturnValue({
+    width: TRACK_WIDTH,
+    left: 0,
+    right: TRACK_WIDTH,
+    top: 0,
+    bottom: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
+};
+
+/** 트랙 위 `clientX` 지점을 눌렀다 떼는 한 번의 클릭. */
+const clickTrack = (container: HTMLElement, clientX: number) => {
+  const track = getTrack(container);
+  firePointer(track, 'pointerdown', clientX);
+  firePointer(track, 'pointerup', clientX);
+};
+
+/** `index` 번째 thumb 을 잡고 `clientX` 까지 끌었다 놓는 드래그. */
+const dragThumb = (
+  container: HTMLElement,
+  index: number,
+  ...positions: Array<number>
+) => {
+  const thumb = getThumbs(container)[index]!;
+  firePointer(
+    thumb,
+    'pointerdown',
+    Number(thumb.getAttribute('aria-valuenow')),
+  );
+  fireEvent.focus(thumb);
+  positions.forEach((position) => firePointer(thumb, 'pointermove', position));
+  firePointer(thumb, 'pointerup', positions.at(-1)!);
+};
+
+const focusThumb = (container: HTMLElement, index: number) => {
+  const thumb = getThumbs(container)[index]!;
+  thumb.focus();
+  fireEvent.focus(thumb);
+  return thumb;
+};
+
+beforeAll(() => {
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+describe('when given slider helpers', () => {
+  it('should clamp a value into the given range', () => {
+    expect(clamp(5, [0, 10])).toBe(5);
+    expect(clamp(-1, [0, 10])).toBe(0);
+    expect(clamp(11, [0, 10])).toBe(10);
+    expect(clamp(0, [0, 0])).toBe(0);
+  });
+
+  it('should convert a value into a percentage of the range', () => {
+    expect(convertValueToPercentage(0, 0, 100)).toBe(0);
+    expect(convertValueToPercentage(50, 0, 100)).toBe(50);
+    expect(convertValueToPercentage(100, 0, 100)).toBe(100);
+    expect(convertValueToPercentage(15, 10, 20)).toBe(50);
+  });
+
+  it('should clamp the percentage when the value sits outside the range', () => {
+    expect(convertValueToPercentage(-10, 0, 100)).toBe(0);
+    expect(convertValueToPercentage(110, 0, 100)).toBe(100);
+  });
+
+  it('should map a pointer offset onto the value range', () => {
+    expect(linearScale([0, 100], [0, 100])(40)).toBe(40);
+    expect(linearScale([0, 200], [0, 100])(40)).toBe(20);
+    expect(linearScale([0, 100], [10, 20])(50)).toBe(15);
+  });
+
+  it('should fall back to the lower bound when a scale is degenerate', () => {
+    expect(linearScale([0, 0], [0, 100])(40)).toBe(0);
+    expect(linearScale([0, 100], [7, 7])(40)).toBe(7);
+  });
+
+  it('should return the nearest thumb', () => {
+    expect(getClosestThumbIndex([20, 60], 80)).toBe(1);
+    expect(getClosestThumbIndex([20, 60], 10)).toBe(0);
+    expect(getClosestThumbIndex([10], 90)).toBe(0);
+  });
+
+  it('should return the thumb on the dragged side when thumbs are stacked', () => {
+    expect(getClosestThumbIndex([0, 0], 50)).toBe(1);
+    expect(getClosestThumbIndex([50, 50], 80)).toBe(1);
+    expect(getClosestThumbIndex([50, 50], 20)).toBe(0);
+    expect(getClosestThumbIndex([100, 100], 50)).toBe(0);
+  });
+
+  it('should keep preferring the leading thumb when the tie is not a stack', () => {
+    expect(getClosestThumbIndex([0, 10], 5)).toBe(0);
+  });
+});
+
+describe('when given a single-thumb slider', () => {
+  it('should render one thumb at the minimum by default', () => {
+    const { container } = render(<Slider min={10} max={50} />);
+
+    expect(getThumbs(container)).toHaveLength(1);
+    expect(getValues(container)).toEqual(['10']);
+  });
+
+  it('should expose the range through aria attributes', () => {
+    const { container } = render(
+      <Slider min={10} max={50} defaultValue={[30]} />,
+    );
+    const thumb = getThumbs(container)[0]!;
+
+    expect(thumb).toHaveAttribute('role', 'slider');
+    expect(thumb).toHaveAttribute('aria-valuemin', '10');
+    expect(thumb).toHaveAttribute('aria-valuemax', '50');
+    expect(thumb).toHaveAttribute('aria-valuenow', '30');
+    expect(thumb).toHaveAttribute('tabindex', '0');
+  });
+
+  it('should fill the progress bar from the start of the track', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[40]} />,
+    );
+
+    expect(getProgress(container)).toHaveStyle({ left: '0%', right: '60%' });
+  });
+});
+
+describe('when given a range slider', () => {
+  it('should render a thumb per value', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20, 60, 80]} />,
+    );
+
+    expect(getValues(container)).toEqual(['20', '60', '80']);
+  });
+
+  it('should span the progress bar between the outermost values', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20, 60]} />,
+    );
+
+    expect(getProgress(container)).toHaveStyle({ left: '20%', right: '40%' });
+  });
+});
+
+describe('when given title and label', () => {
+  it('should render static nodes as given', () => {
+    const { container } = render(
+      <Slider defaultValue={[30]} title="제목" label="라벨" />,
+    );
+
+    expect(screen.getByText('제목')).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[data-role="slider-label"]'),
+    ).toHaveLength(1);
+  });
+
+  it('should call the title renderer with the current state', () => {
+    const title = vi.fn(() => <span>title</span>);
+
+    render(<Slider min={0} max={100} defaultValue={[20, 60]} title={title} />);
+
+    expect(title).toHaveBeenCalledWith({
+      values: [20, 60],
+      min: 0,
+      max: 100,
+      disabled: undefined,
+    });
+  });
+
+  it('should render a label per thumb with its own index', () => {
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        label={({ value, index }) => `${index}:${value}`}
+      />,
+    );
+
+    const labels = Array.from(
+      container.querySelectorAll('[data-role="slider-label"]'),
+    );
+    expect(labels.map((label) => label.textContent)).toEqual(['0:20', '1:60']);
+  });
+
+  it('should skip labels the renderer opts out of', () => {
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        label={({ index }) => (index === 0 ? 'only first' : null)}
+      />,
+    );
+
+    expect(
+      container.querySelectorAll('[data-role="slider-label"]'),
+    ).toHaveLength(1);
+  });
+});
+
+describe('when operating a slider with the keyboard', () => {
+  const setup = (props = {}) => {
+    const onValueChange = vi.fn();
+    const onValueChangeComplete = vi.fn();
+    const view = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[50]}
+        onValueChange={onValueChange}
+        onValueChangeComplete={onValueChangeComplete}
+        {...props}
+      />,
+    );
+    return { ...view, onValueChange, onValueChangeComplete };
+  };
+
+  it.each([
+    ['ArrowRight', '51'],
+    ['ArrowUp', '51'],
+    ['ArrowLeft', '49'],
+    ['ArrowDown', '49'],
+  ])('should move by one step on %s', (key, expected) => {
+    const { container } = setup();
+
+    fireEvent.keyDown(focusThumb(container, 0), { key });
+
+    expect(getValues(container)).toEqual([expected]);
+  });
+
+  it.each([
+    ['PageUp', false, '60'],
+    ['PageDown', false, '40'],
+    ['ArrowRight', true, '60'],
+    ['ArrowLeft', true, '40'],
+  ])(
+    'should move by ten steps on %s (shift: %s)',
+    (key, shiftKey, expected) => {
+      const { container } = setup();
+
+      fireEvent.keyDown(focusThumb(container, 0), { key, shiftKey });
+
+      expect(getValues(container)).toEqual([expected]);
+    },
+  );
+
+  it('should honour a custom step', () => {
+    const { container } = setup({ step: 5 });
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(getValues(container)).toEqual(['55']);
+  });
+
+  it('should jump to the bounds on Home and End', () => {
+    const { container } = setup();
+    const thumb = focusThumb(container, 0);
+
+    fireEvent.keyDown(thumb, { key: 'End' });
+    expect(getValues(container)).toEqual(['100']);
+
+    fireEvent.keyDown(thumb, { key: 'Home' });
+    expect(getValues(container)).toEqual(['0']);
+  });
+
+  it('should clamp at the bounds instead of overshooting', () => {
+    const { container } = setup({ defaultValue: [100] });
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(getValues(container)).toEqual(['100']);
+  });
+
+  it('should report every keyboard change as completed', () => {
+    const { container, onValueChange, onValueChangeComplete } = setup();
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(onValueChange).toHaveBeenCalledWith([51]);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([51]);
+  });
+
+  it('should not fire callbacks when the value cannot move', () => {
+    const { container, onValueChange, onValueChangeComplete } = setup({
+      defaultValue: [100],
+    });
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onValueChangeComplete).not.toHaveBeenCalled();
+  });
+
+  it('should ignore keys that are not slider controls', () => {
+    const { container, onValueChange } = setup();
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'a' });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('should move only the focused thumb of a range slider', () => {
+    const { container } = setup({ defaultValue: [20, 60] });
+
+    fireEvent.keyDown(focusThumb(container, 1), { key: 'ArrowRight' });
+
+    expect(getValues(container)).toEqual(['20', '61']);
+  });
+
+  it('should still run the consumer onKeyDown handler', () => {
+    const onKeyDown = vi.fn();
+    const { container } = setup({ onKeyDown });
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+});
+
+describe('when operating a slider with a pointer', () => {
+  it('should move the nearest thumb to the clicked position', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        onValueChange={onValueChange}
+      />,
+    );
+    stubTrackRect(container);
+
+    clickTrack(container, 80);
+
+    expect(getValues(container)).toEqual(['20', '80']);
+    expect(onValueChange).toHaveBeenCalledWith([20, 80]);
+  });
+
+  it('should follow the pointer while dragging', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20, 60]} />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 70, 85, 90);
+
+    expect(getValues(container)).toEqual(['20', '90']);
+  });
+
+  it('should report completion once when the drag ends', () => {
+    const onValueChangeComplete = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 70, 85, 90);
+
+    expect(onValueChangeComplete).toHaveBeenCalledTimes(1);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([20, 90]);
+  });
+
+  it('should not report completion when the drag lands where it started', () => {
+    const onValueChangeComplete = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 60);
+
+    expect(onValueChangeComplete).not.toHaveBeenCalled();
+  });
+
+  it('should clamp a pointer position outside the track', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[50]} />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 0, 250);
+    expect(getValues(container)).toEqual(['100']);
+
+    dragThumb(container, 0, -80);
+    expect(getValues(container)).toEqual(['0']);
+  });
+
+  it('should still run the consumer pointer handlers', () => {
+    const onPointerDown = vi.fn();
+    const onPointerMove = vi.fn();
+    const onPointerUp = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[50]}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 0, 70);
+
+    expect(onPointerDown).toHaveBeenCalled();
+    expect(onPointerMove).toHaveBeenCalled();
+    expect(onPointerUp).toHaveBeenCalled();
+  });
+});
+
+describe('when given a disabled slider', () => {
+  it('should take the thumb out of the tab order', () => {
+    const { container } = render(<Slider defaultValue={[30]} disabled />);
+    const thumb = getThumbs(container)[0]!;
+
+    expect(thumb).toHaveAttribute('tabindex', '-1');
+    expect(thumb).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should ignore keyboard input', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Slider defaultValue={[30]} disabled onValueChange={onValueChange} />,
+    );
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(getValues(container)).toEqual(['30']);
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('should ignore pointer input', () => {
+    const onValueChange = vi.fn();
+    const onValueChangeComplete = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[30]}
+        disabled
+        onValueChange={onValueChange}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    clickTrack(container, 80);
+
+    expect(getValues(container)).toEqual(['30']);
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onValueChangeComplete).not.toHaveBeenCalled();
+  });
+});
+
+describe('when given a controlled slider', () => {
+  it('should keep rendering the controlled value', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        value={[40]}
+        onValueChange={onValueChange}
+        onValueChangeComplete={vi.fn()}
+      />,
+    );
+    stubTrackRect(container);
+
+    clickTrack(container, 80);
+
+    expect(onValueChange).toHaveBeenCalledWith([80]);
+    expect(getValues(container)).toEqual(['40']);
+  });
+
+  it('should render the next controlled value', () => {
+    const { container, rerender } = render(
+      <Slider min={0} max={100} value={[40]} />,
+    );
+
+    rerender(<Slider min={0} max={100} value={[70]} />);
+
+    expect(getValues(container)).toEqual(['70']);
+  });
+});
+
+describe('when a slider lives inside a form', () => {
+  it('should render a native range input per thumb', () => {
+    const { container } = render(
+      <form>
+        <Slider min={0} max={100} defaultValue={[20, 60]} name="range" />
+      </form>,
+    );
+
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="range"]'),
+    );
+    expect(inputs.map((input) => input.value)).toEqual(['20', '60']);
+  });
+
+  it('should submit a single thumb under the plain name', () => {
+    const { container } = render(
+      <form>
+        <Slider min={0} max={100} defaultValue={[20]} name="range" />
+      </form>,
+    );
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[type="range"]'),
+    ).toHaveAttribute('name', 'range');
+  });
+
+  it('should submit a controlled range under an array name', () => {
+    const { container } = render(
+      <form>
+        <Slider min={0} max={100} value={[20, 60]} name="range" />
+      </form>,
+    );
+
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="range"]'),
+    );
+    expect(inputs.map((input) => input.name)).toEqual(['range[]', 'range[]']);
+  });
+
+  it('should restore the initial value when the form resets', () => {
+    const { container } = render(
+      <form>
+        <Slider min={0} max={100} defaultValue={[20, 60]} name="range" />
+      </form>,
+    );
+    stubTrackRect(container);
+
+    clickTrack(container, 90);
+    expect(getValues(container)).toEqual(['20', '90']);
+
+    fireEvent.reset(container.querySelector('form')!);
+
+    expect(getValues(container)).toEqual(['20', '60']);
+  });
+});
+
+describe('when given a range slider with minStepBetweenThumbs', () => {
+  it('should allow a move that keeps the gap', () => {
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        minStepBetweenThumbs={10}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 40);
+
+    expect(getValues(container)).toEqual(['20', '40']);
+  });
+
+  it('should block a move that would close the gap', () => {
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20, 60]}
+        minStepBetweenThumbs={10}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 25);
+
+    expect(getValues(container)).toEqual(['20', '60']);
+  });
+});
+
+describe('when given a range slider with disableSwapThumbs', () => {
+  it('should block a thumb from crossing its sibling', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20, 60]} disableSwapThumbs />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 0, 80);
+
+    expect(getValues(container)).toEqual(['20', '60']);
+  });
+
+  it('should let thumbs stack on the same value', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20, 60]} disableSwapThumbs />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 0, 60);
+
+    expect(getValues(container)).toEqual(['60', '60']);
+  });
+
+  it('should swap freely when the flag is off', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20, 60]} />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 0, 80);
+
+    expect(getValues(container)).toEqual(['60', '80']);
+  });
+});
+
+describe('when a range slider has stacked thumbs', () => {
+  it('should call onValueChangeComplete even though both thumbs share a value', () => {
+    const onValueChange = vi.fn();
+    const onValueChangeComplete = vi.fn();
+
+    const { container } = render(
+      <Slider
+        min={1}
+        max={100}
+        defaultValue={[1, 2]}
+        onValueChange={onValueChange}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 0);
+
+    expect(getValues(container)).toEqual(['1', '1']);
+    expect(onValueChange).toHaveBeenCalledWith([1, 1]);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([1, 1]);
+  });
+
+  it('should report completion when a three-thumb move both stacks and swaps', () => {
+    const onValueChangeComplete = vi.fn();
+
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[10, 20, 30]}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 2, 10);
+
+    expect(getValues(container)).toEqual(['10', '10', '20']);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([10, 10, 20]);
+  });
+
+  it('should keep the dragged thumb focused so it can be pulled back out', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[10, 20]} />,
+    );
+    stubTrackRect(container);
+
+    const rightThumb = getThumbs(container)[1]!;
+    firePointer(rightThumb, 'pointerdown', 20);
+    fireEvent.focus(rightThumb);
+    firePointer(rightThumb, 'pointermove', 10);
+
+    expect(document.activeElement).toBe(getThumbs(container)[1]);
+  });
+
+  it('should keep dragging the same thumb after the values stack', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[10, 20]} disableSwapThumbs />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 1, 10, 45);
+
+    expect(getValues(container)).toEqual(['10', '45']);
+  });
+
+  it('should move the trailing thumb when the track is clicked past stacked thumbs', () => {
+    const onValueChangeComplete = vi.fn();
+
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[0, 0]}
+        disableSwapThumbs
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    clickTrack(container, 50);
+
+    expect(getValues(container)).toEqual(['0', '50']);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([0, 50]);
+  });
+
+  it('should still move the leading thumb when the track is clicked before stacked thumbs', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[100, 100]} disableSwapThumbs />,
+    );
+    stubTrackRect(container);
+
+    clickTrack(container, 50);
+
+    expect(getValues(container)).toEqual(['50', '100']);
+  });
+});
+
+describe('when checking slider accessibility', () => {
+  /**
+   * `aria-input-field-name` is knowingly excluded: `labelId` is generated but
+   * never attached to an element, so every thumb points `aria-labelledby` at a
+   * missing node. That is a pre-existing defect tracked separately.
+   */
+  const axeOptions = {
+    rules: { 'aria-input-field-name': { enabled: false } },
+  };
+
+  it('should have no violations as a range slider', async () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[10, 20]} label="label" />,
+    );
+
+    expect(await axe(container, axeOptions)).toHaveNoViolations();
+  });
+
+  it('should have no violations when disabled', async () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[10]} disabled title="title" />,
+    );
+
+    expect(await axe(container, axeOptions)).toHaveNoViolations();
+  });
+});
+
+/**
+ * `SliderThumb` receives `length={value?.length ?? 0}`, which only counts the
+ * controlled prop — an uncontrolled range reports `0`, so both thumbs submit
+ * under the same name. Enable once `length` is derived from `values`.
+ */
+describe.skip('when submitting an uncontrolled range slider', () => {
+  it('should submit every thumb under an array name', () => {
+    const { container } = render(
+      <form>
+        <Slider min={0} max={100} defaultValue={[20, 60]} name="range" />
+      </form>,
+    );
+
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="range"]'),
+    );
+    expect(inputs.map((input) => input.name)).toEqual(['range[]', 'range[]']);
+  });
+});
+
+/**
+ * `snapToStep` computes `((next - min) / step) * step`, where `step` cancels
+ * itself out — so pointer positions never snap to the step grid and fractional
+ * steps are rounded to whole numbers. Enable these once the formula is fixed to
+ * `Math.round((next - min) / step) * step + min`.
+ */
+describe.skip('when given a slider with a coarse step', () => {
+  it('should snap a pointer position onto the step grid', () => {
+    const { container } = render(
+      <Slider min={0} max={100} step={5} defaultValue={[0]} />,
+    );
+    stubTrackRect(container);
+
+    dragThumb(container, 0, 13);
+
+    expect(getValues(container)).toEqual(['15']);
+  });
+
+  it('should support fractional steps', () => {
+    const { container } = render(
+      <Slider min={0} max={10} step={0.5} defaultValue={[0]} />,
+    );
+
+    fireEvent.keyDown(focusThumb(container, 0), { key: 'ArrowRight' });
+
+    expect(getValues(container)).toEqual(['0.5']);
+  });
+});

--- a/packages/wds/src/components/slider/index.tsx
+++ b/packages/wds/src/components/slider/index.tsx
@@ -115,10 +115,17 @@ const Slider = forwardRef<
             return prevValues;
           }
 
-          const sortedNextValues = nextValues.sort((a, b) => a - b);
+          const sortedNextValues = [...nextValues].sort((a, b) => a - b);
 
+          /**
+           * `indexOf` resolves to the leftmost slot when thumbs share a value,
+           * which would hand the focus over to a thumb the user never touched.
+           * Keep the dragged thumb where it is unless sorting actually moved it.
+           */
           currentFocusedIndex.current =
-            sortedNextValues.indexOf(calculatedNextValue);
+            sortedNextValues[index] === calculatedNextValue
+              ? index
+              : sortedNextValues.indexOf(calculatedNextValue);
 
           const hasChanged =
             sortedNextValues.toString() !== prevValues.toString();
@@ -264,10 +271,12 @@ const Slider = forwardRef<
             if (target.hasPointerCapture(event.pointerId)) {
               target.releasePointerCapture(event.pointerId);
 
-              const prevValue =
-                slideStartValues.current[currentFocusedIndex.current];
-              const nextValue = values[currentFocusedIndex.current];
-              const hasChanged = nextValue !== prevValue;
+              /**
+               * Comparing a single index misses changes whenever thumbs end up
+               * stacked or swapped, so compare the whole set instead.
+               */
+              const hasChanged =
+                slideStartValues.current.toString() !== values.toString();
               rect.current = undefined;
 
               if (hasChanged) {

--- a/scripts/api-generator/src/extractor.ts
+++ b/scripts/api-generator/src/extractor.ts
@@ -268,7 +268,11 @@ export class Extractor {
    * Generic 타입이나 utility 타입 조합
    */
   private isComplexTypeAnnotation(text: string): boolean {
-    const utilityTypes = ['ComponentPropsWithoutRef', 'ComponentProps'];
+    const utilityTypes = [
+      'ComponentPropsWithoutRef',
+      'ComponentProps',
+      'FunctionComponent',
+    ];
 
     return utilityTypes.some((t) => text.includes(`${t}<`));
   }


### PR DESCRIPTION
## Summary

range Slider에서 두 thumb의 값이 같아지는 순간 발생하던 세 가지 문제를 수정했습니다. 공통 뿌리는 **"값이 중복될 때 `indexOf`가 항상 가장 왼쪽 인덱스를 반환한다"**는 편향이며, 서로 다른 세 지점에 각각 존재했습니다.

- **`onValueChangeComplete` 미호출** — `onPointerUp`이 `currentFocusedIndex` 한 칸만 비교해 변경 여부를 판정했습니다. 겹침과 교차가 동시에 일어나면 배열이 분명히 바뀌었는데도 "변화 없음"으로 판단합니다. 배열 전체 비교로 변경했습니다.
- **포커스 오염** — `sortedNextValues.indexOf(calculatedNextValue)`가 중복 값에서 왼쪽 칸을 반환해, 사용자가 잡고 있던 thumb이 아닌 반대쪽 thumb으로 포커스와 후속 조작이 넘어갔습니다. 정렬 후에도 원래 칸에 값이 남아 있으면 조작 중인 인덱스를 유지하도록 했습니다.
- **`disableSwapThumbs` 조작 불가** — `getClosestThumbIndex`가 겹친 thumb 중 항상 왼쪽을 골라, 교차 차단 로직과 맞물려 트랙 클릭이 통째로 막혔습니다. 값이 **완전히 겹친 경우에만** 조작 방향 기준 tie-break를 적용하도록 했습니다.

`min`에서만 완전 먹통으로 느껴진 이유는 갈 수 있는 방향이 오른쪽뿐이기 때문입니다. `max` 쪽은 왼쪽 편향이 우연히 맞아떨어져 정상 동작하고 있었습니다.

추가로 `api-generator`에서 `FunctionComponent<T>`처럼 제네릭이 붙은 타입이 보존 대상으로 걸리지 않아 `api.json`이 비대해지던 문제를 함께 고쳤습니다 (`preservedTypeNames`는 이름이 정확히 일치할 때만 매칭됩니다).

## Jira

[WRP-2040](https://wantedlab.atlassian.net/browse/WRP-2040) — Slider: thumb이 같은 값으로 겹칠 때 조작·onValueChangeComplete가 끊기는 문제 수정

- Status: 열림
- Type: 작업

## Test plan

Slider 유닛 테스트를 새로 추가했습니다 (`packages/wds/src/components/slider/index.test.tsx`, 62 passed / 3 skipped).

- [x] helpers 순수 함수 (`clamp`, `convertValueToPercentage`, `linearScale`, `getClosestThumbIndex`)
- [x] 렌더링 — 단일/range thumb, aria 속성, progress bar 범위, title·label 렌더러
- [x] 키보드 — 화살표·PageUp/Down·Shift 조합·Home/End, 정수 `step` 반영(skip 키는 ×10), 경계 clamp, 콜백 호출/미호출
- [x] 포인터 — 트랙 클릭, 드래그, 완료 콜백 1회 호출, 제자리 복귀 시 미호출, 트랙 밖 clamp
- [x] disabled, controlled/uncontrolled, form 제출·reset
- [x] `minStepBetweenThumbs` / `disableSwapThumbs` 제약
- [x] 겹친 thumb 회귀 6종 (이번 수정이 없으면 실패)
- [x] `vitest-axe` 접근성

**교체 검증** — 세 수정을 개별로 되돌려 각각이 독립적으로 테스트에 잡히는 것을 확인했습니다.

| 되돌린 수정 | 실패하는 테스트 |
| --- | --- |
| `onPointerUp` 배열 비교 | 1개 (3-thumb 겹침+교차) |
| `currentFocusedIndex` 추적 | 2개 (포커스 유지, 겹친 뒤 드래그 지속) |
| `getClosestThumbIndex` tie-break | 2개 (helpers 단위, 겹친 상태 트랙 클릭) |

`pnpm vitest run packages/` 486개 기존 테스트 통과, `eslint` 통과, slider 관련 타입 오류 없음을 확인했습니다.

## 함께 발견된 별건 (이번 PR 범위 밖)

조사 중 드러났지만 이번 스코프에 포함하지 않은 결함입니다. 테스트에 `describe.skip` + 사유 주석으로 남겨두었습니다.

- **소수 `step` 미지원** — `step`은 `types.ts` 주석대로 키보드 조작 시 한 번에 움직이는 값이고, 정수 `step`은 정상 동작합니다. 다만 `snapToStep`이 `Math.round(nextValue)`로 축약되는 탓에(`((next - min) / step) * step`에서 `step`이 대수적으로 상쇄됨) 소수 `step`이 정수로 반올림됩니다. `step={0.5}`는 1씩 움직이고 `step={0.1}`은 아예 움직이지 않습니다.
- **uncontrolled range의 form `name` 충돌** — `SliderThumb`이 `length={value?.length ?? 0}`로 controlled prop만 세기 때문에, uncontrolled range slider는 두 input이 같은 `name`으로 제출됩니다. `values.length` 기준이어야 합니다.
- **`aria-labelledby`가 빈 참조** — `labelId`가 생성만 되고 어떤 엘리먼트에도 `id`로 붙지 않아 모든 thumb이 존재하지 않는 노드를 가리킵니다. axe `aria-input-field-name` 위반이라 해당 룰만 비활성화한 상태로 접근성 테스트를 통과시켰습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMtujMwTuPYzmoz4VXcN5s

[WRP-2040]: https://wantedlab.atlassian.net/browse/WRP-2040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 여러 thumb이 같은 값/위치에 겹친 상황에서 드래그 중인 thumb 선택과 포커스 유지가 더 정확해졌습니다.
  - thumb 값이 교환·겹침된 경우에도 “값 변경 완료” 알림이 올바른 타이밍에 정확히 1회만 발생하도록 개선했습니다.
  - 슬라이더 값 정렬 및 포인터 조작 안정성이 향상되었습니다.
- **테스트**
  - 키보드·포인터, 범위 슬라이더, 비활성/폼 연동, 접근성까지 커버리지를 크게 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->