### PR TITLE
docs: 코드 실행/공유 가능한 playground 페이지 추가

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -38,6 +38,7 @@
     "gray-matter": "^4.0.3",
     "hast-util-to-html": "^9.0.5",
     "lottie-web": "^5.13.0",
+    "lz-string": "^1.5.0",
     "mdast-util-mdx-jsx": "^3.2.0",
     "next": "^16.2.6",
     "next-mdx-remote": "^6.0.0",

--- a/docs/src/app/playground/page.tsx
+++ b/docs/src/app/playground/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react';
+
+import Playground from '@/features/playground/components/playground';
+import PlaygroundFallback from '@/features/playground/components/fallback';
+import { createMetadata } from '@/helpers/metadata';
+
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-static';
+
+export const metadata: Metadata = createMetadata({
+  title: 'Playground',
+});
+
+const PlaygroundPage = () => {
+  return (
+    <Suspense fallback={<PlaygroundFallback />}>
+      <Playground />
+    </Suspense>
+  );
+};
+
+export default PlaygroundPage;

--- a/docs/src/features/docs/components/mdx/demo/editor/index.tsx
+++ b/docs/src/features/docs/components/mdx/demo/editor/index.tsx
@@ -60,6 +60,7 @@ import { collapsedStyle, editorStyle, focusGuardStyle } from './style';
 import SearchCode from './search-code';
 import { getDefaultSearchQuery } from './helpers';
 
+import type { SxProp } from '@montage-ui/core';
 import type { SearchQuery } from '@codemirror/search';
 import type { ViewUpdate } from '@codemirror/view';
 import type { Dispatch, SetStateAction } from 'react';
@@ -71,6 +72,7 @@ type Props = {
   onCollapseChange: Dispatch<SetStateAction<boolean>>;
   isResetting: boolean;
   handleResetComplete: () => void;
+  sx?: SxProp;
 };
 
 const Editor = ({
@@ -80,6 +82,7 @@ const Editor = ({
   onCollapseChange,
   isResetting,
   handleResetComplete,
+  sx,
 }: Props) => {
   const [node, setNode] = useState<HTMLDivElement | null>(null);
   const focusGuardRef = useRef<HTMLDivElement>(null);
@@ -284,7 +287,7 @@ const Editor = ({
           />
         )}
 
-        <Box ref={setNode} sx={editorStyle} />
+        <Box ref={setNode} sx={[editorStyle, sx]} />
       </ScrollArea>
 
       {collapsed && (

--- a/docs/src/features/layout/components/gnb/constants.ts
+++ b/docs/src/features/layout/components/gnb/constants.ts
@@ -1,3 +1,5 @@
+export const GNB_HIDDEN_SEGMENTS = ['playground'];
+
 export const GNB_NAVIGATION_LINKS = [
   {
     label: 'Getting started',

--- a/docs/src/features/layout/components/gnb/index.tsx
+++ b/docs/src/features/layout/components/gnb/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@montage-ui/core';
 import { IconMenu, IconMoon, IconSearch, IconSun } from '@montage-ui/icon';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSelectedLayoutSegments } from 'next/navigation';
 import { useCallback } from 'react';
 
 import Logo from '@/assets/logo';
@@ -26,12 +26,14 @@ import {
 } from './style';
 import { useSearch } from './hooks';
 import { DocSearchModal } from './search-modal';
-import { GNB_NAVIGATION_LINKS } from './constants';
+import { GNB_HIDDEN_SEGMENTS, GNB_NAVIGATION_LINKS } from './constants';
 
 const Gnb = () => {
   const { setTheme, theme: currentTheme } = useThemeControl();
   const pathname = usePathname();
   const [, ...currentSlug] = pathname.split('/').filter(Boolean);
+
+  const segments = useSelectedLayoutSegments();
 
   const lnbContext = useLnbContext();
 
@@ -46,6 +48,10 @@ const Gnb = () => {
   const handleThemeChange = useCallback(() => {
     setTheme(currentTheme === 'light' ? 'dark' : 'light');
   }, [currentTheme, setTheme]);
+
+  if (GNB_HIDDEN_SEGMENTS.includes(segments.at(0) ?? '')) {
+    return null;
+  }
 
   return (
     <>

--- a/docs/src/features/playground/components/fallback/index.tsx
+++ b/docs/src/features/playground/components/fallback/index.tsx
@@ -1,0 +1,15 @@
+import { FlexBox, Loading } from '@montage-ui/core';
+
+const PlaygroundFallback = () => {
+  return (
+    <FlexBox
+      alignItems="center"
+      justifyContent="center"
+      sx={{ width: '100%', height: '100dvh' }}
+    >
+      <Loading variant="circular" aria-label="불러오는 중" />
+    </FlexBox>
+  );
+};
+
+export default PlaygroundFallback;

--- a/docs/src/features/playground/components/playground/constants.ts
+++ b/docs/src/features/playground/components/playground/constants.ts
@@ -1,0 +1,20 @@
+export const PLAYGROUND_QUERY_KEY = {
+  code: 'code',
+  transparent: 'transparent',
+  showCode: 'showCode',
+} as const;
+
+export const PLAYGROUND_DEFAULT_CODE = `import { FlexBox, Typography } from '@montage-ui/core';
+
+const Demo = () => {
+  return (
+    <FlexBox flexDirection="column" gap="16px">
+      <Typography variant="title3" weight="bold">
+        Playground
+      </Typography>
+    </FlexBox>
+  );
+};
+
+export default Demo;
+`;

--- a/docs/src/features/playground/components/playground/helpers.ts
+++ b/docs/src/features/playground/components/playground/helpers.ts
@@ -1,0 +1,59 @@
+import {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent,
+} from 'lz-string';
+
+import { PLAYGROUND_DEFAULT_CODE, PLAYGROUND_QUERY_KEY } from './constants';
+
+import type { PlaygroundShareState } from './types';
+
+export const compressCode = (code: string) =>
+  compressToEncodedURIComponent(code);
+
+export const decompressCode = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const decompressed = decompressFromEncodedURIComponent(
+      value.replace(/ /g, '+'),
+    );
+
+    return decompressed || null;
+  } catch {
+    return null;
+  }
+};
+
+export const parseShareState = (
+  searchParams: URLSearchParams,
+): PlaygroundShareState => ({
+  code:
+    decompressCode(searchParams.get(PLAYGROUND_QUERY_KEY.code)) ??
+    PLAYGROUND_DEFAULT_CODE,
+  isTransparent: searchParams.get(PLAYGROUND_QUERY_KEY.transparent) === '1',
+});
+
+export const serializeShareState = ({
+  code,
+  isTransparent,
+}: PlaygroundShareState): string => {
+  const searchParams = new URLSearchParams();
+
+  searchParams.set(PLAYGROUND_QUERY_KEY.code, compressCode(code));
+
+  if (isTransparent) {
+    searchParams.set(PLAYGROUND_QUERY_KEY.transparent, '1');
+  }
+
+  return searchParams.toString();
+};
+
+export const createShareUrl = (state: PlaygroundShareState): string => {
+  const { origin, pathname } = window.location;
+
+  return `${origin}${pathname}?${serializeShareState(state)}`;
+};
+
+export const noop = () => {};

--- a/docs/src/features/playground/components/playground/hooks.ts
+++ b/docs/src/features/playground/components/playground/hooks.ts
@@ -1,0 +1,72 @@
+import { useCallback, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import copy from 'copy-to-clipboard';
+import { useToast } from '@montage-ui/core';
+
+import { createShareUrl, parseShareState } from './helpers';
+
+import type { PlaygroundShareState } from './types';
+
+export const useInitialShareState = (): PlaygroundShareState => {
+  const searchParams = useSearchParams();
+
+  const [initialState] = useState(() => parseShareState(searchParams));
+
+  return initialState;
+};
+
+type UsePlaygroundControlsParams = {
+  initialState: PlaygroundShareState;
+  value: string;
+  handleValueChange: (value: string) => void;
+};
+
+export const usePlaygroundControls = ({
+  initialState,
+  value,
+}: UsePlaygroundControlsParams) => {
+  const toast = useToast();
+
+  const [isTransparent, setIsTransparent] = useState(
+    initialState.isTransparent,
+  );
+
+  const handleShare = useCallback(() => {
+    const shareUrl = createShareUrl({
+      code: value,
+      isTransparent,
+    });
+
+    window.history.replaceState(null, '', shareUrl);
+
+    if (copy(shareUrl)) {
+      toast({
+        variant: 'positive',
+        content: '공유 링크를 클립보드에 복사 했습니다.',
+      });
+    }
+  }, [value, isTransparent, toast]);
+
+  const handleCopy = useCallback(() => {
+    const selection = window.getSelection()?.toString();
+
+    if (selection) {
+      copy(selection);
+      return;
+    }
+
+    if (copy(value)) {
+      toast({
+        variant: 'positive',
+        content: '코드를 클립보드에 복사 했습니다.',
+      });
+    }
+  }, [value, toast]);
+
+  return {
+    isTransparent,
+    setIsTransparent,
+    handleShare,
+    handleCopy,
+  };
+};

--- a/docs/src/features/playground/components/playground/index.tsx
+++ b/docs/src/features/playground/components/playground/index.tsx
@@ -1,0 +1,124 @@
+'use client';
+import {
+  Box,
+  FlexBox,
+  Loading,
+  ScrollArea,
+  Typography,
+} from '@montage-ui/core';
+import { IconCircleExclamationFill } from '@montage-ui/icon';
+
+import DelayMount from '@/components/delay-mount';
+import Editor from '@/features/docs/components/mdx/demo/editor';
+import { useReactDemoRunner } from '@/features/docs/components/mdx/demo/hooks';
+
+import Toolbar from './toolbar';
+import { useInitialShareState, usePlaygroundControls } from './hooks';
+import {
+  editorFallbackStyle,
+  editorPanelStyle,
+  editorStyle,
+  errorStyle,
+  layoutStyle,
+  panelsStyle,
+  previewPanelStyle,
+  previewViewportStyle,
+} from './style';
+import { noop } from './helpers';
+
+const Playground = () => {
+  const initialState = useInitialShareState();
+
+  const { value, handleValueChange, element, error } = useReactDemoRunner({
+    code: initialState.code,
+  });
+
+  const { isTransparent, setIsTransparent, handleShare, handleCopy } =
+    usePlaygroundControls({ initialState, value, handleValueChange });
+
+  const errorMessage = error?.toString();
+
+  return (
+    <FlexBox
+      as="main"
+      flexDirection="column"
+      data-role="playground"
+      sx={layoutStyle}
+    >
+      <Toolbar
+        isTransparent={isTransparent}
+        onIsTransparentChange={setIsTransparent}
+        onShare={handleShare}
+        onCopy={handleCopy}
+      />
+
+      <FlexBox flexDirection="column" sx={panelsStyle}>
+        <FlexBox
+          flexDirection="column"
+          data-role="playground-editor"
+          sx={editorPanelStyle}
+        >
+          <DelayMount
+            delay={300}
+            fallback={
+              <FlexBox
+                alignItems="center"
+                justifyContent="center"
+                sx={editorFallbackStyle}
+              >
+                <Loading variant="circular" aria-hidden />
+
+                <Box as="pre" sx={{ height: 0, width: 0, overflow: 'hidden' }}>
+                  <code>{value}</code>
+                </Box>
+              </FlexBox>
+            }
+          >
+            <Box sx={editorStyle}>
+              <Editor
+                value={value}
+                onValueChange={handleValueChange}
+                collapsed={false}
+                onCollapseChange={noop}
+                isResetting={false}
+                handleResetComplete={noop}
+                sx={{ height: '100%' }}
+              />
+            </Box>
+          </DelayMount>
+        </FlexBox>
+
+        <FlexBox
+          flexDirection="column"
+          data-role="playground-preview"
+          sx={previewPanelStyle({ isTransparent })}
+        >
+          <ScrollArea
+            sx={{ flex: '1 1 auto', minHeight: 0 }}
+            viewportProps={{ sx: previewViewportStyle }}
+          >
+            <FlexBox flexDirection="column" sx={{ width: '100%' }}>
+              {element}
+            </FlexBox>
+          </ScrollArea>
+
+          {errorMessage && (
+            <FlexBox gap="6px" role="alert" sx={errorStyle}>
+              <IconCircleExclamationFill aria-hidden />
+
+              <Typography
+                as="pre"
+                variant="caption1"
+                color="semantic.foreground.negative.primary"
+              >
+                {errorMessage}
+              </Typography>
+            </FlexBox>
+          )}
+        </FlexBox>
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+export default Playground;

--- a/docs/src/features/playground/components/playground/style.ts
+++ b/docs/src/features/playground/components/playground/style.ts
@@ -1,0 +1,132 @@
+import { addOpacity, css, respondMore } from '@montage-ui/core';
+
+import type { Theme } from '@montage-ui/core';
+
+export const layoutStyle = css`
+  --playground-toolbar-height: 56px;
+  --playground-panels-height: calc(100dvh - var(--playground-toolbar-height));
+
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+`;
+
+export const panelsStyle = (theme: Theme) => css`
+  flex: 1 1 auto;
+  min-height: 0;
+
+  --playground-panel-height: calc(var(--playground-panels-height) / 2);
+
+  ${respondMore(theme.breakpoint.lg)} {
+    flex-direction: row;
+    --playground-panel-height: var(--playground-panels-height);
+  }
+`;
+
+export const editorPanelStyle = (theme: Theme) => css`
+  flex: 1 1 50%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  background-color: ${theme.semantic.surface.elevated.primary};
+`;
+
+export const editorStyle = css`
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+
+  [data-radix-scroll-area-viewport] {
+    height: var(--playground-panel-height);
+  }
+`;
+
+export const editorFallbackStyle = (theme: Theme) => css`
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  background-color: ${theme.semantic.surface.elevated.primary};
+`;
+
+type PreviewPanelStyleParams = {
+  isTransparent: boolean;
+};
+
+export const previewPanelStyle =
+  ({ isTransparent }: PreviewPanelStyleParams) =>
+  (theme: Theme) => css`
+    flex: 1 1 50%;
+    min-height: 0;
+    min-width: 0;
+    background-color: ${theme.semantic.background.neutral.primary};
+    border-left: 1px solid ${theme.semantic.line.neutral.primary};
+
+    ${isTransparent &&
+    css`
+      background-image:
+        linear-gradient(
+          45deg,
+          ${theme.semantic.background.neutral.secondary} 25%,
+          transparent 25%
+        ),
+        linear-gradient(
+          135deg,
+          ${theme.semantic.background.neutral.secondary} 25%,
+          transparent 25%
+        ),
+        linear-gradient(
+          45deg,
+          transparent 75%,
+          ${theme.semantic.background.neutral.secondary} 75%
+        ),
+        linear-gradient(
+          135deg,
+          transparent 75%,
+          ${theme.semantic.background.neutral.secondary} 75%
+        );
+      background-position:
+        0px 0px,
+        10px 0px,
+        10px -10px,
+        0px 10px;
+      background-size: 20px 20px;
+    `}
+  `;
+
+export const previewViewportStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 40px 16px;
+  box-sizing: border-box;
+
+  [data-radix-scroll-area-content] {
+    display: flex;
+    width: 100%;
+  }
+`;
+
+export const errorStyle = (theme: Theme) => css`
+  flex: 0 0 auto;
+  max-height: 30%;
+  overflow: auto;
+  padding: 12px 16px;
+  background-color: ${addOpacity(
+    theme.semantic.foreground.negative.primary,
+    theme.opacity[8],
+  )};
+  box-shadow: inset 0 1px 0 0
+    ${addOpacity(theme.semantic.foreground.negative.primary, theme.opacity[28])};
+
+  svg {
+    flex: 0 0 auto;
+    color: ${theme.semantic.foreground.negative.primary};
+  }
+
+  pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+`;

--- a/docs/src/features/playground/components/playground/toolbar/index.tsx
+++ b/docs/src/features/playground/components/playground/toolbar/index.tsx
@@ -1,0 +1,124 @@
+import {
+  Box,
+  Button,
+  FlexBox,
+  IconButton,
+  NoSsr,
+  Tooltip,
+  TooltipContent,
+  TooltipGroup,
+  TooltipTrigger,
+  Typography,
+  useThemeControl,
+} from '@montage-ui/core';
+import {
+  IconCopy,
+  IconImage,
+  IconLink,
+  IconMoon,
+  IconSun,
+} from '@montage-ui/icon';
+import Link from 'next/link';
+import { useCallback } from 'react';
+
+import Logo from '@/assets/logo';
+
+import { actionsStyle, homeLinkStyle, titleStyle, toolbarStyle } from './style';
+
+import type { Dispatch, SetStateAction } from 'react';
+
+type Props = {
+  isTransparent: boolean;
+  onIsTransparentChange: Dispatch<SetStateAction<boolean>>;
+  onShare: () => void;
+  onCopy: () => void;
+};
+
+const Toolbar = ({
+  isTransparent,
+  onIsTransparentChange,
+  onShare,
+  onCopy,
+}: Props) => {
+  const { theme: currentTheme, setTheme } = useThemeControl();
+
+  const handleThemeChange = useCallback(() => {
+    setTheme(currentTheme === 'light' ? 'dark' : 'light');
+  }, [currentTheme, setTheme]);
+
+  return (
+    <FlexBox
+      as="header"
+      alignItems="center"
+      justifyContent="space-between"
+      gap="16px"
+      data-role="playground-toolbar"
+      sx={toolbarStyle}
+    >
+      <FlexBox alignItems="center" gap="12px">
+        <Box as={Link} href="/" aria-label="Go to home" sx={homeLinkStyle}>
+          <Logo />
+        </Box>
+
+        <Typography
+          variant="body2"
+          weight="bold"
+          color="semantic.foreground.neutral.tertiary"
+          sx={titleStyle}
+        >
+          Playground
+        </Typography>
+      </FlexBox>
+
+      <FlexBox alignItems="center" gap="8px" sx={actionsStyle}>
+        <TooltipGroup>
+          <Tooltip>
+            <TooltipTrigger>
+              <IconButton
+                size={32}
+                aria-pressed={isTransparent}
+                aria-label={
+                  isTransparent ? '배경 투명 해제' : '배경 투명하게 보기'
+                }
+                onClick={() => onIsTransparentChange((prev) => !prev)}
+              >
+                <IconImage />
+              </IconButton>
+            </TooltipTrigger>
+            <TooltipContent size="small">배경 전환</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <IconButton
+                size={32}
+                aria-label="테마 전환"
+                onClick={handleThemeChange}
+              >
+                <NoSsr fallback={<IconSun />}>
+                  {currentTheme === 'light' ? <IconSun /> : <IconMoon />}
+                </NoSsr>
+              </IconButton>
+            </TooltipTrigger>
+            <TooltipContent size="small">테마 전환</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <IconButton size={32} aria-label="코드 복사" onClick={onCopy}>
+                <IconCopy />
+              </IconButton>
+            </TooltipTrigger>
+            <TooltipContent size="small">코드 복사</TooltipContent>
+          </Tooltip>
+        </TooltipGroup>
+
+        <Button size="small" leadingContent={<IconLink />} onClick={onShare}>
+          공유하기
+        </Button>
+      </FlexBox>
+    </FlexBox>
+  );
+};
+
+export default Toolbar;

--- a/docs/src/features/playground/components/playground/toolbar/style.ts
+++ b/docs/src/features/playground/components/playground/toolbar/style.ts
@@ -1,0 +1,35 @@
+import { css, respondMore } from '@montage-ui/core';
+
+import type { Theme } from '@montage-ui/core';
+
+export const toolbarStyle = (theme: Theme) => css`
+  flex: 0 0 auto;
+  height: var(--playground-toolbar-height);
+  padding: 0 12px;
+  box-sizing: border-box;
+  background-color: ${theme.semantic.background.neutral.primary};
+  box-shadow: inset 0 -1px 0 0 ${theme.semantic.line.neutral.primary};
+
+  ${respondMore(theme.breakpoint.sm)} {
+    padding: 0 20px;
+  }
+`;
+
+export const homeLinkStyle = (theme: Theme) => css`
+  flex: 0 0 auto;
+  color: ${theme.semantic.foreground.neutral.primary};
+  border-radius: 8px;
+  outline-offset: 4px;
+`;
+
+export const titleStyle = (theme: Theme) => css`
+  display: none;
+
+  ${respondMore(theme.breakpoint.md)} {
+    display: block;
+  }
+`;
+
+export const actionsStyle = css`
+  flex: 0 0 auto;
+`;

--- a/docs/src/features/playground/components/playground/types.ts
+++ b/docs/src/features/playground/components/playground/types.ts
@@ -1,0 +1,7 @@
+/** 공유 링크로 직렬화되는 플레이그라운드 상태. */
+export type PlaygroundShareState = {
+  /** 에디터에 입력된 코드. */
+  code: string;
+  /** 미리보기 배경을 투명(체커보드)으로 표시할지 여부. */
+  isTransparent: boolean;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       lottie-web:
         specifier: ^5.13.0
         version: 5.13.0
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       mdast-util-mdx-jsx:
         specifier: ^3.2.0
         version: 3.2.0


### PR DESCRIPTION
## Summary

문서 사이트에 `/playground` 를 추가했습니다. 기존에는 MDX 데모 블록 안에서만 코드를 수정해볼 수 있었는데, 이제 문서 맥락과 분리된 전체 화면에서 컴포넌트 코드를 자유롭게 작성·실행하고 그 상태를 링크로 공유할 수 있습니다.

- `docs/src/app/playground/page.tsx` — `force-static` + `Suspense` 로 playground 라우트 추가 (`useSearchParams` 때문에 fallback 필요)
- `features/playground/components/playground` — 좌: 에디터 / 우: 프리뷰 2분할 레이아웃. 실행은 기존 `useReactDemoRunner` 를 재사용하고, 런타임 에러는 `role="alert"` 영역에 노출
- 공유: 코드를 `lz-string` 으로 압축해 쿼리스트링(`?code=...&transparent=1`)에 담고 `history.replaceState` 로 URL 갱신 + 클립보드 복사
- 툴바: 배경 투명 전환 / 테마 전환 / 코드 복사 / 공유하기
- GNB: `GNB_HIDDEN_SEGMENTS` 를 두고 playground 세그먼트에서는 전용 툴바만 쓰도록 GNB 를 렌더하지 않음
- 데모 `Editor` 에 `sx` prop 을 추가해 playground 에서 높이를 100% 로 채울 수 있게 함 (기존 동작 영향 없음)
- 의존성: `docs` 에 `lz-string@^1.5.0` 추가

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Other

> 변경 범위가 `docs/**` (+ `docs` 의존성으로 인한 `pnpm-lock.yaml`) 뿐이라 배포되는 패키지에는 영향이 없어 릴리즈 마일스톤은 붙이지 않았습니다.
>
> _Jira 티켓 없음 — 문서 사이트 전용 변경._

## Test plan

- [ ] `pnpm -F docs dev` 후 `/playground` 진입 → 기본 코드가 프리뷰에 정상 렌더되는지
- [ ] 코드 수정 → 프리뷰 갱신 / 잘못된 코드 입력 → 에러 메시지 노출
- [ ] `공유하기` → URL 이 갱신되고 클립보드에 복사, 새 탭에서 그 URL 로 열었을 때 코드와 배경 투명 상태가 복원되는지
- [ ] 배경 투명 전환 / 테마 전환 (light ↔ dark) 동작
- [ ] `/playground` 에서 GNB 가 안 보이고, 다른 문서 페이지에서는 정상 노출되는지
- [ ] 기존 문서 데모 블록(`Editor`) 이 그대로 동작하는지 (`sx` prop 추가 회귀 확인)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 코드 편집과 실시간 미리보기를 제공하는 Playground 페이지가 추가되었습니다.
  - 코드 복사 및 공유 링크 생성 기능을 지원합니다.
  - 테마 전환과 미리보기 배경 투명도 설정을 사용할 수 있습니다.
  - 공유 링크를 통해 코드와 투명도 설정을 복원할 수 있습니다.
  - 편집기 로딩 화면과 실행 오류 안내가 제공됩니다.
- **UI 개선**
  - Playground에서는 전역 내비게이션이 표시되지 않도록 변경되었습니다.
  - 반응형 패널 구성과 접근성 라벨·툴팁이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->