### PR TITLE
chore: v4 마이그레이션 스킬 사실 오류 정정 및 포맷 정리

### DIFF
--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/SKILL.md
@@ -200,8 +200,10 @@ rewrites `package.json` a resume looks exactly like "already migrated".
    of these break the parser identically.
    **Expect two known false-positive shapes**: a generic arrow-function declaration
    (`const f = <T>(x: T) => x`, `<T extends object>(x: T) => x`) and a regex literal with a
-   named capture group (`/#(?<id>\w+)/`) both match the pattern but parse fine — this
-   repo's own source yields 10 such hits across 404 `.ts` files. Confirm
+   named capture group (`/#(?<id>\w+)/`) both match the pattern but parse fine — the
+   Montage repo's own `packages/core/src` yielded ~9 such hits across ~290 `.ts` files when
+   this was written, all of them generic arrow declarations; expect a comparable handful per
+   few hundred files rather than a clean scan. Confirm
    each hit is a real CAST (a type in angle brackets applied to an expression) before
    converting anything; never rewrite a generic arrow's type parameter list.
    The scan is still a heuristic; the "treat any `ERR` as a step failure" rule is the backstop)
@@ -390,10 +392,20 @@ Populate `completedSteps` from the state file read in preflight (empty on a firs
 the script skips those steps deterministically without spawning an agent, and each step
 agent re-checks the state file as a second layer.
 
-`${CLAUDE_PLUGIN_ROOT}` is the plugin root (`.claude-plugin/montage-migration`); expand it
-to an absolute path before passing it — the Workflow args must be literal paths. If the
-variable is unset in this environment, fall back to the "Base directory for this skill" line
-announced when the skill loaded, or to the directory of the loaded SKILL.md. ALWAYS pass `codemodVersion` as the concrete version
+`${CLAUDE_PLUGIN_ROOT}` is the plugin's own INSTALL directory, which is outside the repo
+being migrated; expand it to an absolute path before passing it — the Workflow args must be
+literal paths. If the variable is unset in this environment, fall back to the "Base directory
+for this skill" line announced when the skill loaded, or to the directory of the loaded
+SKILL.md. **Never resolve it against `repoRoot`.** `.claude-plugin/montage-migration` is
+where these files live in the montage-web SOURCE repo (and is the right path only when the
+plugin was loaded from a checkout of it, e.g. `--plugin-dir`); a consumer repo has no such
+directory, so guessing that path there yields an unreadable `scriptPath` and the codemod
+phase dies before step ① — while a marketplace install sits under Claude Code's own plugin
+cache instead. Whatever the resolution, confirm
+`<root>/skills/montage-v3-to-v4/scripts/migration-workflow.js` actually exists before
+invoking the Workflow rather than trusting a constructed path.
+
+ALWAYS pass `codemodVersion` as the concrete version
 resolved in preflight (first run) or read from the state file (resume) — the script
 rejects dist-tags, since the value is recorded in the state file and a dist-tag would
 re-resolve on resume and break the same-build guarantee. The workflow returns per-step results plus a

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/known-issues.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/known-issues.md
@@ -4,6 +4,10 @@ Deliberate decisions, not oversights. The validation Workflow reads this file an
 re-report anything listed here, which is what keeps successive runs comparable. Remove an entry
 when the underlying decision changes.
 
+Every path below is relative to the **montage-web source repo**, not to a repo being migrated —
+this file ships with the plugin but is maintainer-facing, and none of these paths exist in a
+consumer checkout.
+
 ## Version bumps deferred
 
 `.claude-plugin/montage-migration/.claude-plugin/plugin.json` (1.0.0) and

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -172,7 +172,14 @@ grep -rnE "\b(ListCard|CardBody|CardRow)" <targets>
 #    Do NOT widen it to a bare prefix `\bFormControl` either: that also matches consumer
 #    identifiers like FormControls / FormControlPanel / FormControlled, and a false "new
 #    names present" reading is what triggers the spurious HALF-migrated stop-and-reconcile.
-grep -rnE "\bFormControl\b|\bFormControl(Props|Field|Label|Message|NegativeMessage|PositiveMessage)" <targets>
+#    The sub-component group carries `(Props)?\b` — every sub-component ships a Props type
+#    (FormControlFieldProps, FormControlLabelProps, FormControlNegativeMessageProps, …), so
+#    a `\b` placed directly after the group instead — \bFormControl(Field|Label|…)\b —
+#    matches NONE of them (the char after `FormControlField` is `P`, a word character) and
+#    returns ZERO on a type-only tree: the same "step ⑥ never ran" misread as the empty
+#    branch above. Keep MessageAccessory ahead of Message so a leftmost-first engine cannot
+#    stop at the shorter alternative.
+grep -rnE "\bFormControl\b|\bFormControl(Field|Label|MessageAccessory|Message|NegativeMessage|PositiveMessage)?(Props)?\b" <targets>
 # ⑦ push-badge-migration — single-quoted so the pattern's own double quotes reach grep
 #    intact. Anchored on PushBadge on purpose: a bare `text=` matches TextField / Chip /
 #    analytics code everywhere and is no evidence at all. Multi-line props escape it — see

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/codemod-steps.md
@@ -158,10 +158,21 @@ grep -rnE -- "--grid-(column|row)-spacing" <targets>
 grep -rn "data-component" <targets>
 # ⑤ list-card-migration
 grep -rnE "\b(ListCard|CardBody|CardRow)" <targets>
-# ⑥ form-control-migration — the Props alternate matters: a type-only
-#    `import type { FormControlProps }` file is invisible to bare \bFormControl\b, and the
-#    step-⑥ pre-check uses \bFormControl(Props)?\b for the same reason
-grep -rnE "\bFormControl(\b|Props|Field|Label|Message|NegativeMessage|PositiveMessage)" <targets>
+# ⑥ form-control-migration — two TOP-LEVEL alternatives, deliberately. The first covers a
+#    tree whose only new name is the plain root (see the caveat below); the second covers
+#    the sub-components and the Props types, including a type-only
+#    `import type { FormControlProps }` file that `\bFormControl\b` alone would miss (the
+#    step-⑥ pre-check uses \bFormControl(Props)?\b for the same reason).
+#    Do NOT collapse it to a single group with \b as a BRANCH — \bFormControl(\b|Props|…) —
+#    that is an empty subexpression, which ugrep (the grep Claude Code shadows `grep` with)
+#    REJECTS: "empty (sub)expression", printed to stderr with NO matches. Zero output from
+#    the one already-applied detector reads as "step ⑥ never ran" and walks straight into
+#    the double-swap corruption; BSD/GNU grep accept the form, so the break is
+#    environment-dependent and easy to miss.
+#    Do NOT widen it to a bare prefix `\bFormControl` either: that also matches consumer
+#    identifiers like FormControls / FormControlPanel / FormControlled, and a false "new
+#    names present" reading is what triggers the spurious HALF-migrated stop-and-reconcile.
+grep -rnE "\bFormControl\b|\bFormControl(Props|Field|Label|Message|NegativeMessage|PositiveMessage)" <targets>
 # ⑦ push-badge-migration — single-quoted so the pattern's own double quotes reach grep
 #    intact. Anchored on PushBadge on purpose: a bare `text=` matches TextField / Chip /
 #    analytics code everywhere and is no evidence at all. Multi-line props escape it — see
@@ -184,8 +195,9 @@ reconcile with the user, never re-run the codemod over it.
 
 **Step ⑥ caveat — a bare `FormControl` is ambiguous.** A v3 tree using only the plain
 `FormField` root migrates to a plain `FormControl` with no sub-components — which is exactly
-why the presence pattern includes bare `\bFormControl\b`: without it both greps would return
-zero on such a tree and the already-applied direction would be invisible. A bare hit is still
+why the presence pattern carries `\bFormControl\b` as its own alternative: without it both
+greps would return zero on such a tree and the already-applied direction would be
+invisible. A bare hit is still
 ambiguous (the correct new root OR a surviving v3 inner slot), so the step-⑥ pre-check, not
 these greps, is the authoritative test for the already-applied direction.
 
@@ -221,7 +233,7 @@ file; on a repo whose only v3 `invalid` usage was the Checkbox family, prefer th
 commit / `git log -S"invalid"` over either grep.
 
 **Step ③ caveat — the weakest signal of the eight.** `css-variable-migration` covers the
-69 `KNOWN_WDS_VARIABLES`: 67 come out with the `--wds-` prefix simply stripped
+68 `KNOWN_WDS_VARIABLES`: 66 come out with the `--wds-` prefix simply stripped
 (`--modal-translate`, `--switch-width`, `--card-content-item-*`, …) and the remaining two,
 `--wds-column-spacing` / `--wds-row-spacing`, are renamed to `--grid-*-spacing`. Only
 `--grid-column-spacing` / `--grid-row-spacing` are unambiguous evidence; the stripped

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/references/manual-migrations.md
@@ -5,12 +5,17 @@ completed (see `codemod-steps.md`). Each section lists scan patterns to locate a
 code — scan first, then apply fixes only where a real occurrence exists.
 
 Scan patterns use `grep -E` syntax with `\b`/`\s`/`\w` shorthands — supported by GNU grep,
-macOS BSD grep, and ripgrep alike, but ONLY OUTSIDE bracket expressions (translate the
+macOS BSD grep, ripgrep, and the ugrep that Claude Code shadows `grep` with alike, but ONLY
+OUTSIDE bracket expressions (translate the
 shorthands to POSIX classes for busybox or other minimal greps). **Inside `[...]` always use
 a POSIX class**: BSD/GNU `grep -E` treat `[\w.]` as the literal 3-character set
 `{backslash, w, dot}`, while ripgrep's Rust regex honors `\w` there — the same pattern
 silently yields different worklists per tool, which is how a scan comes back empty instead of
-failing. Write `[[:alnum:]_.]` instead. Patterns beginning with `-` (e.g. `--wds-`) must be passed after
+failing. Write `[[:alnum:]_.]` instead. **Never write `\b` as an alternation BRANCH**
+(`X(\b|Props|…)`): BSD/GNU accept it, ugrep rejects it as an empty subexpression and prints
+an error with NO matches — a tool-dependent zero that reads as "nothing to migrate". Give it
+its own top-level alternative instead (`\bX\b|\bX(Props|…)`), the shape step ⑥'s presence
+grep uses. Patterns beginning with `-` (e.g. `--wds-`) must be passed after
 a `--` separator or via `-e` (`grep -rn -e "--wds-"`), or grep parses them as options and
 exits without scanning. The patterns are line-based heuristics: multi-line JSX props and
 non-literal forms (`variant={'bottom'}`, responsive objects) escape them, so treat a clean

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
@@ -299,13 +299,21 @@ for (const t of args.targets) {
 // twice over it — the same run-once corruption path as a nested target. Workflow scripts
 // have no path module, so normalize by string.
 const canonicalTargets = (() => {
-  const repoRootNormalized = String(args.repoRoot || '').replace(/\/+$/, '');
+  // Windows separators are folded to '/' FIRST, before any check below reads a segment:
+  // '..\other-repo' contains no '/' at all, so the '..' check would see a single segment
+  // and the absolute-path check would see no leading '/' — both wave it through, and on
+  // Windows that target points OUTSIDE repoRoot. A codemod let loose on a foreign tree is
+  // also unrecoverable: `git -C <repoRoot> checkout` cannot restore what it never tracked.
+  const normalizePath = (value) =>
+    String(value)
+      .replace(/\\/g, '/')
+      .replace(/\/{2,}/g, '/')
+      .replace(/\/+$/, '');
+  const repoRootNormalized = normalizePath(args.repoRoot || '');
   const seen = new Map();
 
   for (const raw of args.targets) {
-    let t = String(raw)
-      .replace(/\/{2,}/g, '/')
-      .replace(/\/+$/, '');
+    let t = normalizePath(raw);
 
     if (t.split('/').includes('..')) {
       throw new Error(
@@ -405,7 +413,10 @@ for (const key of ['repoRoot', 'stateFile', 'referencesDir']) {
     );
   }
 }
-const excludeFilesInput = args.excludeFiles || [];
+// Default ONLY on undefined — `|| []` would turn null / false / '' into an empty list and
+// skip the type check below, running step ⑥ over the files the user ring-fenced.
+const excludeFilesInput =
+  args.excludeFiles === undefined ? [] : args.excludeFiles;
 if (!Array.isArray(excludeFilesInput)) {
   throw new Error('excludeFiles must be an array of repo-relative paths');
 }

--- a/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
+++ b/.claude-plugin/montage-migration/skills/montage-v3-to-v4/scripts/migration-workflow.js
@@ -8,7 +8,7 @@ export const meta = {
     { title: 'Codemods', detail: '8 v4 codemods, strictly sequential' },
     { title: 'Scan', detail: 'parallel read-only scans for manual migrations' },
   ],
-}
+};
 
 // Required args (pass via Workflow tool `args`):
 //   repoRoot:      absolute path of the repo being migrated
@@ -56,19 +56,22 @@ const CODEMOD_STEPS = [
   {
     id: 'package-name-migration',
     title: 'Package name migration (@wanteddev/* → @montage-ui/*)',
-    surface: 'import sources: @wanteddev/wds* → @montage-ui/* (and @wanteddev/montage-mcp)',
+    surface:
+      'import sources: @wanteddev/wds* → @montage-ui/* (and @wanteddev/montage-mcp)',
     precheck: 'None.',
     verify:
       'grep for "@wanteddev/" in .ts/.tsx/.js/.jsx AND .mjs/.cjs/.mts/.cts inside the targets. Import declarations in .ts/.tsx/.js/.jsx must have zero hits, EXCEPT `@wanteddev/montage-mcp` — that is the codemod\'s own post-migration name for wds-mcp; leave it alone. Import declarations in .mjs/.cjs/.mts/.cts are legitimate leftovers (the CLI runs jscodeshift with --extensions=tsx,ts,jsx,js only) — fix them by hand NOW, they are not codemod failures. Remaining hits in `export ... from`, require(), dynamic import(), jest.mock()/vi.mock(), or `declare module` lines are NOT covered by the codemod — fix those by hand NOW as part of this step (they are code, unlike the config-file work of manual step M1). Hits in package.json/configs belong to manual step M1; leave them.',
   },
   {
     id: 'semantic-token-migration',
-    title: 'Semantic token migration (v3 semantic color tokens → v4 property/intent/variant structure)',
+    title:
+      'Semantic token migration (v3 semantic color tokens → v4 property/intent/variant structure)',
     surface:
       'semantic.<old path> dot paths in JS/TS and --semantic-<old-dashed> variables in JS/TS + stylesheets',
-    precheck: 'None. (The transform is idempotent and safe on hand-migrated v4 token code — the rename map is prefix-free and no new path matches an old key.)',
+    precheck:
+      'None. (The transform is idempotent and safe on hand-migrated v4 token code — the rename map is prefix-free and no new path matches an old key.)',
     verify:
-      'Run the two step-2 verification greps from codemod-steps.md: the old dot-path pattern (semantic.(label|status|fill|material|inverse), semantic.interaction, semantic.primary., semantic.accent., semantic.background.(normal|elevated|transparent|status), semantic.line.(normal|solid|primary|status)) over the targets, and the old CSS-variable pattern (--semantic-… equivalents) INCLUDING .css/.scss/.sass/.less. Neither pattern matches any v4 name. Remaining hits should only be group-level references (theme.semantic.label passed/iterated whole), dynamically built names (`--semantic-${x}`, \'semantic.\' + path), or computed access (semantic[\'label\']) — all owned by manual step M9; report them in verifyFindings, do not fix them here. Then skim the diff for false positives: the transform is NOT import-gated, so a non-Montage object accessed as <x>.semantic.<old-path> or an unrelated string containing semantic.<old-path>/--semantic-<old-dashed> was rewritten too — revert genuinely unrelated rewrites in this step and note them. Expect surface.brand.primary at former primary.normal sites (including text/icon-color usages) and foreground.* tokens at former deleted-accent sites — the reclassification decisions belong to manual step M9; do NOT re-map them here. Dot-path token strings inside stylesheets are NOT converted (the stylesheet pass renames only the --semantic-* variable form) — flag any such hit for M9.',
+      "Run the two step-2 verification greps from codemod-steps.md: the old dot-path pattern (semantic.(label|status|fill|material|inverse), semantic.interaction, semantic.primary., semantic.accent., semantic.background.(normal|elevated|transparent|status), semantic.line.(normal|solid|primary|status)) over the targets, and the old CSS-variable pattern (--semantic-… equivalents) INCLUDING .css/.scss/.sass/.less. Neither pattern matches any v4 name. Remaining hits should only be group-level references (theme.semantic.label passed/iterated whole), dynamically built names (`--semantic-${x}`, 'semantic.' + path), or computed access (semantic['label']) — all owned by manual step M9; report them in verifyFindings, do not fix them here. Then skim the diff for false positives: the transform is NOT import-gated, so a non-Montage object accessed as <x>.semantic.<old-path> or an unrelated string containing semantic.<old-path>/--semantic-<old-dashed> was rewritten too — revert genuinely unrelated rewrites in this step and note them. Expect surface.brand.primary at former primary.normal sites (including text/icon-color usages) and foreground.* tokens at former deleted-accent sites — the reclassification decisions belong to manual step M9; do NOT re-map them here. Dot-path token strings inside stylesheets are NOT converted (the stylesheet pass renames only the --semantic-* variable form) — flag any such hit for M9.",
   },
   {
     id: 'css-variable-migration',
@@ -81,7 +84,8 @@ const CODEMOD_STEPS = [
   },
   {
     id: 'dom-identifier-migration',
-    title: 'DOM identifier migration (wds-component → data-component, region manager ids)',
+    title:
+      'DOM identifier migration (wds-component → data-component, region manager ids)',
     surface:
       'wds-component / wds-ignore-* / wds-region-manager identifier strings and attribute names in JS/TS + stylesheets',
     precheck: 'None.',
@@ -90,7 +94,8 @@ const CODEMOD_STEPS = [
   },
   {
     id: 'list-card-migration',
-    title: 'Card / ListCard naming migration (CardList → ListCard, CardContent → CardBody/ListCardBody)',
+    title:
+      'Card / ListCard naming migration (CardList → ListCard, CardContent → CardBody/ListCardBody)',
     surface:
       'CardList* / CardContent* identifiers and their Props/Skeleton forms → ListCard* / CardBody* / CardRow*',
     precheck:
@@ -100,7 +105,8 @@ const CODEMOD_STEPS = [
   },
   {
     id: 'form-control-migration',
-    title: 'Form Control naming migration (FormField → FormControl → FormControlField swap)',
+    title:
+      'Form Control naming migration (FormField → FormControl → FormControlField swap)',
     surface:
       'FormField* / FormLabel / FormMessage / FormErrorMessage identifiers → FormControl* (and the old FormControl slot → FormControlField)',
     precheck:
@@ -110,7 +116,8 @@ const CODEMOD_STEPS = [
   },
   {
     id: 'push-badge-migration',
-    title: 'PushBadge variant/count migration (variant="number"|"new" → "text", count → text)',
+    title:
+      'PushBadge variant/count migration (variant="number"|"new" → "text", count → text)',
     surface:
       'PushBadge JSX props: variant="number"|"new" → variant="text", count → text (variant="new" also gains text="N")',
     precheck:
@@ -120,25 +127,46 @@ const CODEMOD_STEPS = [
   },
   {
     id: 'status-migration',
-    title: 'invalid/positive → status migration (TextField, TextArea, Select*, *Picker, Checkbox family, framedStyle)',
+    title:
+      'invalid/positive → status migration (TextField, TextArea, Select*, *Picker, Checkbox family, framedStyle)',
     surface:
-      'invalid → status="negative" on TextField/TextArea/Select/SelectMultiple/DatePicker/DateRangePicker/TimePicker, plus positive → status="positive" on TextField ONLY; invalid → aria-invalid on Checkbox/Radio/CheckMark/RoundCheckbox; framedStyle({ invalid: true }) → framedStyle({ status: \'negative\' }), and the shorthand framedStyle({ invalid }) → framedStyle({ status: invalid ? \'negative\' : \'normal\' }) (NOT a bare rename — status takes a string)',
+      "invalid → status=\"negative\" on TextField/TextArea/Select/SelectMultiple/DatePicker/DateRangePicker/TimePicker, plus positive → status=\"positive\" on TextField ONLY; invalid → aria-invalid on Checkbox/Radio/CheckMark/RoundCheckbox; framedStyle({ invalid: true }) → framedStyle({ status: 'negative' }), and the shorthand framedStyle({ invalid }) → framedStyle({ status: invalid ? 'negative' : 'normal' }) (NOT a bare rename — status takes a string)",
     precheck:
       'None. (Idempotent — the first run removes every invalid/positive it can see, and the transform never treats status as a rename source (it only checks whether one is already there so it never writes a duplicate attribute), so a re-run is a no-op. The one shape it skips, an element carrying BOTH status and invalid (half-hand-migrated), is skipped identically on a second run and belongs to M16. It is still run-once by the state file.)',
     verify:
       'Run `grep -rnE \'<([[:alnum:]_$]+\.)?(TextField|TextArea|Select|SelectMultiple|DatePicker|DateRangePicker|TimePicker|Checkbox|Radio|CheckMark|RoundCheckbox)[^>]*[[:space:]](invalid|positive)[=/ >]\' <targets>` — SINGLE-quoted so the pattern reaches grep intact, and the [[:space:]] before the alternation is REQUIRED: it forces ATTRIBUTE position, which is what keeps this transform\'s own `aria-invalid` output and its `status={invalid ? ...}` fold out of the results (a weaker [^-[:alnum:]_] guard does NOT, because `{` satisfies it). Expect zero hits EXCEPT class (b) below (the transform\'s own fold output) — this is not a plain zero criterion. This is a LINE-based grep and the transform is AST-based, so a clean result is not proof of coverage: multi-line JSX props never match it, yet the transform DID migrate them — do not "fix" the diff to satisfy the grep. Real hits come from three places, none of which is a reason to re-run the codemod: (a) gate-skipped files (namespace imports like M.TextField, re-exports, deep/subpath imports — the codemod only transforms files importing from exactly @montage-ui/core or @wanteddev/wds); no M-section covers in-target hits of this class, so fix them by hand NOW against the surface above, but first confirm the identifier really comes from a montage source; (b) the transform\'s OWN fold output, whenever the folded expression mentions a bare invalid/positive anywhere but immediately after `{` (status={hasError || invalid ? ...}, status={inv ? "negative" : positive ? ...}) — correct v4 code, NEVER edit it and never count it against the zero criterion; (c) elements carrying BOTH status and invalid as two separate attributes (half-hand-migrated) — report for M16, and check the shape first: a lone status= whose expression mentions invalid is class (b), not this. Also report every TextField the transform folded from BOTH invalid AND positive (whose output shape depends on which prop was literal — a literal invalid with a literal positive short-circuits to a bare status="negative" with no textual trace, invalid={inv} positive gives a single ternary, and only both-dynamic gives a nested one; a literal invalid with a DYNAMIC positive is left untransformed on purpose, since folding it would discard an expression v3 still evaluated, so it keeps both attributes and shows up in this grep — report it for M16, never hand-fold it): v3 rendered the negative border AND the positive icon together, v4 cannot, so the icon is gone — a real behavior change for M16 to confirm, not a diff to revert. Also report any {...spread} onto one of these components and any type extending TextFieldProps that re-declares invalid/positive — both are invisible to the transform AND to this grep, and belong to M16 — the typecheck will not find them either, since a TextFieldProps & { invalid?: boolean } intersection is valid and JSX spreads are not excess-property-checked. framedStyle called with a variable instead of an inline object literal keeps its invalid key silently and is M16\'s too.',
   },
-]
+];
 
 // Kept in sync with the M-sections in references/manual-migrations.md and STATE_FILE_TEMPLATE
 // below — see SKILL.md → "State file format" → Consistency surfaces for the canonical list.
 const MANUAL_SCAN_SECTIONS = [
   { id: 'M1', title: 'Package references outside import declarations' },
-  { id: 'M2', title: 'Theme tokens now return var(--...) strings (JS arithmetic breakage)' },
-  { id: 'M3', title: 'CSS variable / DOM identifier leftovers (dynamic names, out-of-target files such as E2E specs and snapshots, camelCase safety net)' },
-  { id: 'M4', title: 'Card / ListCard follow-ups (non-JSX refs, cross-file context, data-component values, old Card names outside the targets)' },
-  { id: 'M5', title: 'FormControl follow-ups (message typography variant/weight, old Form names outside the targets)' },
-  { id: 'M6', title: 'Modal bottom sheet behavior change (onVisibilityChange removal, peekHeight)' },
+  {
+    id: 'M2',
+    title:
+      'Theme tokens now return var(--...) strings (JS arithmetic breakage)',
+  },
+  {
+    id: 'M3',
+    title:
+      'CSS variable / DOM identifier leftovers (dynamic names, out-of-target files such as E2E specs and snapshots, camelCase safety net)',
+  },
+  {
+    id: 'M4',
+    title:
+      'Card / ListCard follow-ups (non-JSX refs, cross-file context, data-component values, old Card names outside the targets)',
+  },
+  {
+    id: 'M5',
+    title:
+      'FormControl follow-ups (message typography variant/weight, old Form names outside the targets)',
+  },
+  {
+    id: 'M6',
+    title:
+      'Modal bottom sheet behavior change (onVisibilityChange removal, peekHeight)',
+  },
   {
     id: 'M7',
     title:
@@ -189,7 +217,7 @@ const MANUAL_SCAN_SECTIONS = [
     title:
       'invalid/positive → status leftovers (props reaching a field via spread or a props object, TextField that set BOTH — v4 status is exclusive so the positive icon is lost, picker auto-promotion to negative in uncontrolled mode that status="normal" cannot suppress, wrapper types re-declaring invalid, framedStyle called with a variable)',
   },
-]
+];
 
 const STEP_RESULT_SCHEMA = {
   type: 'object',
@@ -203,11 +231,12 @@ const STEP_RESULT_SCHEMA = {
     verifyFindings: {
       type: 'array',
       items: { type: 'string' },
-      description: 'Leftover patterns or anomalies found by the post-step verification greps',
+      description:
+        'Leftover patterns or anomalies found by the post-step verification greps',
     },
     error: { type: 'string' },
   },
-}
+};
 
 const SCAN_RESULT_SCHEMA = {
   type: 'object',
@@ -233,33 +262,36 @@ const SCAN_RESULT_SCHEMA = {
       },
     },
   },
-}
+};
 
-const codemodVersion = args.codemodVersion
+const codemodVersion = args.codemodVersion;
 if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(String(codemodVersion))) {
   throw new Error(
     `codemodVersion must be an exact x.y.z version (got ${JSON.stringify(codemodVersion)}) — resolve at preflight with \`npm view '@montage-ui/codemod@^4' version --json\` and take the LAST element of the returned array — the unscoped \`npm view @montage-ui/codemod version\` returns the \`latest\` dist-tag (wrong major once 5.x ships) and the un-jsonned range form prints one \`pkg@x.y.z 'x.y.z'\` line PER matching version — or read the state file's recorded value on resume`,
-  )
+  );
 }
 if (Number(String(codemodVersion).split('.')[0]) !== 4) {
   throw new Error(
     `codemodVersion ${codemodVersion} is outside the 4.x line this skill covers — the v3→v4 transforms ship in @montage-ui/codemod 4.x (a 3.x CLI rejects every transform name with "Invalid transform choice"; a 5.x CLI carries no guarantee these transform names still exist or behave identically). Resolve with \`npm view '@montage-ui/codemod@^4' version --json\` at preflight and take the LAST array element — the un-jsonned range form prints one line PER matching 4.x version`,
-  )
+  );
 }
-if (args.commitNoVerify !== undefined && typeof args.commitNoVerify !== 'boolean') {
+if (
+  args.commitNoVerify !== undefined &&
+  typeof args.commitNoVerify !== 'boolean'
+) {
   throw new Error(
     `commitNoVerify must be a boolean (got ${JSON.stringify(args.commitNoVerify)}) — it carries the preflight agreement on pre-commit hooks into the per-step commits`,
-  )
+  );
 }
-const commitNoVerify = args.commitNoVerify === true
+const commitNoVerify = args.commitNoVerify === true;
 if (!Array.isArray(args.targets) || args.targets.length === 0) {
-  throw new Error('targets must be a non-empty array of directory paths')
+  throw new Error('targets must be a non-empty array of directory paths');
 }
 for (const t of args.targets) {
   if (/[*?{}[\]]/.test(String(t))) {
     throw new Error(
       `target ${JSON.stringify(t)} contains glob metacharacters — the codemod CLI does not expand globs (it silently uses only the first path); pass plain directory paths`,
-    )
+    );
   }
 }
 // Canonicalize targets BEFORE the disjointness check: 'src', './src', 'src/', and
@@ -267,33 +299,38 @@ for (const t of args.targets) {
 // twice over it — the same run-once corruption path as a nested target. Workflow scripts
 // have no path module, so normalize by string.
 const canonicalTargets = (() => {
-  const repoRootNormalized = String(args.repoRoot || '').replace(/\/+$/, '')
-  const seen = new Map()
+  const repoRootNormalized = String(args.repoRoot || '').replace(/\/+$/, '');
+  const seen = new Map();
 
   for (const raw of args.targets) {
-    let t = String(raw).replace(/\/{2,}/g, '/').replace(/\/+$/, '')
+    let t = String(raw)
+      .replace(/\/{2,}/g, '/')
+      .replace(/\/+$/, '');
 
     if (t.split('/').includes('..')) {
       throw new Error(
         `target ${JSON.stringify(raw)} contains a ".." segment — it may point outside the migrated tree; pass a plain path inside the repo`,
-      )
+      );
     }
 
     // Collapse interior '/./' segments and repeated './' prefixes BEFORE the duplicate
     // check — 'src', './src', '././src', and 'src/./sub' vs 'src/sub' must all land on
     // one spelling, or a duplicate pair slips past and every codemod runs twice over it.
-    while (t.includes('/./')) t = t.replace(/\/\.\//g, '/')
-    t = t.replace(/\/\.$/, '')
-    while (t.startsWith('./')) t = t.slice(2)
+    while (t.includes('/./')) t = t.replace(/\/\.\//g, '/');
+    t = t.replace(/\/\.$/, '');
+    while (t.startsWith('./')) t = t.slice(2);
 
-    if (repoRootNormalized && (t === repoRootNormalized || t.startsWith(repoRootNormalized + '/'))) {
-      t = t.slice(repoRootNormalized.length + 1)
+    if (
+      repoRootNormalized &&
+      (t === repoRootNormalized || t.startsWith(repoRootNormalized + '/'))
+    ) {
+      t = t.slice(repoRootNormalized.length + 1);
     }
 
     if (t === '' || t === '.') {
       throw new Error(
         `target ${JSON.stringify(raw)} resolves to the repo root ('.') — SKILL.md preflight item 4 forbids '.' as a target: it would run every codemod over the ENTIRE repo, build output and fixtures included; pass the specific source/stylesheet directories (or the root-level stylesheet's own path) instead`,
-      )
+      );
     }
 
     // Build output / dependency directories, at ANY segment. This is the second layer:
@@ -316,31 +353,33 @@ const canonicalTargets = (() => {
       '.turbo',
       '.svelte-kit',
       'storybook-static',
-    ])
-    const offendingSegment = t.split('/').find((seg) => BUILD_OUTPUT_SEGMENTS.has(seg))
+    ]);
+    const offendingSegment = t
+      .split('/')
+      .find((seg) => BUILD_OUTPUT_SEGMENTS.has(seg));
     if (offendingSegment !== undefined) {
       throw new Error(
         `target ${JSON.stringify(raw)} contains the build-output/dependency segment ${JSON.stringify(offendingSegment)} — SKILL.md preflight item 4 forbids these ("Never make build output a target"). The codemod CLI's ignore list is consulted only for directories met while recursing, never for the path you pass, so this target's generated stylesheets WOULD be rewritten. If preflight's stylesheet-discovery command produced this path, its exclusion filter did not fire — re-run that command with the --exclude-dir flags and the anchored (^|\\./|/) filter, and pass only real source directories`,
-      )
+      );
     }
 
     if (t.startsWith('/') || /^[A-Za-z]:[\\/]/.test(t)) {
       throw new Error(
         `target ${JSON.stringify(raw)} resolves outside repoRoot ${JSON.stringify(args.repoRoot)} — every codemod must run inside the migrated repo, or a failed step cannot be restored with \`git -C <repoRoot> checkout\` and the tree is left half-transformed (the corruption path)`,
-      )
+      );
     }
 
-    const previous = seen.get(t)
+    const previous = seen.get(t);
     if (previous !== undefined) {
       throw new Error(
         `duplicate targets point at the same tree — ${JSON.stringify(previous)} and ${JSON.stringify(raw)} both resolve to ${JSON.stringify(t)}, so each codemod would run twice over it (the run-once corruption path); list each directory exactly once`,
-      )
+      );
     }
-    seen.set(t, raw)
+    seen.set(t, raw);
   }
 
-  return [...seen.keys()]
-})()
+  return [...seen.keys()];
+})();
 
 for (const a of canonicalTargets) {
   for (const b of canonicalTargets) {
@@ -349,51 +388,56 @@ for (const a of canonicalTargets) {
     if (a !== b && (b + '/').startsWith(a === '.' ? '' : a + '/')) {
       throw new Error(
         `targets must be disjoint directories — ${JSON.stringify(b)} is nested inside ${JSON.stringify(a)}, so each codemod would run twice over the nested subtree (the run-once corruption path); keep only the outer directory`,
-      )
+      );
     }
   }
 }
 if (typeof args.autoCommit !== 'boolean') {
-  throw new Error('autoCommit must be a boolean')
+  throw new Error('autoCommit must be a boolean');
 }
 for (const key of ['repoRoot', 'stateFile', 'referencesDir']) {
-  if (typeof args[key] !== 'string' || !/^(\/|[A-Za-z]:[\\/])/.test(args[key])) {
-    throw new Error(`${key} must be an absolute path (got ${JSON.stringify(args[key])})`)
+  if (
+    typeof args[key] !== 'string' ||
+    !/^(\/|[A-Za-z]:[\\/])/.test(args[key])
+  ) {
+    throw new Error(
+      `${key} must be an absolute path (got ${JSON.stringify(args[key])})`,
+    );
   }
 }
-const excludeFilesInput = args.excludeFiles || []
+const excludeFilesInput = args.excludeFiles || [];
 if (!Array.isArray(excludeFilesInput)) {
-  throw new Error('excludeFiles must be an array of repo-relative paths')
+  throw new Error('excludeFiles must be an array of repo-relative paths');
 }
 for (const f of excludeFilesInput) {
   if (typeof f !== 'string' || f.startsWith('/') || /^[A-Za-z]:[\\/]/.test(f)) {
     throw new Error(
       `excludeFiles entry ${JSON.stringify(f)} must be a repo-relative path — the move-out/move-back procedure runs from the repo root, and an absolute path would be restored to the wrong location`,
-    )
+    );
   }
   if (String(f).split('/').includes('..')) {
     throw new Error(
       `excludeFiles entry ${JSON.stringify(f)} contains a ".." segment — it points outside the migrated tree, and the move-out/move-back procedure would restore it to the wrong location`,
-    )
+    );
   }
 }
 
 // Canonical targets, never args.targets: the raw list may carry duplicate spellings of one
 // tree, and the step agents must receive the same list the disjointness check validated.
-const targets = JSON.stringify(canonicalTargets)
-const excludeFilesJson = JSON.stringify(excludeFilesInput)
+const targets = JSON.stringify(canonicalTargets);
+const excludeFilesJson = JSON.stringify(excludeFilesInput);
 
 // Every `git -C <repoRoot>` in the step prompts is a command the agent copies verbatim —
 // a repo path containing a space (or any shell metacharacter) breaks all of them unless
 // the interpolation ships pre-quoted. Single-quote POSIX-style; embedded quotes escaped.
-const shq = (p) => `'${String(p).replace(/'/g, `'\\''`)}'`
-const repoRootSh = shq(args.repoRoot)
+const shq = (p) => `'${String(p).replace(/'/g, `'\\''`)}'`;
+const repoRootSh = shq(args.repoRoot);
 // Same treatment for the targets: the step agent pastes these into npx/checkout/pathspec
 // positions, and a double-quoted interpolation would still let `$()`/backticks expand.
 // One token per line, NEVER JSON.stringify — JSON re-escapes `"` and `\`, so a pasted
 // token would no longer be the shell-quoted path. No list-marker prefix either: a `- `
 // pasted along with the token becomes a separate argument.
-const targetsSh = canonicalTargets.map(shq).join('\n')
+const targetsSh = canonicalTargets.map(shq).join('\n');
 
 // Kept in sync with the template in SKILL.md ("State file format") and MANUAL_SCAN_SECTIONS
 // above — see that section's Consistency surfaces list for every surface to update.
@@ -431,23 +475,23 @@ manual:
   M14: pending
   M15: pending
   M16: pending
----`
+---`;
 
 if (args.completedSteps !== undefined && !Array.isArray(args.completedSteps)) {
   throw new Error(
     'completedSteps must be an array of step ids — a string would substring-match through .includes() and skip steps that were never completed',
-  )
+  );
 }
 // Deduplicated on read: the all-completed gate below compares LENGTH against
 // CODEMOD_STEPS, so a list with repeats would satisfy it without covering every step.
-const completedSteps = [...new Set(args.completedSteps || [])]
+const completedSteps = [...new Set(args.completedSteps || [])];
 {
-  const knownStepIds = new Set(CODEMOD_STEPS.map((s) => s.id))
+  const knownStepIds = new Set(CODEMOD_STEPS.map((s) => s.id));
   for (const id of completedSteps) {
     if (!knownStepIds.has(id)) {
       throw new Error(
         `completedSteps contains unknown step id ${JSON.stringify(id)} — a typo silently skips nothing and lets a completed step re-run (the corruption path); use the exact ids: ${[...knownStepIds].join(', ')}`,
-      )
+      );
     }
   }
   // A gap in the canonical order is legal but exceptional: only the single-codemod path can
@@ -457,24 +501,26 @@ const completedSteps = [...new Set(args.completedSteps || [])]
   const gaps = CODEMOD_STEPS.filter(
     (s, i) =>
       !completedSteps.includes(s.id) &&
-      CODEMOD_STEPS.slice(i + 1).some((later) => completedSteps.includes(later.id)),
-  ).map((s) => s.id)
+      CODEMOD_STEPS.slice(i + 1).some((later) =>
+        completedSteps.includes(later.id),
+      ),
+  ).map((s) => s.id);
   if (gaps.length > 0 && args.allowOutOfOrderSteps !== true) {
     throw new Error(
       `completedSteps is not a prefix of the canonical order — ${JSON.stringify(gaps)} are pending while later steps are marked completed. Three causes, and the script cannot tell them apart: (a) a STALE list, in which case the orchestrator-level skip would silently skip a step that never ran (under-migration with no later scan to catch it), (b) a genuine out-of-order state produced by the single-codemod path with explicit user confirmation, or (c) a resume of an OLDER state file that predates a step inserted mid-order (the gap step's key was ABSENT from the file and was added as pending per SKILL.md preflight item 1 — e.g. semantic-token-migration). Refresh the list from the state file; if the gap is the confirmed single-codemod one or the verified missing-key one, re-run with allowOutOfOrderSteps: true.`,
-    )
+    );
   }
   if (gaps.length > 0) {
     log(
       `Proceeding with a non-prefix completedSteps list (allowOutOfOrderSteps) — ${JSON.stringify(gaps)} are pending while later steps are marked completed.`,
-    )
+    );
   }
 }
 
-const stepResults = []
-let aborted = null
-let stateCheckReport = null
-let stateCheckError = null
+const stepResults = [];
+let aborted = null;
+let stateCheckReport = null;
+let stateCheckError = null;
 
 // Every step being skipped means no step agent runs, so nothing would verify the state
 // file or the targets it records — the scan-only re-run path in SKILL.md Step 2 lands here.
@@ -506,16 +552,25 @@ Report structured data only, no prose.`,
             items: {
               type: 'object',
               required: ['file', 'name'],
-              properties: { file: { type: 'string' }, name: { type: 'string' } },
+              properties: {
+                file: { type: 'string' },
+                name: { type: 'string' },
+              },
             },
           },
-          stepMarks: { type: 'object', additionalProperties: { type: 'string' } },
-          manualMarks: { type: 'object', additionalProperties: { type: 'string' } },
+          stepMarks: {
+            type: 'object',
+            additionalProperties: { type: 'string' },
+          },
+          manualMarks: {
+            type: 'object',
+            additionalProperties: { type: 'string' },
+          },
           notes: { type: 'array', items: { type: 'string' } },
         },
       },
     },
-  )
+  );
 
   // scan-only is legitimate ONLY when the state file itself marks every codemod step
   // completed — a stale completedSteps arg alone must not skip a pending codemod.
@@ -523,29 +578,30 @@ Report structured data only, no prose.`,
     ? CODEMOD_STEPS.map((s) => s.id).filter(
         (id) => stateCheck.stepMarks[id] !== 'completed',
       )
-    : null
+    : null;
 
   // targets are not the only locked field: running with a different codemodVersion changes
   // the transform BUILD mid-migration, and a flipped autoCommit changes the failure handling
   // every later step branches on. Both are recorded, so both are comparable — compare them.
   const versionMismatch =
-    stateCheck?.codemodVersion && String(stateCheck.codemodVersion) !== String(codemodVersion)
+    stateCheck?.codemodVersion &&
+    String(stateCheck.codemodVersion) !== String(codemodVersion)
       ? `state file records codemodVersion ${stateCheck.codemodVersion} but this run passed ${codemodVersion} — the same-build guarantee is broken; re-run with the recorded version, or reconcile with the user before changing the pin`
-      : null
+      : null;
   const autoCommitMismatch =
     stateCheck?.autoCommit !== undefined &&
     String(stateCheck.autoCommit) !== String(args.autoCommit)
       ? `state file records autoCommit ${stateCheck.autoCommit} but this run passed ${args.autoCommit} — every step's failure handling and clean-tree expectation branches on it; re-run with the recorded value`
-      : null
+      : null;
   // The recorded exclusions outlive the run that created them: the final verification uses
   // them to tell a ring-fenced hand-migrated file from a leftover, and a resume that drops
   // the arg would un-exclude those files for any later step ⑥ work.
-  const recordedExclusions = stateCheck?.excludeFiles || []
+  const recordedExclusions = stateCheck?.excludeFiles || [];
   const exclusionsMismatch =
     JSON.stringify([...recordedExclusions].sort()) !==
     JSON.stringify([...excludeFilesInput].sort())
       ? `state file records excludeFiles ${JSON.stringify(recordedExclusions)} but this run passed ${JSON.stringify(excludeFilesInput)} — pass the recorded list back on every invocation; omitting it un-excludes the files the user ring-fenced and makes the final verification treat their Form* mentions as leftovers`
-      : null
+      : null;
 
   if (
     !stateCheck ||
@@ -565,34 +621,34 @@ Report structured data only, no prose.`,
           : versionMismatch ||
             autoCommitMismatch ||
             exclusionsMismatch ||
-            `completedSteps claims all ${CODEMOD_STEPS.length} steps are done, but the state file marks ${JSON.stringify(notCompleted)} as not completed — a stale completedSteps list would silently skip pending codemods; refresh it from the state file and re-run`
-    aborted = 'state-file-verification'
-    log(`Aborting before the scans — ${stateCheckError}`)
+            `completedSteps claims all ${CODEMOD_STEPS.length} steps are done, but the state file marks ${JSON.stringify(notCompleted)} as not completed — a stale completedSteps list would silently skip pending codemods; refresh it from the state file and re-run`;
+    aborted = 'state-file-verification';
+    log(`Aborting before the scans — ${stateCheckError}`);
   } else {
-    stateCheckReport = stateCheck
+    stateCheckReport = stateCheck;
     log(
       `state file verified (targets match, all ${CODEMOD_STEPS.length} steps completed) — running scans only`,
-    )
+    );
   }
 }
 
 for (const step of CODEMOD_STEPS) {
   // A failed state-file verification must never be followed by a codemod invocation.
-  if (aborted) break
+  if (aborted) break;
 
   if (completedSteps.includes(step.id)) {
     // Deterministic orchestrator-level skip. The step agent's own state-file check
     // (procedure step 1) stays as the second layer, guarding runs launched with a
     // stale completedSteps list.
-    log(`${step.id}: skipped (state file marks it completed)`)
+    log(`${step.id}: skipped (state file marks it completed)`);
     stepResults.push({
       step: step.id,
       status: 'skipped',
       filesChanged: 0,
       committed: false,
       verifyFindings: [],
-    })
-    continue
+    });
+    continue;
   }
 
   // On state-file recreation the agent must mark every step that already ran in THIS
@@ -602,9 +658,11 @@ for (const step of CODEMOD_STEPS) {
   const stepsDoneByNow = JSON.stringify([
     ...new Set([
       ...completedSteps,
-      ...CODEMOD_STEPS.slice(0, CODEMOD_STEPS.indexOf(step) + 1).map((s) => s.id),
+      ...CODEMOD_STEPS.slice(0, CODEMOD_STEPS.indexOf(step) + 1).map(
+        (s) => s.id,
+      ),
     ]),
-  ])
+  ]);
 
   // Structural gate: only the form-control-migration agent ever receives a MOVE-OUT list —
   // any other step moving files out would silently skip their transformation. Every step
@@ -612,7 +670,7 @@ for (const step of CODEMOD_STEPS) {
   // step 1 (a resume that drops the arg must fail loudly at the FIRST step, not only at ⑥
   // or on the scan-only path).
   const stepExcludeFiles =
-    step.id === 'form-control-migration' ? excludeFilesJson : '[]'
+    step.id === 'form-control-migration' ? excludeFilesJson : '[]';
 
   const result = await agent(
     `You are executing ONE step of the Montage v3 → v4 migration in the repo at ${args.repoRoot}.
@@ -647,35 +705,42 @@ If ANY dirty path is not explainable by a completed step's rename surface, repor
 7. If the codemod failed partway, NEVER leave a half-transformed tree (re-running a codemod over one is the documented corruption path for steps 5–6 — list-card-migration and form-control-migration — and excluding the partially-transformed files later is the WRONG fix): when autoCommit is true (tree was clean at step start), restore with \`git -C ${repoRootSh} checkout -- <each shell-quoted target>\`; when autoCommit is false, restore the targets from the snapshot recorded in step 5 (\`git -C ${repoRootSh} checkout <snapshot-hash> -- <each shell-quoted target>\` — this reverts only this step's changes; earlier steps' uncommitted work is inside the snapshot; if no hash was printed the tree was clean, so plain \`git checkout -- <each shell-quoted target>\` is equivalent). Move any excluded files back per step 8, then report status "failed" with the error.
 8. If files were moved out in step 4: move each back to its exact original path, re-run the path+hash command and diff against the recording from step 4 — must be empty (do NOT rely on a plain \`git status\` no-diff check — it is only meaningful when autoCommit is true; with autoCommit false the excluded files legitimately carry earlier steps' uncommitted changes and show as modified), and confirm the temp dir is empty. If the hash diff is NON-empty, or \`find "$EXCL" -type f\` still lists files, STOP: report status "failed" with the unrestored paths, KEEP the recovery record, do NOT update the state file and do NOT commit — the orchestrator must surface this to the user. Only on a clean move-back, delete the \`.claude/montage-migration-v4.exclusions.json\` recovery record from step 4. Do this BEFORE the state update and commit — a commit must never contain their deletions.
 9. Post-step verification: ${step.verify} Record findings in verifyFindings; apply only the fixes the verification instructions explicitly assign to this step — leave everything marked M1–M16 to the manual phase.
-10. Update the state file: set steps.${step.id} to "completed", and — for form-control-migration with a non-empty move-out list — write that list to the state file\'s \`excludeFiles:\` key, so later sessions can tell a ring-fenced file from a migration leftover (the final verification depends on it). For css-variable-migration and dom-identifier-migration, append every revert from step 9 to the \`revertedNames:\` key as a file-scoped entry — \`- file: <repo-relative path>\` on one line, \`  name: <reverted name>\` on the next, one entry per (file, name) occurrence — for the same reason — the final verification cannot otherwise tell your deliberate revert from an unmigrated leftover. If the file is missing, recreate it from the template below FIRST — but set every step in this list to "completed" before writing (they all ran, either in earlier sessions or earlier in THIS run; an all-pending file would trigger corrupting re-runs on a later resume): ${stepsDoneByNow}. Report the recreation in verifyFindings together with the recreated \`targets\`, \`autoCommit\`, \`codemodVersion\` AND the fact that every \`manual:\` mark was reset to "pending". Report the two carried-over lists precisely, because they behave differently: \`revertedNames:\` ALWAYS comes back empty (the template cannot recover it, so steps ③/④'s deliberate reverts are no longer distinguishable from leftovers at final verification), while \`excludeFiles:\` is rebuilt from THIS invocation's \`excludeFiles\` arg — currently ${excludeFilesInput.length ? JSON.stringify(excludeFilesInput) : 'EMPTY, so an earlier session\'s ring-fenced list is lost and must be re-established with the user before the final verification'} — all of it comes from this invocation's args and the template, not the lost original, so the orchestrator must confirm each with the user (a finished M-section silently reset to pending is as damaging as a wrong targets list). Ensure the file's path is ignored so it never enters commits: resolve the exclude file with \`git -C ${repoRootSh} rev-parse --git-path info/exclude\` (in a linked worktree or submodule \`.git\` is a FILE, so a literal .git/info/exclude path fails), append the entry only if missing — do the same for \`.claude/montage-migration-v4.exclusions.json\`, the step-⑥ recovery record, which must never enter a commit either — then confirm both with \`git -C ${repoRootSh} check-ignore -q <shell-quoted path>\`. Template:
+10. Update the state file: set steps.${step.id} to "completed", and — for form-control-migration with a non-empty move-out list — write that list to the state file\'s \`excludeFiles:\` key, so later sessions can tell a ring-fenced file from a migration leftover (the final verification depends on it). For css-variable-migration and dom-identifier-migration, append every revert from step 9 to the \`revertedNames:\` key as a file-scoped entry — \`- file: <repo-relative path>\` on one line, \`  name: <reverted name>\` on the next, one entry per (file, name) occurrence — for the same reason — the final verification cannot otherwise tell your deliberate revert from an unmigrated leftover. If the file is missing, recreate it from the template below FIRST — but set every step in this list to "completed" before writing (they all ran, either in earlier sessions or earlier in THIS run; an all-pending file would trigger corrupting re-runs on a later resume): ${stepsDoneByNow}. Report the recreation in verifyFindings together with the recreated \`targets\`, \`autoCommit\`, \`codemodVersion\` AND the fact that every \`manual:\` mark was reset to "pending". Report the two carried-over lists precisely, because they behave differently: \`revertedNames:\` ALWAYS comes back empty (the template cannot recover it, so steps ③/④'s deliberate reverts are no longer distinguishable from leftovers at final verification), while \`excludeFiles:\` is rebuilt from THIS invocation's \`excludeFiles\` arg — currently ${excludeFilesInput.length ? JSON.stringify(excludeFilesInput) : "EMPTY, so an earlier session's ring-fenced list is lost and must be re-established with the user before the final verification"} — all of it comes from this invocation's args and the template, not the lost original, so the orchestrator must confirm each with the user (a finished M-section silently reset to pending is as damaging as a wrong targets list). Ensure the file's path is ignored so it never enters commits: resolve the exclude file with \`git -C ${repoRootSh} rev-parse --git-path info/exclude\` (in a linked worktree or submodule \`.git\` is a FILE, so a literal .git/info/exclude path fails), append the entry only if missing — do the same for \`.claude/montage-migration-v4.exclusions.json\`, the step-⑥ recovery record, which must never enter a commit either — then confirm both with \`git -C ${repoRootSh} check-ignore -q <shell-quoted path>\`. Template:
 ${STATE_FILE_TEMPLATE}
 11. Refuse to commit while \`${args.repoRoot}/.claude/montage-migration-v4.exclusions.json\` exists — its presence means excluded files are still moved out, and \`git add -A\` would commit their deletion. If autoCommit is true: \`git -C ${repoRootSh} add -A && git -C ${repoRootSh} commit${commitNoVerify ? ' --no-verify' : ''} -m "chore(montage): v4 codemod — ${step.id}"\` and record the commit hash. ${
       commitNoVerify
-        ? 'The `--no-verify` flag is deliberate: preflight confirmed with the user that this repo\'s pre-commit hooks would reject the intentionally non-building codemod commits.'
+        ? "The `--no-verify` flag is deliberate: preflight confirmed with the user that this repo's pre-commit hooks would reject the intentionally non-building codemod commits."
         : 'No `--no-verify` was agreed at preflight, so run the commit as written. If a pre-commit hook (.husky/, core.hooksPath, lint-staged) rejects it, do NOT retry with --no-verify on your own and do NOT amend the hook config: report status "failed" with the hook output, so the orchestrator can settle the policy with the user and re-run with commitNoVerify: true.'
     } The state file is ignored via the resolved \`info/exclude\` path from step 10, so it must not appear in the commit — if \`git check-ignore\` there reported it as NOT ignored, fix the ignore entry before committing rather than committing the state file.
 
 Report filesChanged for THIS step only: with autoCommit true, use the commit stat; with autoCommit false, diff against the step-5 snapshot (\`git -C ${repoRootSh} diff --stat <snapshot-hash> -- <each shell-quoted target>\`) — a plain \`git diff --stat\` there also counts every earlier step's uncommitted output and would report an inflated, cumulative number. Your final output is structured data for the orchestrator, not prose.`,
-    { label: `codemod:${step.id}`, phase: 'Codemods', schema: STEP_RESULT_SCHEMA },
-  )
+    {
+      label: `codemod:${step.id}`,
+      phase: 'Codemods',
+      schema: STEP_RESULT_SCHEMA,
+    },
+  );
 
-  stepResults.push(result)
+  stepResults.push(result);
 
   if (!result || result.status === 'failed') {
-    aborted = step.id
-    log(`Aborting migration at step ${step.id} — fix the reported error, then resume; completed steps will be skipped.`)
-    break
+    aborted = step.id;
+    log(
+      `Aborting migration at step ${step.id} — fix the reported error, then resume; completed steps will be skipped.`,
+    );
+    break;
   }
-  log(`${step.id}: ${result.status} (${result.filesChanged} files)`)
+  log(`${step.id}: ${result.status} (${result.filesChanged} files)`);
 }
 
-let scanResults = []
+let scanResults = [];
 
 if (!aborted) {
   scanResults = await parallel(
-    MANUAL_SCAN_SECTIONS.map((section) => () =>
-      agent(
-        `You are scanning (READ-ONLY — do not edit any file) the repo at ${args.repoRoot} for Montage v3 → v4 manual-migration targets.
+    MANUAL_SCAN_SECTIONS.map(
+      (section) => () =>
+        agent(
+          `You are scanning (READ-ONLY — do not edit any file) the repo at ${args.repoRoot} for Montage v3 → v4 manual-migration targets.
 
 Section: ${section.id} — ${section.title}
 State file: ${args.stateFile} — read its \`excludeFiles:\` and \`revertedNames:\` lists BEFORE assessing hits. A hit inside an \`excludeFiles\` path is a file the user ring-fenced from step ⑥ (M5's pattern reaches them, and they must never be edited). A \`revertedNames\` entry excuses a hit only when BOTH its \`file\` and \`name\` match the hit — the same name in another file is still a work item, since steps ③/④ judged it per file. Mark matching hits as expected survivors, not work items.
@@ -684,10 +749,14 @@ State file: ${args.stateFile} — read its \`excludeFiles:\` and \`revertedNames
 2. Run the section's scan patterns over the repo. Scan the WHOLE repo (configs, E2E tests, stylesheets), not just source targets, but skip .git, node_modules, .next, dist, build output, and lockfiles.
 3. For each hit, assess it against the fix rules: does it actually need the manual migration, or is it a false positive (e.g. theme token used inside a CSS template literal is fine)? Record file, line, a one-line snippet, and your assessment.
 4. Do not fix anything. Your final output is structured data for the orchestrator.`,
-        { label: `scan:${section.id}`, phase: 'Scan', schema: SCAN_RESULT_SCHEMA },
-      ),
+          {
+            label: `scan:${section.id}`,
+            phase: 'Scan',
+            schema: SCAN_RESULT_SCHEMA,
+          },
+        ),
     ),
-  )
+  );
 }
 
 return {
@@ -696,4 +765,4 @@ return {
   stateCheckError,
   steps: stepResults.filter(Boolean),
   manualScan: scanResults.filter(Boolean),
-}
+};

--- a/.claude/skills/migration-skill-authoring/scripts/analyze-codemods.js
+++ b/.claude/skills/migration-skill-authoring/scripts/analyze-codemods.js
@@ -4,11 +4,13 @@ export const meta = {
     'Analyze codemod transforms for behavior, idempotency, and ordering constraints before authoring a migration skill',
   whenToUse:
     'Invoked by the migration-skill-authoring skill: one analysis agent per transform + one CLI/docs agent',
-  phases: [{ title: 'Analyze', detail: 'one agent per transform + CLI/docs facts' }],
-}
+  phases: [
+    { title: 'Analyze', detail: 'one agent per transform + CLI/docs facts' },
+  ],
+};
 
 // The harness may deliver `args` as a JSON string instead of an object — normalize first.
-const input = typeof args === 'string' ? JSON.parse(args) : (args ?? {})
+const input = typeof args === 'string' ? JSON.parse(args) : (args ?? {});
 
 // Required args:
 //   repoRoot:   absolute path of this design-system repo
@@ -34,7 +36,10 @@ const TRANSFORM_SCHEMA = {
   ],
   properties: {
     transform: { type: 'string' },
-    summary: { type: 'string', description: 'What the codemod does, 2-4 sentences' },
+    summary: {
+      type: 'string',
+      description: 'What the codemod does, 2-4 sentences',
+    },
     detection: {
       type: 'string',
       description:
@@ -42,7 +47,8 @@ const TRANSFORM_SCHEMA = {
     },
     importGated: {
       type: 'boolean',
-      description: 'true if the transform only fires when specific gating imports are present',
+      description:
+        'true if the transform only fires when specific gating imports are present',
     },
     idempotency: {
       type: 'object',
@@ -54,7 +60,10 @@ const TRANSFORM_SCHEMA = {
           description:
             'Concretely what happens on a second run over already-migrated code. Trace rename chains: does any rename VALUE appear as another rename KEY? Also state what happens on hand-migrated code.',
         },
-        evidence: { type: 'string', description: 'file:line references backing the claim' },
+        evidence: {
+          type: 'string',
+          description: 'file:line references backing the claim',
+        },
       },
     },
     ordering: {
@@ -66,43 +75,55 @@ const TRANSFORM_SCHEMA = {
     manualFollowUps: {
       type: 'array',
       items: { type: 'string' },
-      description: 'Things the codemod cannot do that consumers must fix by hand afterwards',
+      description:
+        'Things the codemod cannot do that consumers must fix by hand afterwards',
     },
-    cliCommand: { type: 'string', description: 'Exact npx command for a src directory' },
+    cliCommand: {
+      type: 'string',
+      description: 'Exact npx command for a src directory',
+    },
     testFiles: { type: 'array', items: { type: 'string' } },
   },
-}
+};
 
 const DOCS_SCHEMA = {
   type: 'object',
   required: ['invocation', 'batchMode', 'notes'],
   properties: {
-    invocation: { type: 'string', description: 'Canonical non-interactive CLI usage line' },
+    invocation: {
+      type: 'string',
+      description: 'Canonical non-interactive CLI usage line',
+    },
     batchMode: {
       type: 'string',
-      description: 'Whether the CLI can batch transforms or takes one per invocation; how many path args it honors; whether globs are expanded',
+      description:
+        'Whether the CLI can batch transforms or takes one per invocation; how many path args it honors; whether globs are expanded',
     },
     styleTextTransforms: {
       type: 'string',
-      description: 'Which transforms are registered in STYLE_TEXT_TRANSFORMS (stylesheet pass)',
+      description:
+        'Which transforms are registered in STYLE_TEXT_TRANSFORMS (stylesheet pass)',
     },
     latestPublishedVersion: {
       type: 'string',
-      description: 'Latest published version per CHANGELOG.md and current lerna.json version',
+      description:
+        'Latest published version per CHANGELOG.md and current lerna.json version',
     },
     recommendedOrder: {
       type: 'string',
-      description: 'Ordering implied by the MIGRATION.md section order and constants.ts',
+      description:
+        'Ordering implied by the MIGRATION.md section order and constants.ts',
     },
     notes: { type: 'array', items: { type: 'string' } },
   },
-}
+};
 
-phase('Analyze')
+phase('Analyze');
 
-const tasks = input.transforms.map((t) => () =>
-  agent(
-    `You are analyzing a jscodeshift codemod in the Montage design system repo at ${input.repoRoot}.
+const tasks = input.transforms.map(
+  (t) => () =>
+    agent(
+      `You are analyzing a jscodeshift codemod in the Montage design system repo at ${input.repoRoot}.
 
 Target transform: ${t.key}
 Read these files completely: ${t.files}
@@ -112,9 +133,9 @@ Find and read any test files for this transform (Glob/Grep for "*${t.key}*" unde
 ${t.extra || ''}
 
 Answer with file:line evidence. A consumer-facing skill will run this codemod EXACTLY ONCE in a fixed order in consumer repos, so the idempotency and ordering analysis must be correct, not guessed. Idempotency is a source-level fact: trace whether any rename VALUE appears as another rename KEY (double-swap corruption), and whether running against hand-migrated code corrupts. Your final output is raw data for the orchestrator, not prose for a human.`,
-    { label: `analyze:${t.key}`, phase: 'Analyze', schema: TRANSFORM_SCHEMA },
-  ),
-)
+      { label: `analyze:${t.key}`, phase: 'Analyze', schema: TRANSFORM_SCHEMA },
+    ),
+);
 
 if (!input.skipDocsAgent) {
   tasks.push(() =>
@@ -126,21 +147,27 @@ Read: packages/codemod/package.json, packages/codemod/src/cli.ts, packages/codem
 Determine from SOURCE (not docs — the help text has been wrong before): exact non-interactive invocation, how many path positionals are honored, whether globs are expanded, which transforms get the stylesheet text pass (STYLE_TEXT_TRANSFORMS), extensions and ignore patterns, and any ordering implied for this version's transforms. Your final output is raw data for the orchestrator.`,
       { label: 'analyze:cli-docs', phase: 'Analyze', schema: DOCS_SCHEMA },
     ),
-  )
+  );
 }
 
-const results = await parallel(tasks)
-const transformResults = results.slice(0, input.transforms.length)
-const transforms = transformResults.filter(Boolean)
-const missing = input.transforms.filter((t, i) => !transformResults[i]).map((t) => t.key)
-const docs = input.skipDocsAgent ? 'skipped' : results[input.transforms.length] || null
+const results = await parallel(tasks);
+const transformResults = results.slice(0, input.transforms.length);
+const transforms = transformResults.filter(Boolean);
+const missing = input.transforms
+  .filter((t, i) => !transformResults[i])
+  .map((t) => t.key);
+const docs = input.skipDocsAgent
+  ? 'skipped'
+  : results[input.transforms.length] || null;
 
 log(
   `Analyzed ${transforms.length}/${input.transforms.length} transforms` +
-    (missing.length ? ` — MISSING: ${missing.join(', ')} (re-run before deriving the design)` : ''),
-)
+    (missing.length
+      ? ` — MISSING: ${missing.join(', ')} (re-run before deriving the design)`
+      : ''),
+);
 
 // missing lists transforms whose analysis agent failed; docs is null when the docs
 // agent failed (vs 'skipped' when skipDocsAgent was set). Never derive ordering or
 // idempotency from a result with missing entries.
-return { transforms, missing, docs }
+return { transforms, missing, docs };

--- a/.claude/skills/migration-skill-authoring/scripts/validate-migration-skill.js
+++ b/.claude/skills/migration-skill-authoring/scripts/validate-migration-skill.js
@@ -5,14 +5,25 @@ export const meta = {
   whenToUse:
     'Invoked by the migration-skill-authoring skill after authoring or updating a migration skill; re-run until no critical/major survives verification',
   phases: [
-    { title: 'Scope', detail: 'resolve the changed regions this run is accountable for' },
-    { title: 'Review', detail: '4 parallel reviewers (fact-check, consistency, quality, structure)' },
-    { title: 'Verify', detail: 'per-file dedup + reproduce each finding; unreproducible findings are dropped' },
+    {
+      title: 'Scope',
+      detail: 'resolve the changed regions this run is accountable for',
+    },
+    {
+      title: 'Review',
+      detail:
+        '4 parallel reviewers (fact-check, consistency, quality, structure)',
+    },
+    {
+      title: 'Verify',
+      detail:
+        'per-file dedup + reproduce each finding; unreproducible findings are dropped',
+    },
   ],
-}
+};
 
 // The harness may deliver `args` as a JSON string instead of an object — normalize first.
-const input = typeof args === 'string' ? JSON.parse(args) : (args ?? {})
+const input = typeof args === 'string' ? JSON.parse(args) : (args ?? {});
 
 // Required args:
 //   repoRoot: absolute path of this design-system repo
@@ -38,25 +49,28 @@ const input = typeof args === 'string' ? JSON.parse(args) : (args ?? {})
 //             change is already committed on a feature branch. Ignored when scope is 'full'.
 
 if (!input.repoRoot || !input.skillDir || !input.transformsDir) {
-  throw new Error('repoRoot, skillDir and transformsDir are required absolute paths')
+  throw new Error(
+    'repoRoot, skillDir and transformsDir are required absolute paths',
+  );
 }
 
-const pluginRoot = input.pluginRoot || input.skillDir.split('/skills/')[0]
-const knownIssuesFile = input.knownIssuesFile || `${input.skillDir}/known-issues.md`
+const pluginRoot = input.pluginRoot || input.skillDir.split('/skills/')[0];
+const knownIssuesFile =
+  input.knownIssuesFile || `${input.skillDir}/known-issues.md`;
 
 const SKILL_FILE_LIST = [
   `${input.skillDir}/SKILL.md`,
   `${input.skillDir}/references/codemod-steps.md`,
   `${input.skillDir}/references/manual-migrations.md`,
   `${input.skillDir}/scripts/migration-workflow.js`,
-]
-const SKILL_FILES = SKILL_FILE_LIST.join(', ')
+];
+const SKILL_FILES = SKILL_FILE_LIST.join(', ');
 const PLUGIN_FILE_LIST = [
   `${pluginRoot}/README.md`,
   `${pluginRoot}/README.ko.md`,
   `${pluginRoot}/.claude-plugin/plugin.json`,
   `${input.repoRoot}/.claude-plugin/marketplace.json`,
-]
+];
 
 // Three defects made previous runs untrustworthy, and each rule below exists for one of
 // them: confident findings read off a STALE DUPLICATE of the skill (a previous run produced
@@ -66,17 +80,17 @@ const PATH_RULES = `PATH DISCIPLINE — non-negotiable, and the single largest s
 - The skill under review consists of EXACTLY these files: ${SKILL_FILES}. Supporting files: ${PLUGIN_FILE_LIST.join(', ')}.
 - Read and cite ONLY those absolute paths. This repository is checked out MORE THAN ONCE on this machine — git worktrees live under a \`.claude/worktrees/<branch>/\` subtree, and \`${input.repoRoot}\` may itself BE such a worktree whose parent checkout holds an OLDER copy of these same files at the same relative path. Reading the wrong copy produces findings that are confident, specific, and entirely false.
 - Never search above \`${input.repoRoot}\`. Never use a path you were not given here. Never re-resolve a file by name, glob, or memory when its absolute path is in the list above. If any search returns a path outside the list, discard the hit — do not "reconcile" it.
-- For EVERY file you cite, run \`wc -l <absolute path from the list>\` FIRST and put that count in the finding's \`fileLines\`. The verification phase re-runs \`wc -l\` and REFUTES any finding whose \`fileLines\` disagrees, on the grounds that you read a different file — so this field is your own protection.`
+- For EVERY file you cite, run \`wc -l <absolute path from the list>\` FIRST and put that count in the finding's \`fileLines\`. The verification phase re-runs \`wc -l\` and REFUTES any finding whose \`fileLines\` disagrees, on the grounds that you read a different file — so this field is your own protection.`;
 
 const SEVERITY_RULES = `SEVERITY — rate by CONSEQUENCE for a fresh Claude instance executing the skill in a consumer repo, not by how wrong the text feels:
 - critical: following the docs corrupts code, loses work, or leaves a corruption GUARD silently inert (a scan that cannot match, a check that never runs).
 - major: a fresh instance is likely to take a wrong action, or a documented claim about runtime behavior is false.
 - minor: duplication, drift, or imprecision with no wrong-action path; missing cross-reference; wording.
-Style, file length, word budget, description length, and "this could be leaner" are minor by definition — never rate them higher. If a finding's only harm is that a human reviewer would find it untidy, it is minor.`
+Style, file length, word budget, description length, and "this could be leaner" are minor by definition — never rate them higher. If a finding's only harm is that a human reviewer would find it untidy, it is minor.`;
 
 const EVIDENCE_RULES = `EVIDENCE — every finding needs an \`evidence\` field containing either the exact command you ran WITH its observed output, or a verbatim quote with file:line from the allowed paths. Claims about runtime behavior (a grep pattern, a regex, the CLI, a transform) must be EXECUTED: \`/usr/bin/grep -E\` against a fixture you write, \`node -e\` for a regex, the real transform for a codemod claim. A finding you cannot back this way must not be reported at all — an unbacked finding is worse than a missed one, because it costs a maintainer a full investigation.
 
-ACCEPTED TRADE-OFFS — read \`${knownIssuesFile}\` if it exists (it may not; that is fine). Every entry is a deliberate, accepted decision. Do not report it again, and do not report a restatement of it under a different framing.`
+ACCEPTED TRADE-OFFS — read \`${knownIssuesFile}\` if it exists (it may not; that is fine). Every entry is a deliberate, accepted decision. Do not report it again, and do not report a restatement of it under a different framing.`;
 
 const FINDINGS_SCHEMA = {
   type: 'object',
@@ -86,7 +100,15 @@ const FINDINGS_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['severity', 'file', 'fileLines', 'issue', 'fix', 'evidence', 'scope'],
+        required: [
+          'severity',
+          'file',
+          'fileLines',
+          'issue',
+          'fix',
+          'evidence',
+          'scope',
+        ],
         properties: {
           scope: {
             type: 'string',
@@ -95,23 +117,31 @@ const FINDINGS_SCHEMA = {
               'delta = anchored in a changed region; blast-radius = contradicts a changed region from unchanged text; pre-existing-critical = untouched by this change but a corruption path',
           },
           severity: { type: 'string', enum: ['critical', 'major', 'minor'] },
-          file: { type: 'string', description: 'Absolute path from the allowed list' },
+          file: {
+            type: 'string',
+            description: 'Absolute path from the allowed list',
+          },
           fileLines: {
             type: 'number',
-            description: 'Output of `wc -l` on that absolute path — proves which copy was read',
+            description:
+              'Output of `wc -l` on that absolute path — proves which copy was read',
           },
           line: { type: 'number' },
-          issue: { type: 'string', description: 'What is wrong, with evidence' },
+          issue: {
+            type: 'string',
+            description: 'What is wrong, with evidence',
+          },
           fix: { type: 'string', description: 'Concrete suggested fix' },
           evidence: {
             type: 'string',
-            description: 'Command + observed output, or verbatim file:line quote',
+            description:
+              'Command + observed output, or verbatim file:line quote',
           },
         },
       },
     },
   },
-}
+};
 
 const VERIFIED_SCHEMA = {
   type: 'object',
@@ -121,7 +151,15 @@ const VERIFIED_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['verdict', 'severity', 'file', 'issue', 'fix', 'reason', 'scope'],
+        required: [
+          'verdict',
+          'severity',
+          'file',
+          'issue',
+          'fix',
+          'reason',
+          'scope',
+        ],
         properties: {
           scope: {
             type: 'string',
@@ -140,23 +178,24 @@ const VERIFIED_SCHEMA = {
           mergedFrom: {
             type: 'array',
             items: { type: 'string' },
-            description: 'Reviewers that reported this same defect, when duplicates were merged',
+            description:
+              'Reviewers that reported this same defect, when duplicates were merged',
           },
         },
       },
     },
   },
-}
+};
 
-const scopeMode = input.scope === 'full' ? 'full' : 'delta'
-const diffBase = input.diffBase || 'HEAD'
+const scopeMode = input.scope === 'full' ? 'full' : 'delta';
+const diffBase = input.diffBase || 'HEAD';
 
 // Resolve WHAT CHANGED before reviewing. Scripts cannot run shell commands, so one cheap
 // agent owns the git plumbing and hands back per-file changed line ranges.
-let changeMap = null
+let changeMap = null;
 
 if (scopeMode === 'delta') {
-  phase('Scope')
+  phase('Scope');
 
   changeMap = await agent(
     `Read-only. Determine which regions of a migration skill package changed, so reviewers know what this validation run is accountable for.
@@ -201,17 +240,21 @@ Report structured data only.`,
         },
       },
     },
-  )
+  );
 
-  if (!changeMap || !Array.isArray(changeMap.changedFiles) || changeMap.changedFiles.length === 0) {
+  if (
+    !changeMap ||
+    !Array.isArray(changeMap.changedFiles) ||
+    changeMap.changedFiles.length === 0
+  ) {
     log(
       `No changes found against ${diffBase} — falling back to a FULL audit (nothing to scope to). Pass a different diffBase if the change is already committed.`,
-    )
-    changeMap = null
+    );
+    changeMap = null;
   } else {
     log(
       `Scoping to ${changeMap.changedFiles.length} changed file(s) vs ${diffBase}; pre-existing defects are reported only when critical.`,
-    )
+    );
   }
 }
 
@@ -221,7 +264,7 @@ const formatChangeMap = (cm) =>
       (f) =>
         `- ${f.file}: lines ${f.ranges.map((r) => (r.length > 1 ? `${r[0]}-${r[1]}` : String(r[0]))).join(', ')} — ${f.summary}`,
     )
-    .join('\n')
+    .join('\n');
 
 const SCOPE_RULES = changeMap
   ? `SCOPE — this run validates a CHANGE, not the whole package. Read every file you were given (you cannot check consistency otherwise), but be strict about what you REPORT.
@@ -235,11 +278,11 @@ Report a finding ONLY if it is one of:
 - \`scope: "pre-existing-critical"\` — untouched by this change, but following the docs corrupts code, loses work, or leaves a corruption guard silently inert. ONLY \`critical\` qualifies here; a pre-existing \`major\` or \`minor\` does NOT.
 
 Do NOT report a pre-existing \`major\` or \`minor\` that this change neither introduced nor invalidated, however real it is. Those are a separate audit (\`scope: 'full'\`); including them here drowns the change review and prevents it from ever converging. Set the \`scope\` field on every finding — the verification phase REFUTES anything whose scope it cannot justify.`
-  : `SCOPE — full audit: report every defect you can evidence, anywhere in the package. Set \`scope: "delta"\` on all findings (there is no change baseline to compare against in this mode).`
+  : `SCOPE — full audit: report every defect you can evidence, anywhere in the package. Set \`scope: "delta"\` on all findings (there is no change baseline to compare against in this mode).`;
 
-phase('Review')
+phase('Review');
 
-const REVIEWERS = ['fact-check', 'consistency', 'quality', 'structure']
+const REVIEWERS = ['fact-check', 'consistency', 'quality', 'structure'];
 
 const results = await parallel([
   () =>
@@ -260,7 +303,11 @@ ${SEVERITY_RULES}
 ${EVIDENCE_RULES}
 
 Report only findings you verified. Your final output is raw data for the orchestrator.`,
-      { label: 'validate:fact-check', phase: 'Review', schema: FINDINGS_SCHEMA },
+      {
+        label: 'validate:fact-check',
+        phase: 'Review',
+        schema: FINDINGS_SCHEMA,
+      },
     ),
   () =>
     agent(
@@ -279,7 +326,11 @@ ${SEVERITY_RULES}
 ${EVIDENCE_RULES}
 
 Report every mismatch you can quote both sides of. Your final output is raw data for the orchestrator.`,
-      { label: 'validate:consistency', phase: 'Review', schema: FINDINGS_SCHEMA },
+      {
+        label: 'validate:consistency',
+        phase: 'Review',
+        schema: FINDINGS_SCHEMA,
+      },
     ),
   () =>
     agent(
@@ -321,14 +372,14 @@ ${EVIDENCE_RULES}
 Report failures only. Your final output is raw data for the orchestrator.`,
       { label: 'validate:structure', phase: 'Review', schema: FINDINGS_SCHEMA },
     ),
-])
+]);
 
-const completed = results.filter(Boolean).length
+const completed = results.filter(Boolean).length;
 const raw = results.flatMap((r, i) =>
   r ? (r.findings || []).map((f) => ({ ...f, reviewer: REVIEWERS[i] })) : [],
-)
+);
 
-log(`${raw.length} raw findings from ${completed}/4 reviewers — verifying`)
+log(`${raw.length} raw findings from ${completed}/4 reviewers — verifying`);
 
 if (raw.length === 0) {
   return {
@@ -342,7 +393,7 @@ if (raw.length === 0) {
     diffBase: changeMap ? diffBase : null,
     changedFiles: changeMap ? changeMap.changedFiles.map((f) => f.file) : null,
     clean: completed === 4,
-  }
+  };
 }
 
 // Group by the file each finding names so one verifier sees every claim about that file —
@@ -350,31 +401,36 @@ if (raw.length === 0) {
 // reviewers lands in the same group). A barrier is required here for exactly that reason.
 // Groups are capped so the run stays inside the agent budget; the overflow group is merged,
 // never dropped.
-const MAX_GROUPS = 8
-const groups = new Map()
+const MAX_GROUPS = 8;
+const groups = new Map();
 for (const f of raw) {
-  const key = String(f.file || 'unknown').split('/').filter(Boolean).pop() || 'unknown'
-  if (!groups.has(key)) groups.set(key, [])
-  groups.get(key).push(f)
+  const key =
+    String(f.file || 'unknown')
+      .split('/')
+      .filter(Boolean)
+      .pop() || 'unknown';
+  if (!groups.has(key)) groups.set(key, []);
+  groups.get(key).push(f);
 }
-let grouped = [...groups.entries()].sort((a, b) => b[1].length - a[1].length)
+let grouped = [...groups.entries()].sort((a, b) => b[1].length - a[1].length);
 if (grouped.length > MAX_GROUPS) {
-  const kept = grouped.slice(0, MAX_GROUPS - 1)
-  const merged = grouped.slice(MAX_GROUPS - 1)
-  kept.push([
-    merged.map(([k]) => k).join('+'),
-    merged.flatMap(([, v]) => v),
-  ])
-  log(`${merged.length} small groups merged into one verifier batch (nothing dropped)`)
-  grouped = kept
+  const kept = grouped.slice(0, MAX_GROUPS - 1);
+  const merged = grouped.slice(MAX_GROUPS - 1);
+  kept.push([merged.map(([k]) => k).join('+'), merged.flatMap(([, v]) => v)]);
+  log(
+    `${merged.length} small groups merged into one verifier batch (nothing dropped)`,
+  );
+  grouped = kept;
 }
 
-phase('Verify')
+phase('Verify');
 
 const verifiedGroups = await parallel(
-  grouped.map(([key, items]) => () =>
-    agent(
-      `You are the adversarial VERIFIER for review findings about "${key}". DEFAULT TO REFUTED — a finding survives only if you reproduce it yourself.
+  grouped.map(
+    ([key, items]) =>
+      () =>
+        agent(
+          `You are the adversarial VERIFIER for review findings about "${key}". DEFAULT TO REFUTED — a finding survives only if you reproduce it yourself.
 
 Findings to verify (JSON, as reported, including each reviewer's claimed \`fileLines\`):
 ${JSON.stringify(items, null, 2)}
@@ -385,12 +441,12 @@ Procedure, in order:
 3. REPRODUCE each surviving finding against the real file. Quote file:line for a textual claim. For any claim about behavior, EXECUTE it: \`/usr/bin/grep -E\` on a fixture you write, \`node -e\` for a regex or a script predicate, the real codemod CLI for a transform claim. CONFIRMED requires a reproduction you can state in \`reason\`; anything else is REFUTED with what you actually observed.
 4. RE-RATE severity per the rubric below, independently of what the reviewer claimed — reviewers systematically over-rate. Downgrade style/length/budget findings to minor.
 5. RE-CHECK SCOPE, after re-rating (the order matters — a finding the reviewer called critical and you downgrade to major loses its pre-existing exemption). ${
-        changeMap
-          ? `This run validates a CHANGE. The changed regions are:
+            changeMap
+              ? `This run validates a CHANGE. The changed regions are:
 ${formatChangeMap(changeMap)}
    Set \`scope\` yourself rather than trusting the reviewer's: "delta" if the defect sits inside a changed region, "blast-radius" if it is unchanged text the change made wrong (a now-stale cross-reference, count, or duplicated statement — verify BOTH sides, quoting the changed region it contradicts), "pre-existing-critical" if untouched by the change but a genuine corruption path. REFUTE with reason "out-of-scope: pre-existing <severity>, not introduced or invalidated by this change" any finding that ends up outside a changed region, does not contradict one, and is not \`critical\` after your re-rating. Do not stretch "blast-radius" to cover a defect that merely lives near a changed region — the change must be what makes it wrong.`
-          : `This run is a FULL audit, so every finding is in scope; set \`scope: "delta"\` on all of them.`
-      }
+              : `This run is a FULL audit, so every finding is in scope; set \`scope: "delta"\` on all of them.`
+          }
 
 Allowed absolute paths (read nothing else, never search above ${input.repoRoot}, and never re-resolve a file by name when its path is here):
 ${[...SKILL_FILE_LIST, ...PLUGIN_FILE_LIST].join('\n')}
@@ -400,18 +456,20 @@ Accepted trade-offs (REFUTE anything restating an entry here, reason "accepted-t
 ${SEVERITY_RULES}
 
 Return every finding you were given, each with a verdict — REFUTED ones included, so the orchestrator can see what was dropped and why. Your final output is raw data for the orchestrator.`,
-      { label: `verify:${key}`, phase: 'Verify', schema: VERIFIED_SCHEMA },
-    ),
+          { label: `verify:${key}`, phase: 'Verify', schema: VERIFIED_SCHEMA },
+        ),
   ),
-)
+);
 
-const order = { critical: 0, major: 1, minor: 2 }
-const assessed = verifiedGroups.filter(Boolean).flatMap((g) => g.verified || [])
+const order = { critical: 0, major: 1, minor: 2 };
+const assessed = verifiedGroups
+  .filter(Boolean)
+  .flatMap((g) => g.verified || []);
 const allConfirmed = assessed
   .filter((f) => f.verdict === 'CONFIRMED')
-  .sort((a, b) => order[a.severity] - order[b.severity])
-const refuted = assessed.filter((f) => f.verdict === 'REFUTED')
-const lostGroups = grouped.length - verifiedGroups.filter(Boolean).length
+  .sort((a, b) => order[a.severity] - order[b.severity]);
+const refuted = assessed.filter((f) => f.verdict === 'REFUTED');
+const lostGroups = grouped.length - verifiedGroups.filter(Boolean).length;
 
 // Split the two audiences apart: the change's own worklist, and corruption paths this change
 // merely happens to sit next to. Both ship — but only the first governs convergence, or a
@@ -423,28 +481,34 @@ const lostGroups = grouped.length - verifiedGroups.filter(Boolean).length
 // verifier should have returned) rather than letting it bypass convergence unexamined.
 const scopeViolations = allConfirmed.filter(
   (f) => f.scope === 'pre-existing-critical' && f.severity !== 'critical',
-)
-const confirmed = allConfirmed.filter((f) => f.scope !== 'pre-existing-critical')
+);
+const confirmed = allConfirmed.filter(
+  (f) => f.scope !== 'pre-existing-critical',
+);
 const preExisting = allConfirmed.filter(
   (f) => f.scope === 'pre-existing-critical' && f.severity === 'critical',
-)
+);
 if (scopeViolations.length > 0) {
   log(
     `${scopeViolations.length} finding(s) claimed scope "pre-existing-critical" at non-critical severity — scope contract enforced: moved to refuted as out-of-scope.`,
-  )
+  );
 }
 
-const blocking = confirmed.filter((f) => f.severity !== 'minor').length
+const blocking = confirmed.filter((f) => f.severity !== 'minor').length;
 log(
   `${confirmed.length} in-scope confirmed (${blocking} critical/major)` +
-    (preExisting.length > 0 ? `, ${preExisting.length} pre-existing critical` : '') +
+    (preExisting.length > 0
+      ? `, ${preExisting.length} pre-existing critical`
+      : '') +
     `, ${refuted.length} refuted, ${raw.length} raw` +
-    (lostGroups > 0 ? ` — WARNING: ${lostGroups} verifier group(s) returned nothing; their findings are unassessed` : ''),
-)
+    (lostGroups > 0
+      ? ` — WARNING: ${lostGroups} verifier group(s) returned nothing; their findings are unassessed`
+      : ''),
+);
 if (preExisting.length > 0) {
   log(
     `${preExisting.length} pre-existing corruption path(s) surfaced outside this change — they do NOT block convergence, but fix or record them deliberately.`,
-  )
+  );
 }
 
 return {
@@ -465,4 +529,4 @@ return {
   diffBase: changeMap ? diffBase : null,
   changedFiles: changeMap ? changeMap.changedFiles.map((f) => f.file) : null,
   clean: blocking === 0 && completed === 4 && lostGroups === 0,
-}
+};


### PR DESCRIPTION
## Summary

`feature/4.0.0`에 올라가 있는 v3→v4 마이그레이션 스킬을 코드모드 소스와 대조해 사실 오류 3건과 경로 설명 오류 1건을 정정했습니다.

- **step ⑥ presence grep이 실행 환경에서 에러로 죽었습니다.** `\bFormControl(\b|Props|…)` 는 `\b`를 alternation 브랜치로 쓰는데, Claude Code가 `grep`을 셰도잉하는 ugrep이 이를 `empty (sub)expression`으로 거부합니다(BSD/GNU는 허용). 출력 0 + stderr 에러라 "step ⑥이 아직 안 돌았다"로 읽힐 수 있습니다. top-level alternation(`\bFormControl\b|\bFormControl(Props|Field|…)`)으로 교체해 **원래 매칭 의미를 그대로 보존**하면서 양쪽 grep에서 동작하게 했습니다. bare prefix `\bFormControl`로 넓히는 방향은 `FormControls` / `FormControlPanel` 같은 소비자 식별자까지 잡아 허위 HALF-migrated 경보를 만들므로 주석으로 막았습니다.
- **`KNOWN_WDS_VARIABLES` 개수 정정** (69/67 → 68/66). #615에서 `--wds-icon-button-inset`이 제거됐습니다. 전환은 prefix 패턴 기반이라 동작 영향은 없고 문서 수치만 stale했습니다.
- **legacy angle-bracket cast 스캔의 캘리브레이션 수치**가 스코프 없이 `10 hits / 404 .ts files`로 적혀 재현 불가능했습니다. 측정 대상을 명시하고 근사값으로 바꿔 다음 커밋에서 또 틀린 값이 되지 않게 했습니다.
- **`${CLAUDE_PLUGIN_ROOT}` 설명 정정.** 플러그인 루트를 `.claude-plugin/montage-migration`이라고 안내하고 있었는데, 이건 소스 저장소 경로이고 **소비자 저장소에는 없습니다.** `repoRoot` 기준으로 해석하지 말 것을 명시하고, 조립한 경로를 믿지 말고 스크립트 존재를 확인하도록 했습니다.
- **재발 방지**: `manual-migrations.md` 프리앰블의 grep 호환성 목록이 "GNU / BSD / ripgrep"만 나열하고 **실제로 실행되는 ugrep을 빼놓고 있었습니다** — 이 누락이 위 패턴이 출하된 이유입니다. ugrep을 추가하고 `\b`를 alternation 브랜치로 쓰지 말라는 규칙을 넣었습니다.
- `known-issues.md`는 플러그인과 함께 소비자에게 배포되지만 안의 경로는 전부 소스 저장소 기준이라 프리앰블에 한정어를 달았습니다.

두 번째 커밋은 **포맷 전용**입니다 (`prettier --check`가 세 스크립트에서 실패 중이었음).

## 영향 범위 — 과장하지 않기

**step ⑥의 코드 손상 자체는 막혀 있습니다.** 워크플로 스크립트가 step agent에게 강제하는 step ⑥ pre-check가 ugrep 안전한 패턴(`\bFormControl(Props)?\b` 등)을 쓰고, 이미 마이그레이션된 파일을 발견하면 `failed`로 중단시킵니다. 깨진 presence grep이 잃는 것은 **오케스트레이터 레벨의 1차 감지 신호**이고, 실패 모드는 "조용한 코드 손상"이 아니라 "혼란스러운 중단 / 잘못된 상태 판정"입니다. 등급은 critical이 아니라 **major**로 보는 게 정확합니다.

나머지 항목은 동작 영향이 없는 문서 정확성 문제입니다. 이 스킬의 전제가 *"모든 사실 주장은 검증된 상태로 출하한다"* 이므로, 그 전제 자체를 지키는 것이 이 PR의 목적입니다.

## 검증

- `codemod-steps.md`의 실행 가능한 grep **14개** + M-section 스캔 패턴 **59개**를 BSD grep·ugrep 양쪽에서 실제 실행 → **에러 0**
- 프리플라이트 스타일시트 탐색 명령, step ⑤/⑥ `comm` 사전점검 4개 정상 실행 확인
- rename table 8종(package 11 / semantic 60 / css exceptions 2 / dom 4 / list-card 9+3+10 / form-control / push-badge / status)을 코드모드 소스와 대조 — 위 1건 외 전부 일치
- transform 동작 주장 대조: form-control 스왑 비멱등성, status의 `invalid positive={pos}` 미변환·`status` 선재 시 skip, push-badge의 `variant="new"` + `count` 삭제
- `MIGRATION.md` 4.0.0의 `###` 섹션 17개 전부가 8 steps + M1–M16 중 하나에 귀속 — 커버리지 갭 0. 3.0.0 이후 breaking 커밋 14건 모두 대응 섹션 존재
- prettier 커밋: 변경 전후 **문자열·숫자·식별자 AST 토큰 동일성** 확인(TypeScript 파서) — step agent가 그대로 따르는 프롬프트 문자열 값 불변. `node --check` + async 래핑 파싱 통과

## Test plan

- [ ] step ⑥ presence grep을 실제 소비자 저장소에서 실행해 stderr 에러 없이 결과가 나오는지 확인
- [ ] `npx prettier --check` 통과 확인

## 노트

- **Jira 티켓 없음** — `feature/4.0.0`에 이미 있는 스킬 문서의 사실 정정이라 티켓 없이 진행했습니다. 필요하면 티켓 만들고 재작업하겠습니다.
- **마일스톤 없음** — 변경이 전부 `.claude-plugin/` / `.claude/` 하위로 배포 영향이 없습니다. 스킬을 처음 추가한 #599도 동일하게 마일스톤 없이 `feature/4.0.0`에 머지됐습니다.
- **커밋 2개를 `--no-verify`로 만들었습니다.** commit-msg 훅(`scripts/commit-msg.mjs`)의 `getSubject`가 Jira ID 없는 브랜치에서 `${issueNo} ${subject}`를 무조건 조립해 subject 앞에 공백을 붙입니다(최근 60커밋 중 2건뿐인 비정상 형태). 우회한 검사는 수동으로 통과 확인했습니다 — `commitlint` 두 메시지 PASS, `eslint` 0 errors(세 스크립트는 eslint ignore 대상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 마이그레이션 사전 점검 기준과 워크플로 실행 지침을 구체화했습니다.
  * macOS BSD grep 및 ugrep 호환 스캔 안내를 추가했습니다.
  * `FormControl` 검사 규칙과 CSS 변수 변환 대상 수를 수정했습니다.
  * 플러그인 경로와 소비자 체크아웃의 파일 경로 차이를 명확히 설명했습니다.

* **개선**
  * 마이그레이션 검증 및 분석 도구의 가독성과 유지보수성을 개선했습니다.
  * Windows 경로 처리와 파일 제외 설정의 안정성을 높였습니다.
  * 기존 검증, 단계 실행, 결과 집계 동작은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->