### PR TITLE
refactor(core): 실효 없는 will-change 선언 제거

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1308,7 +1308,7 @@ Button의 `color="secondary"` 가 제거되었습니다. 기존 secondary는 ass
 npx @montage-ui/codemod@latest button-secondary-migration
 ```
 
-## ListCell
+### ListCell
 
 ListCell 컴포넌트의 active 옵션이 selected로 변경됩니다.
 

--- a/packages/core/src/components/accordion/style.ts
+++ b/packages/core/src/components/accordion/style.ts
@@ -156,7 +156,6 @@ export const accordionDividerStyle = ({
 }) => css`
   margin: 0 auto;
   width: calc(100% - (var(--list-cell-horizontal-padding, 0px) * 2));
-  will-change: opacity;
 
   ${!disableAnimation &&
   css`

--- a/packages/core/src/components/button/style.ts
+++ b/packages/core/src/components/button/style.ts
@@ -220,7 +220,6 @@ const buttonColorStyle = (
         background-color: ${theme.semantic.surface.neutral.secondary};
         box-shadow: none;
         backdrop-filter: blur(32px);
-        will-change: backdrop-filter;
 
         [data-role='button-loading'] {
           color: inherit;

--- a/packages/core/src/components/card/style.ts
+++ b/packages/core/src/components/card/style.ts
@@ -175,7 +175,6 @@ export const cardThumbnailStyle =
       overflow: hidden;
 
       img {
-        will-change: transform;
         transition: transform 0.2s ease;
       }
     }

--- a/packages/core/src/components/checkbox/style.ts
+++ b/packages/core/src/components/checkbox/style.ts
@@ -97,7 +97,6 @@ export const checkboxStyle =
         transform 0.2s ease;
       pointer-events: none;
       transform: scale(0.75);
-      will-change: transform;
     }
 
     ${checkboxSizeStyle({ size, bold, tight })}

--- a/packages/core/src/components/loading/style.ts
+++ b/packages/core/src/components/loading/style.ts
@@ -122,7 +122,6 @@ export const loadingWantedAnimatedSvgStyle = (theme: Theme) => css`
   }
 
   g path {
-    will-change: transform;
     animation: animation-circular-bounce calc(var(--time) * 3s)
       cubic-bezier(0.8, 0, 0.2, 1) infinite;
     transform: scale(0);


### PR DESCRIPTION
## Summary

성능 이득이 없는 위치에 선언돼 있던 `will-change`를 제거합니다.

`will-change`는 브라우저에 레이어를 미리 승격하라고 지시하는 속성이라, 상시 선언하면 실제 애니메이션이 일어나지 않는 동안에도 메모리와 컴포지팅 비용을 계속 점유합니다. 짧은 transition이나 이미 가속되는 속성에는 실익이 없습니다.

부수적으로 `will-change`는 새로운 **stacking context를 생성**하므로 선언된 요소 안팎의 `z-index` 쌓임 순서가 의도와 다르게 동작하는 문제가 있었고, 제거로 함께 해소됩니다.

### 제거 대상

| 파일 | 선언 | 위치 |
| --- | --- | --- |
| `accordion/style.ts` | `will-change: opacity` | divider |
| `button/style.ts` | `will-change: backdrop-filter` | 반투명 배경 variant |
| `card/style.ts` | `will-change: transform` | thumbnail 이미지 hover |
| `checkbox/style.ts` | `will-change: transform` | 체크 아이콘 |
| `loading/style.ts` | `will-change: transform` | wanted 애니메이션 SVG path |

그 외 `MIGRATION.md`의 ListCell 항목 heading 레벨(`##` → `###`)을 형제 항목에 맞춰 정정했습니다.

## Jira

[WRP-2424](https://wantedlab.atlassian.net/browse/WRP-2424) — core 과도하게 선언된 will-change 제거

- Status: 열림
- Type: 작업
- Relates to: [WRP-802](https://wantedlab.atlassian.net/browse/WRP-802) — [디자인시스템] 4.0.0 Major 업데이트

## Test plan

- [ ] Card thumbnail hover 확대 애니메이션이 이전과 동일하게 부드러운지
- [ ] Checkbox 체크 아이콘 scale transition 회귀 없는지
- [ ] Loading(wanted) 애니메이션 프레임 드랍 없는지
- [ ] Accordion 펼침/접힘 시 divider opacity transition 회귀 없는지
- [ ] Button 반투명 variant의 backdrop-filter 렌더링 정상인지
- [ ] stacking context 제거로 인한 쌓임 순서 변화 확인 (의도한 개선 방향이지만, 기존에 이 stacking context에 의존해 가려져 있던 요소가 없는지)
- [ ] 시각 회귀 테스트 (CI)

별도 마이그레이션 가이드는 추가하지 않았습니다. 공개 API 변경이 없고 소비자가 손댈 것이 없는 내부 스타일 정리입니다.

[WRP-2424]: https://wantedlab.atlassian.net/browse/WRP-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WRP-802]: https://wantedlab.atlassian.net/browse/WRP-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 마이그레이션 문서에서 `ListCell` 제목의 계층 구조를 올바르게 수정했습니다.

- **스타일**
  - 아코디언, 버튼, 카드 썸네일, 체크박스, 로딩 컴포넌트의 불필요한 렌더링 최적화 설정을 정리했습니다.
  - 기존 애니메이션, 전환 효과, 변환 및 배경 흐림 동작은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->