### PR TITLE
fix(core): push badge 한 글자 고정 너비를 letter-spacing 보정으로 대체

### DIFF
--- a/packages/core/src/components/push-badge/style.ts
+++ b/packages/core/src/components/push-badge/style.ts
@@ -86,7 +86,7 @@ const pushBadgeSizeStyle = (
 
             ${shouldFixedWidth &&
             css`
-              width: ${theme.dimension[16]};
+              letter-spacing: -0.003em;
             `}
 
             --push-badge-outline-border-width: 1px;
@@ -100,7 +100,7 @@ const pushBadgeSizeStyle = (
 
             ${shouldFixedWidth &&
             css`
-              width: ${theme.dimension[20]};
+              letter-spacing: -0.003em;
             `}
 
             --push-badge-outline-border-width: 1.5px;
@@ -114,7 +114,7 @@ const pushBadgeSizeStyle = (
 
             ${shouldFixedWidth &&
             css`
-              width: ${theme.dimension[24]};
+              letter-spacing: -0.003em;
             `}
 
             --push-badge-outline-border-width: 2px;


### PR DESCRIPTION
## Summary

- `text` / `max-count` variant에서 한 글자 텍스트(`shouldFixedWidth`)일 때 `width`를 dimension(16/20/24)으로 고정하던 스타일을 제거
- 대신 `letter-spacing: -0.003em` 보정만 적용 — 원형 크기는 기존 `min-width` / `height`가 그대로 보장

_No Jira ticket — minor style fix._

## Test plan

- [ ] push badge `text` / `max-count` variant의 size별(xsmall/small/medium) 한 글자 렌더링 확인
- [ ] visual regression 스냅샷 diff 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 푸시 배지의 초소형, 소형, 중형 크기에서 고정 너비를 제거했습니다.
  * 텍스트 간격을 조정해 배지 내 콘텐츠가 더 자연스럽게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->