### PR TITLE
feat(core): with-interaction 모바일 tap highlight 제거

### DIFF
--- a/packages/core/src/components/with-interaction/style.ts
+++ b/packages/core/src/components/with-interaction/style.ts
@@ -38,6 +38,7 @@ export const getWrapperStyle =
   ({ disabled, variant, scale }: WithInteractionProps) =>
   (theme: Theme) => css`
     position: relative;
+    -webkit-tap-highlight-color: transparent;
 
     &:focus-visible {
       outline-style: solid;


### PR DESCRIPTION
## Summary

- `with-interaction` wrapper 스타일에 `-webkit-tap-highlight-color: transparent`를 추가해 모바일 브라우저 탭 시 나타나는 자체 하이라이트를 제거합니다.

## Jira

[WRP-2315](https://wantedlab.atlassian.net/browse/WRP-2315) — [Web] 모바일 자체 tap highlight 제거

- Status: 열림
- Type: 작업

## Test plan

- [ ] 모바일(iOS Safari / Android Chrome)에서 인터랙션 컴포넌트 탭 시 브라우저 기본 하이라이트가 표시되지 않는지 확인
- [ ] 기존 `:focus-visible` outline 및 인터랙션 오버레이 동작에 영향이 없는지 확인

[WRP-2315]: https://wantedlab.atlassian.net/browse/WRP-2315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 모바일 환경에서 요소를 탭할 때 표시되는 기본 하이라이트 효과를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->