### PR TITLE
docs: 모바일 웹 큰 텍스트 대응 text-scale meta 태그 추가

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -41,16 +41,7 @@ const RootLayout = async ({ children }: LayoutProps<'/'>) => {
   return (
     <html suppressHydrationWarning lang="ko">
       <head>
-        <meta
-          name="theme-color"
-          content="#ffffff"
-          media="(prefers-color-scheme: light)"
-        />
-        <meta
-          name="msapplication-TileColor"
-          content="#ffffff"
-          media="(prefers-color-scheme: light)"
-        />
+        <meta name="text-scale" content="scale" />
         <link rel="preconnect" href="https://static.wanted.co.kr" />
         <meta
           name="msapplication-TileImage"


### PR DESCRIPTION
## Summary

- 디자인시스템 문서 사이트에 `<meta name="text-scale" content="scale" />` 추가 — 문서 모웹에서 "더 큰 텍스트" 설정에 따라 문서 텍스트가 확대되도록 대응
- `viewport.themeColor` export와 중복되던 light 모드 `theme-color` meta 및 legacy `msapplication-TileColor` meta 제거

## Jira

[WRP-2328](https://wantedlab.atlassian.net/browse/WRP-2328) — [Web] 디자인시스템 문서 text-scale meta 태그 추가 (모바일 웹 큰 텍스트 대응)

- Status: 열림
- Type: 작업

디자인시스템 4.0.0 에픽(WRP-802) 관련 작업입니다.

## Test plan

- [ ] 모바일 웹뷰(원티드 앱)에서 OS 큰 텍스트 설정 시 문서 텍스트 스케일 적용 확인
- [ ] light/dark 모드에서 브라우저 theme-color 정상 적용 확인 (viewport export 기반)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-2328]: https://wantedlab.atlassian.net/browse/WRP-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서 및 접근성**
  * 브라우저의 텍스트 크기 조정을 지원하도록 관련 메타 정보를 업데이트했습니다.
  * 더 이상 사용되지 않는 테마 색상 메타 정보를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->