### PR TITLE
refactor(core,eslint-plugin): chip iconOnly prop 제거

### DIFF
--- a/docs/data/components/actions/chip/web.mdx
+++ b/docs/data/components/actions/chip/web.mdx
@@ -79,36 +79,6 @@ const Demo = () => {
 export default Demo;`}
 />
 
-## Icon only
-
-iconOnly prop 을 사용하면 아이콘만 단독으로 배치할 수 있습니다.<br/>
-다른 Solid, Outlined Chip과 나란히 함께 사용할 때 iconOnly를 사용합니다.
-
-<Demo code={`import { FlexBox, Chip } from '@montage-ui/core';
-import { IconBlank } from '@montage-ui/icon';
-
-const Demo = () => {
-  return (
-    <FlexBox gap="12px" justifyContent="center">
-      <Chip variant="solid" iconOnly>
-        <IconBlank />
-      </Chip>
-      <Chip variant="solid" iconOnly active>
-        <IconBlank />
-      </Chip>
-      <Chip variant="outlined" iconOnly>
-        <IconBlank />
-      </Chip>
-      <Chip variant="outlined" iconOnly active>
-        <IconBlank />
-      </Chip>
-    </FlexBox>
-  )
-}
-
-export default Demo;`}
-/>
-
 ## Sizes
 
 4가지 사이즈를 제공합니다.
@@ -150,36 +120,6 @@ const Demo = () => {
         </Chip>
         <Chip variant="outlined" size="large" leadingContent={<IconBlank />} trailingContent={<IconBlank />}>
           Large
-        </Chip>
-      </FlexBox>
-
-      <FlexBox gap="12px" alignItems="center">
-        <Chip variant="solid" size="xsmall" iconOnly>
-          <IconBlank />
-        </Chip>
-        <Chip variant="solid" size="small" iconOnly>
-          <IconBlank />
-        </Chip>
-        <Chip variant="solid" size="medium" iconOnly>
-          <IconBlank />
-        </Chip>
-        <Chip variant="solid" size="large" iconOnly>
-          <IconBlank />
-        </Chip>
-      </FlexBox>
-
-      <FlexBox gap="12px" alignItems="center">
-        <Chip variant="outlined" size="xsmall" iconOnly>
-          <IconBlank />
-        </Chip>
-        <Chip variant="outlined" size="small" iconOnly>
-          <IconBlank />
-        </Chip>
-        <Chip variant="outlined" size="medium" iconOnly>
-          <IconBlank />
-        </Chip>
-        <Chip variant="outlined" size="large" iconOnly>
-          <IconBlank />
         </Chip>
       </FlexBox>
     </FlexBox>

--- a/packages/core/src/components/chip/index.tsx
+++ b/packages/core/src/components/chip/index.tsx
@@ -19,7 +19,6 @@ const Chip = forwardRef(
       variant = 'solid',
       disabled = false,
       disableInteraction = false,
-      iconOnly,
       leadingContent,
       trailingContent,
       size = 'medium',
@@ -50,7 +49,7 @@ const Chip = forwardRef(
       >
         <Box
           as={as || 'button'}
-          aria-labelledby={iconOnly ? undefined : id}
+          aria-labelledby={id}
           role="button"
           type="button"
           ref={ref}
@@ -62,7 +61,6 @@ const Chip = forwardRef(
           {...props}
           sx={[
             chipStyle({
-              iconOnly,
               active,
               variant,
               size,
@@ -75,15 +73,9 @@ const Chip = forwardRef(
             props.sx,
           ]}
         >
-          {iconOnly ? (
-            children
-          ) : (
-            <>
-              {Boolean(leadingContent) && leadingContent}
-              <span id={id}>{children}</span>
-              {Boolean(trailingContent) && trailingContent}
-            </>
-          )}
+          {Boolean(leadingContent) && leadingContent}
+          <span id={id}>{children}</span>
+          {Boolean(trailingContent) && trailingContent}
         </Box>
       </WithInteraction>
     );

--- a/packages/core/src/components/chip/style.ts
+++ b/packages/core/src/components/chip/style.ts
@@ -7,7 +7,7 @@ import type { ChipProps } from './types';
 import type { Theme } from '@montage-ui/engine';
 
 export const chipStyle =
-  ({ xs, sm, md, lg, xl, size, iconOnly, variant }: ChipProps) =>
+  ({ xs, sm, md, lg, xl, size, variant }: ChipProps) =>
   (theme: Theme) => css`
     display: inline-flex;
     align-items: center;
@@ -32,20 +32,20 @@ export const chipStyle =
     }
 
     ${chipVariantStyle({ variant }, theme)}
-    ${chipSizeStyle({ size, iconOnly }, theme)}
+    ${chipSizeStyle({ size }, theme)}
 
   ${createResponsiveStyle(
       { xs, sm, md, lg, xl },
       theme,
     )(
       (params) => css`
-        ${chipSizeStyle({ size: params?.size, iconOnly }, theme)}
+        ${chipSizeStyle({ size: params?.size }, theme)}
         ${params?.sx}
       `,
     )}
   `;
 
-const chipSizeStyle = ({ size, iconOnly }: ChipProps = {}, theme: Theme) => {
+const chipSizeStyle = ({ size }: ChipProps = {}, theme: Theme) => {
   switch (size) {
     case 'xsmall':
       return css`
@@ -66,7 +66,7 @@ const chipSizeStyle = ({ size, iconOnly }: ChipProps = {}, theme: Theme) => {
       return css`
         border-radius: ${theme.radius[10]};
         min-height: ${theme.dimension[32]};
-        padding: ${iconOnly ? '9px' : theme.spacing[8]};
+        padding: ${theme.spacing[8]};
         gap: ${theme.spacing[2]};
 
         svg {
@@ -81,7 +81,7 @@ const chipSizeStyle = ({ size, iconOnly }: ChipProps = {}, theme: Theme) => {
       return css`
         border-radius: ${theme.radius[10]};
         min-height: ${theme.dimension[36]};
-        padding: ${iconOnly ? '11px' : `9px ${theme.spacing[10]}`};
+        padding: 9px ${theme.spacing[10]};
         gap: ${theme.spacing[2]};
 
         svg {
@@ -97,9 +97,7 @@ const chipSizeStyle = ({ size, iconOnly }: ChipProps = {}, theme: Theme) => {
       return css`
         border-radius: ${theme.radius[12]};
         min-height: ${theme.dimension[40]};
-        padding: ${iconOnly
-          ? theme.spacing[12]
-          : `${theme.spacing[10]} ${theme.spacing[12]}`};
+        padding: ${theme.spacing[10]} ${theme.spacing[12]};
         gap: ${theme.spacing[2]};
 
         svg {

--- a/packages/core/src/components/chip/types.ts
+++ b/packages/core/src/components/chip/types.ts
@@ -14,8 +14,6 @@ export type ChipDefaultProps = WithSxProps<{
   leadingContent?: ReactNode;
   /** Content displayed in the trailing area. */
   trailingContent?: ReactNode;
-  /** Whether to show only the icon. If `iconOnly` is enabled, you must provide an icon component as the `children`. */
-  iconOnly?: boolean;
   /** The content of the chip. */
   children?: ReactNode;
 }>;

--- a/packages/eslint-plugin/src/rules/icon-button-uses-name/index.test.ts
+++ b/packages/eslint-plugin/src/rules/icon-button-uses-name/index.test.ts
@@ -44,27 +44,6 @@ run({
     },
     {
       code: `
-        import { Chip } from '@montage-ui/core';
-
-        <Chip iconOnly aria-label="close" />
-      `,
-    },
-    {
-      code: `
-        import { Chip } from '@montage-ui/core';
-
-        <Chip iconOnly={false} />
-      `,
-    },
-    {
-      code: `
-        import { Chip } from '@montage-ui/core';
-
-        <Chip />
-      `,
-    },
-    {
-      code: `
         import { TopNavigationButton } from '@montage-ui/core';
 
         <TopNavigationButton aria-label="close" />
@@ -125,14 +104,6 @@ run({
         import { TopNavigationButton } from '@montage-ui/core';
 
         <TopNavigationButton />
-      `,
-      errors: 1,
-    },
-    {
-      code: `
-        import { Chip } from '@montage-ui/core';
-
-        <Chip iconOnly />
       `,
       errors: 1,
     },

--- a/packages/eslint-plugin/src/rules/icon-button-uses-name/index.ts
+++ b/packages/eslint-plugin/src/rules/icon-button-uses-name/index.ts
@@ -18,7 +18,6 @@ const ICON_ONLY_BUTTON_COMPONENTS = [
   'Button',
   'ActionAreaButton',
   'FallbackViewActionAreaButton',
-  'Chip',
 ];
 
 const TARGET_COMPONENTS = [


### PR DESCRIPTION
## Summary

- `Chip`의 `iconOnly` prop 제거 — `types.ts`의 prop 정의, `index.tsx`의 `aria-labelledby`/렌더 분기, `style.ts`의 사이즈별 padding 분기를 삭제했습니다. non-iconOnly 렌더링 스타일 값은 그대로라 기존 화면 변화는 없습니다.
- docs `chip/web.mdx`의 "Icon only" 섹션과 Sizes 데모의 iconOnly 예제를 제거했습니다.
- `eslint-plugin`의 `icon-button-uses-name` 룰 대상 컴포넌트에서 `Chip`을 제거하고 관련 테스트 케이스를 정리했습니다.
- MIGRATION.md·마이그레이션 스킬·codemod는 chip iconOnly 언급이 없어 변경 사항이 없습니다 (문서상 iconOnly 언급은 전부 Button/SegmentedControl 소관).

## 배경

`iconOnly`는 chip 디자인 개편 PR(#609)에서 추가된 prop으로, 4.0.0 미배포 상태에서 제거합니다.

- Figma 4.0.0에서 Chip의 Icon Only variant가 제거되었습니다 (48 → 24 variants).
- leading/trailing을 slot으로 여는 방향과 iconOnly가 양립하지 않습니다 (iconOnly는 아이콘 규격 강제를 전제로 정사각 배치).
- 미배포 상태라 제품 사용처가 없어 breaking change가 아닙니다.

**커밋 히스토리 정리**: lerna 자동 changelog에 "추가 → 제거" 노이즈가 남지 않도록, #609의 커밋 메시지를 `feat(core,eslint-plugin): chip 디자인 개편 및 iconOnly prop 추가` → `feat(core,eslint-plugin): chip 디자인 개편`으로 리라이트(force-push)했고, 이 PR은 changelog에 잡히지 않는 `refactor` 타입을 사용합니다.

## Jira

[WRP-2279](https://wantedlab.atlassian.net/browse/WRP-2279) — [WDS] Chip iconOnly 제거

- Status: 열림
- Type: 하위 작업

## Test plan

- [x] `icon-button-uses-name` 룰 테스트 12개 통과
- [x] `@montage-ui/core` 빌드 성공 (타입 에러 없음)
- [ ] CI visual regression 통과 확인 — non-iconOnly 스타일은 미변경이라 스크린샷 diff가 없어야 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-2279]: https://wantedlab.atlassian.net/browse/WRP-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * Chip의 `iconOnly` 지원이 제거되었습니다.
  * Chip은 모든 크기에서 기본 패딩과 일반 콘텐츠 구성을 사용합니다.
  * 아이콘 전용 Chip 관련 문서와 예제가 삭제되었습니다.
  * Chip이 아이콘 전용 버튼 규칙의 검사 대상에서 제외되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->