### PR TITLE
feat(core): avatar group 최대 5개 제한 및 AvatarGroupContent 추가

### DIFF
--- a/docs/data/components/contents/avatar-group/web.mdx
+++ b/docs/data/components/contents/avatar-group/web.mdx
@@ -2,13 +2,15 @@
 title: Avatar group
 description: Avatar Group은 여러 사용자를 그룹으로 묶어 표시하는 컴포넌트입니다. 겹쳐진 아바타 목록을 통해 공간을 효율적으로 사용하며, 그룹에 속한 멤버들을 직관적으로 보여주고 추가 멤버 수를 표시할 수 있습니다.
 createdAt: 2025-06-17
-updatedAt: 2025-06-17
+updatedAt: 2025-07-30
 ---
 
 
 ## Basic avatar group
 
 여러개의 아바타를 그룹으로 표시할 수 있습니다.
+
+> 최대 5개의 아바타까지 표시됩니다.
 
 <Demo code={`import { Avatar, AvatarGroup } from '@montage-ui/core';
 
@@ -76,7 +78,9 @@ export default Demo;`}
 
 `trailingContent` 옵션을 통해 그룹 뒤에 컨텐츠를 추가할 수 있습니다.
 
-<Demo code={`import { Avatar, AvatarGroup, TextButton, FlexBox, Typography } from '@montage-ui/core';
+`AvatarGroupContent` 로 감싸서 사용합니다.
+
+<Demo code={`import { Avatar, AvatarGroup, TextButton, FlexBox, AvatarGroupContent } from '@montage-ui/core';
 
 const Demo = () => {
   return (
@@ -84,9 +88,11 @@ const Demo = () => {
       <AvatarGroup
         size="small"
         trailingContent={(
-          <TextButton color="assistive" size="small">
-            외 0명
-          </TextButton>
+          <AvatarGroupContent variant="text-button">
+            <TextButton color="assistive" size="small">
+              외 0명
+            </TextButton>
+          </AvatarGroupContent>
         )}>
         <Avatar variant="person" size="small" />
         <Avatar variant="person" size="small" />
@@ -96,9 +102,9 @@ const Demo = () => {
       <AvatarGroup
         size="small"
         trailingContent={(
-          <Typography variant="label1" weight="bold" color="semantic.foreground.neutral.tertiary">
+          <AvatarGroupContent variant="text">
             외 0명
-          </Typography>
+          </AvatarGroupContent>
         )}>
         <Avatar variant="person" size="small" />
         <Avatar variant="person" size="small" />
@@ -114,7 +120,13 @@ export default Demo;`}
 
 ## API
 
+### AvatarGroup
+
 정해진 breakpoint에 따라 아래 옵션을 override 할 수 있습니다.
 - size
 
 <PropsTable component="AvatarGroup" />
+
+### AvatarGroupContent
+
+<PropsTable component="AvatarGroupContent" />

--- a/packages/core/src/components/avatar-group/index.tsx
+++ b/packages/core/src/components/avatar-group/index.tsx
@@ -58,14 +58,17 @@ const AvatarGroupContent = forwardRef<
           flexShrink={0}
           alignItems="center"
           data-component="avatar-group-content"
-          {...props}
           ref={ref}
-          sx={{
-            ['[data-component="text-button"] > span']: typographyStyle(
-              'label1',
-              'medium',
-            ),
-          }}
+          {...props}
+          sx={[
+            {
+              ['[data-component="text-button"] > span']: typographyStyle(
+                'label1',
+                'medium',
+              ),
+            },
+            props.sx,
+          ]}
         >
           <TextButtonProvider assistive="semantic.foreground.neutral.secondary">
             {children}

--- a/packages/core/src/components/avatar-group/index.tsx
+++ b/packages/core/src/components/avatar-group/index.tsx
@@ -1,11 +1,16 @@
 import { Children, forwardRef } from 'react';
 
 import { FlexBox } from '../flex-box';
+import { Typography } from '../typography';
+import { TextButtonProvider } from '../text-button/contexts';
+import { typographyStyle } from '../../utils';
 
 import { avatarGroupStyle } from './style';
 
 import type { DefaultComponentPropsInternal } from '@montage-ui/engine';
-import type { AvatarGroupProps } from './types';
+import type { AvatarGroupContentProps, AvatarGroupProps } from './types';
+
+const MAX_AVATAR_COUNT = 5;
 
 const AvatarGroup = forwardRef<
   HTMLDivElement,
@@ -15,7 +20,9 @@ const AvatarGroup = forwardRef<
     { size = 'small', xs, sm, md, lg, xl, children, trailingContent, ...props },
     ref,
   ) => {
-    const reverseChildren = Children.toArray(children).reverse();
+    const reverseChildren = Children.toArray(children)
+      .slice(0, MAX_AVATAR_COUNT)
+      .reverse();
 
     return (
       <FlexBox
@@ -40,6 +47,51 @@ const AvatarGroup = forwardRef<
 
 AvatarGroup.displayName = 'AvatarGroup';
 
-export { AvatarGroup };
+const AvatarGroupContent = forwardRef<
+  HTMLDivElement,
+  DefaultComponentPropsInternal<AvatarGroupContentProps, 'div'>
+>(({ variant = 'text', children, ...props }, ref) => {
+  switch (variant) {
+    case 'text-button':
+      return (
+        <FlexBox
+          flexShrink={0}
+          alignItems="center"
+          data-component="avatar-group-content"
+          {...props}
+          ref={ref}
+          sx={{
+            ['[data-component="text-button"] > span']: typographyStyle(
+              'label1',
+              'medium',
+            ),
+          }}
+        >
+          <TextButtonProvider assistive="semantic.foreground.neutral.secondary">
+            {children}
+          </TextButtonProvider>
+        </FlexBox>
+      );
+    case 'text':
+    default:
+      return (
+        <Typography
+          data-component="avatar-group-content"
+          variant="label1"
+          weight="medium"
+          as="span"
+          {...props}
+          color="semantic.foreground.neutral.secondary"
+          ref={ref}
+        >
+          {children}
+        </Typography>
+      );
+  }
+});
 
-export type { AvatarGroupProps };
+AvatarGroupContent.displayName = 'AvatarGroupContent';
+
+export { AvatarGroup, AvatarGroupContent };
+
+export type { AvatarGroupProps, AvatarGroupContentProps };

--- a/packages/core/src/components/avatar-group/style.ts
+++ b/packages/core/src/components/avatar-group/style.ts
@@ -14,7 +14,7 @@ export const avatarGroupStyle =
       position: relative;
     }
 
-    ${avatarGroupSizeStyle(size)}
+    ${avatarGroupSizeStyle(size, theme)}
 
     [data-component='avatar'] {
       flex-shrink: 0;
@@ -27,7 +27,6 @@ export const avatarGroupStyle =
         left: 0px;
         position: absolute;
         top: 0px;
-        border-radius: inherit;
         border: 1.5px solid ${theme.semantic.background.neutral.primary};
         margin: -1.5px;
         box-sizing: content-box;
@@ -39,33 +38,33 @@ export const avatarGroupStyle =
       theme,
     )(
       (params) => css`
-        ${avatarGroupSizeStyle(params?.size)}
+        ${avatarGroupSizeStyle(params?.size, theme)}
         ${params?.sx}
       `,
     )}
   `;
 
-const avatarGroupSizeStyle = (size: AvatarGroupProps['size']) => {
+const avatarGroupSizeStyle = (size: AvatarGroupProps['size'], theme: Theme) => {
   switch (size) {
     case 'small':
       return css`
-        gap: 10px;
+        gap: ${theme.spacing[10]};
         [data-component='avatar'] {
-          margin-left: -8px;
+          margin-left: calc(${theme.spacing[8]} * -1);
 
           &:last-child {
-            margin-left: 0px;
+            margin-left: ${theme.spacing[0]};
           }
         }
       `;
     case 'xsmall':
       return css`
-        gap: 8px;
+        gap: ${theme.spacing[8]};
         [data-component='avatar'] {
-          margin-left: -6px;
+          margin-left: calc(${theme.spacing[6]} * -1);
 
           &:last-child {
-            margin-left: 0px;
+            margin-left: ${theme.spacing[0]};
           }
         }
       `;

--- a/packages/core/src/components/avatar-group/types.ts
+++ b/packages/core/src/components/avatar-group/types.ts
@@ -7,9 +7,15 @@ type AvatarGroupDefaultProps = WithSxProps<{
    * It is recommended to use sizes consistent with `Avatar` for visual harmony.
    */
   size?: 'xsmall' | 'small';
-  /** The content of the avatar group. Use `Avatar` components as the children. */
+  /**
+   * The content of the avatar group. Use `Avatar` components as the children.
+   * A maximum of 5 children are rendered; the rest are ignored.
+   */
   children?: ReactNode;
-  /** The content displayed in the trailing area. */
+  /**
+   * Content displayed in the trailing area.
+   * Pass an element wrapped with `AvatarGroupContent`.
+   */
   trailingContent?: ReactNode;
 }>;
 
@@ -21,3 +27,9 @@ export type AvatarGroupProps = Merge<
   AvatarGroupDefaultProps,
   AvatarGroupResponsiveProps
 >;
+
+export type AvatarGroupContentProps = WithSxProps<{
+  /** The variant of the `AvatarGroupContent`. */
+  variant?: 'text' | 'text-button';
+  children?: ReactNode;
+}>;


### PR DESCRIPTION
## Summary

- `AvatarGroup` children을 최대 5개까지만 렌더하도록 제한 (초과분은 무시, 디자인 스펙 정합)
- `trailingContent`용 `AvatarGroupContent` 컴포넌트 추가 — `text` / `text-button` variant 제공, 색상은 Label/Neutral(secondary), 타이포는 Label 1 - Medium 토큰 적용
- avatar-group 스타일의 하드코딩 px 값을 `theme.spacing` 토큰으로 전환, avatar border의 `border-radius: inherit` 제거
- 문서(web.mdx)에 최대 5개 안내 및 `AvatarGroupContent` 사용법/PropsTable 추가

## Jira

[WRP-1945](https://wantedlab.atlassian.net/browse/WRP-1945) — [WDS] Avatar Group 업데이트

- Status: 열림
- Type: 하위 작업

Avatar Group 컴포넌트를 업데이트합니다. Trailing Content 리소스(Text·Text Button) 색·타이포 토큰 변경, 최대 표시 인원 5명 정합 등.

## Test plan

- [ ] children을 6개 이상 전달했을 때 5개까지만 렌더되는지 확인
- [ ] `AvatarGroupContent`의 `text` / `text-button` variant가 디자인 핸드오프(색 Label/Neutral, 타이포 Label 1 - Medium)와 일치하는지 확인
- [ ] docs 데모(trailingContent 예제) 정상 렌더 확인
- [ ] CI visual regression diff가 의도된 변경인지 확인 후 스냅샷 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-1945]: https://wantedlab.atlassian.net/browse/WRP-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Avatar Group에 텍스트 및 텍스트 버튼 형태의 콘텐츠 표시를 지원합니다.
  * Avatar Group에서 표시되는 아바타 수를 최대 5개로 제한합니다.

* **스타일 개선**
  * 테마 기반 간격을 적용해 아바타 그룹의 간격과 정렬 일관성을 개선했습니다.

* **문서**
  * Avatar Group 사용 예제와 콘텐츠 API 문서를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->