### PR TITLE
fix(core): 텍스트 슬롯 한글 줄바꿈 규칙 누락 보완

### DIFF
--- a/packages/core/src/components/accordion/index.tsx
+++ b/packages/core/src/components/accordion/index.tsx
@@ -366,6 +366,13 @@ const AccordionDescription = forwardRef<
       weight="regular"
       color="semantic.foreground.neutral.secondary"
       {...props}
+      sx={[
+        {
+          wordBreak: 'keep-all',
+          overflowWrap: 'anywhere',
+        },
+        props.sx,
+      ]}
     />
   );
 });

--- a/packages/core/src/components/alert/index.tsx
+++ b/packages/core/src/components/alert/index.tsx
@@ -292,6 +292,13 @@ const AlertHeading = forwardRef<
       as="h2"
       id={headingId}
       {...props}
+      sx={[
+        {
+          wordBreak: 'keep-all',
+          overflowWrap: 'anywhere',
+        },
+        props.sx,
+      ]}
     >
       {children}
     </Typography>

--- a/packages/core/src/components/card/style.ts
+++ b/packages/core/src/components/card/style.ts
@@ -245,6 +245,8 @@ export const cardThumbnailContentToggleIconStyle = (theme: Theme) => css`
 
 export const cardTitleStyle = (props: CardTitleProps) => (theme: Theme) => css`
   ${ellipsisTypographyStyle(2)}
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 
   &[data-component='card-title'] {
     ${cardTypographyStyle(props, 'bold')(theme)}
@@ -254,6 +256,8 @@ export const cardTitleStyle = (props: CardTitleProps) => (theme: Theme) => css`
 export const cardCaptionStyle =
   (props: TypographyProps) => (theme: Theme) => css`
     ${ellipsisTypographyStyle()}
+    word-break: keep-all;
+    overflow-wrap: anywhere;
 
     &[data-component='card-caption'] {
       ${cardTypographyStyle(props, 'medium')(theme)}

--- a/packages/core/src/components/fallback-view/style.ts
+++ b/packages/core/src/components/fallback-view/style.ts
@@ -18,10 +18,14 @@ export const fallbackViewStyle =
     [data-role='fallback-view-text-title'] {
       text-align: center;
       color: ${theme.semantic.foreground.neutral.primary};
+      word-break: keep-all;
+      overflow-wrap: anywhere;
     }
     [data-role='fallback-view-text-description'] {
       text-align: center;
       color: ${theme.semantic.foreground.neutral.secondary};
+      word-break: keep-all;
+      overflow-wrap: anywhere;
     }
 
     ${createResponsiveStyle(

--- a/packages/core/src/components/form-control/style.ts
+++ b/packages/core/src/components/form-control/style.ts
@@ -237,6 +237,8 @@ export const formLabelStyle =
 
       [data-role='label-content-text'] {
         ${ellipsisTypographyStyle(1)}
+        word-break: keep-all;
+        overflow-wrap: anywhere;
       }
 
       [data-role='label-required-mark'] {
@@ -318,6 +320,8 @@ export const formMessageStyle = (theme: Theme) => css`
     min-width: 0px;
     display: flex;
     width: min-content;
+    word-break: keep-all;
+    overflow-wrap: anywhere;
   }
 `;
 

--- a/packages/core/src/components/list/style.ts
+++ b/packages/core/src/components/list/style.ts
@@ -376,6 +376,9 @@ const listCellExtraContentVariantStyle = (
   switch (variant) {
     case 'text':
       return css`
+        word-break: keep-all;
+        overflow-wrap: anywhere;
+
         &[data-parent-disabled='true'] {
           color: ${theme.semantic.foreground.disable.primary};
         }

--- a/packages/core/src/components/popover/index.tsx
+++ b/packages/core/src/components/popover/index.tsx
@@ -223,6 +223,8 @@ const PopoverContent = forwardRef(
                               data-role="popover-content-heading"
                               sx={{
                                 width: '100%',
+                                wordBreak: 'keep-all',
+                                overflowWrap: 'anywhere',
                               }}
                             >
                               {heading}
@@ -256,7 +258,12 @@ const PopoverContent = forwardRef(
                             weight="medium"
                             color="semantic.foreground.neutral.secondary"
                             data-role="popover-content-description"
-                            sx={{ padding: '2px 0px', width: '100%' }}
+                            sx={{
+                              padding: '2px 0px',
+                              width: '100%',
+                              wordBreak: 'keep-all',
+                              overflowWrap: 'anywhere',
+                            }}
                           >
                             {children}
                           </Typography>
@@ -269,7 +276,12 @@ const PopoverContent = forwardRef(
                             weight="medium"
                             color="semantic.foreground.neutral.secondary"
                             data-role="popover-content-description"
-                            sx={{ padding: '2px 0px', width: '100%' }}
+                            sx={{
+                              padding: '2px 0px',
+                              width: '100%',
+                              wordBreak: 'keep-all',
+                              overflowWrap: 'anywhere',
+                            }}
                           >
                             {children}
                           </Typography>

--- a/packages/core/src/components/progress-tracker/index.tsx
+++ b/packages/core/src/components/progress-tracker/index.tsx
@@ -335,7 +335,12 @@ const ProgressTrackerItemLabel = ({
   if (isCompleted) {
     return Boolean(completedLabel) ? (
       <Typography
-        sx={{ padding: '1px 0px', height: 'fit-content' }}
+        sx={{
+          padding: '1px 0px',
+          height: 'fit-content',
+          wordBreak: 'keep-all',
+          overflowWrap: 'anywhere',
+        }}
         data-role="progress-tracker-item-label"
         color={
           isActive
@@ -353,7 +358,12 @@ const ProgressTrackerItemLabel = ({
 
   return Boolean(label) ? (
     <Typography
-      sx={{ padding: '1px 0px', height: 'fit-content' }}
+      sx={{
+        padding: '1px 0px',
+        height: 'fit-content',
+        wordBreak: 'keep-all',
+        overflowWrap: 'anywhere',
+      }}
       data-role="progress-tracker-item-label"
       color={
         isActive

--- a/packages/core/src/components/section-header/style.ts
+++ b/packages/core/src/components/section-header/style.ts
@@ -20,6 +20,11 @@ export const sectionHeaderStyle =
       color: inherit;
     }
 
+    [data-role='section-header-content-heading'] {
+      word-break: keep-all;
+      overflow-wrap: anywhere;
+    }
+
     [data-role='section-header-trailing-content']
       [data-component='icon-button'][data-variant='normal'],
     [data-role='section-header-heading-content']

--- a/packages/core/src/components/section-message/index.tsx
+++ b/packages/core/src/components/section-message/index.tsx
@@ -105,6 +105,7 @@ const SectionMessage = forwardRef<
             data-role="section-message-content-title"
             id={titleId}
             as="h2"
+            sx={{ wordBreak: 'keep-all', overflowWrap: 'anywhere' }}
           >
             {children}
           </Typography>
@@ -117,6 +118,7 @@ const SectionMessage = forwardRef<
               id={descriptionId}
               color="semantic.foreground.neutral.secondary"
               as="p"
+              sx={{ wordBreak: 'keep-all', overflowWrap: 'anywhere' }}
             >
               {description}
             </Typography>

--- a/packages/core/src/components/segmented-control/style.ts
+++ b/packages/core/src/components/segmented-control/style.ts
@@ -99,6 +99,8 @@ export const segmentedControlItemStyle =
       font: inherit;
       display: block;
       ${ellipsisTypographyStyle(1)}
+      word-break: keep-all;
+      overflow-wrap: anywhere;
     }
 
     & > :not([data-role='segmented-control-item-text']) {

--- a/packages/core/src/components/select/style.ts
+++ b/packages/core/src/components/select/style.ts
@@ -220,6 +220,8 @@ export const selectIconStyle =
 export const selectTextStyle = css`
   user-select: none;
   flex: 1;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 `;
 
 export const selectRenderChipStyle =

--- a/packages/core/src/components/table/style.ts
+++ b/packages/core/src/components/table/style.ts
@@ -62,6 +62,8 @@ export const tableHeadCellStyle = css`
   display: table-cell;
   border: none;
   border-bottom: 1px solid var(--table-border-color);
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 `;
 
 export const tableCellStyle = css`
@@ -72,6 +74,8 @@ export const tableCellStyle = css`
   border: none;
   height: var(--table-cell-min-height, 44px);
   border-bottom: 1px solid var(--table-border-color);
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 `;
 
 export const tableRowStyle = (interaction?: boolean) => (theme: Theme) => css`


### PR DESCRIPTION
## Summary

한글은 브라우저 기본값으로 글자 단위 줄바꿈이 일어나 어절 중간에서 텍스트가 갈라집니다. 이를 막는 `word-break: keep-all`과, 그것만 넣었을 때 긴 URL·영문 문자열이 컨테이너를 넘치는 문제를 막는 `overflow-wrap: anywhere` 조합이 일부 컴포넌트에만 적용돼 있었습니다.

여러 줄로 흐르는 텍스트 슬롯 전체에 동일 규칙을 적용합니다. 값은 다수 선례(`list`, `snackbar`, `toast`, `tooltip`, `top-navigation`)에 맞춰 `anywhere`로 통일했습니다.

**컴포넌트 14개 · 텍스트 슬롯 22개 · 수정 파일 13개**

### 1) 같은 컴포넌트 안에서 규칙이 갈렸던 곳

| 컴포넌트 | 슬롯 |
| --- | --- |
| `alert` | 제목 (설명에는 이미 적용돼 있었음) |
| `list` | 부가 텍스트 (셀 제목·설명에는 이미 적용돼 있었음) |

### 2) 여러 줄로 흐르는 본문 텍스트

| 컴포넌트 | 슬롯 |
| --- | --- |
| `section-message` | 제목, 설명 |
| `popover` | 제목, 설명 |
| `fallback-view` | 제목, 설명 |
| `accordion` | 설명 |
| `form-control` | 안내·오류 메시지 3종 |
| `table` | 머리글 셀, 본문 셀 |
| `section-header` | 제목 |

### 3) 한 줄 말줄임 텍스트

| 컴포넌트 | 슬롯 |
| --- | --- |
| `card` | 제목, 캡션 (`list-card`는 동일 컴포넌트 재사용으로 함께 반영) |
| `form-control` | 라벨 텍스트 |
| `segmented-control` | 항목 텍스트 |
| `select` | 플레이스홀더, 선택값 |
| `progress-tracker` | 단계 라벨 |

3번 묶음은 현재 `nowrap`이라 즉시 보이는 변화가 없습니다. 향후 말줄임 해제나 여러 줄 전환 시 올바르게 동작하도록 미리 넣었고, `list`가 같은 방식으로 처리돼 있어 선례를 따랐습니다.

### 적용 제외

`white-space: nowrap`인 `button`, `chip`, `text-button`, `filter-button`, `tab`, 글자 수 카운터는 규칙이 무의미해 제외했습니다.

## Jira

[WRP-2423](https://wantedlab.atlassian.net/browse/WRP-2423) — core 컴포넌트 한글 줄바꿈 규칙(keep-all / overflow-wrap) 통합 적용

- Status: 열림
- Type: 작업
- Relates to: [WRP-802](https://wantedlab.atlassian.net/browse/WRP-802) — [디자인시스템] 4.0.0 Major 업데이트

## 남은 결정 사항

리뷰 시 함께 봐주시면 좋겠습니다. 이 PR에서는 손대지 않았습니다.

- **짧은 라벨류 적용 여부** — `menu`·`autocomplete` 그룹 제목, `stepper` 단계 라벨, `bottom-navigation` 라벨. 대부분 한두 단어라 줄이 바뀔 일은 드물지만 가능성은 있습니다.
- **`modal` 값 통일 여부** — `modal` 3곳과 `list`의 비말줄임 경로만 `overflow-wrap: break-word`입니다. `break-word`는 한 줄에 들어갈 여지가 있으면 끊지 않으므로 긴 URL이 컨테이너를 넘칠 수 있습니다.

## Test plan

- [ ] 긴 한글 문구를 넣었을 때 어절 중간에서 끊기지 않는지 (`alert` 제목, `section-message`, `popover`, `fallback-view`, `table`, `section-header`)
- [ ] 띄어쓰기 없는 긴 문자열(URL·이메일)이 컨테이너를 넘치지 않는지
- [ ] 좁은 모바일 폭 및 큰 텍스트 설정에서 레이아웃 밀림 없는지
- [ ] `card` 제목 2줄 클램프가 유지되는지
- [ ] 한 줄 말줄임 컴포넌트(`select`, `segmented-control`, `progress-tracker`, `form-control` 라벨)의 `…` 처리가 이전과 동일한지
- [ ] `packages/core` `tsc --noEmit` 통과 (확인 완료)
- [ ] 시각 회귀 테스트 (CI)

별도 마이그레이션 가이드는 추가하지 않았습니다. 공개 API 변경이 없고, 소비자 입장에서는 줄바꿈 위치만 개선되므로 손댈 것이 없습니다.

[WRP-2423]: https://wantedlab.atlassian.net/browse/WRP-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 아코디언, 알림, 카드, 폴백 화면, 폼, 목록, 팝오버 등 다양한 UI에서 긴 텍스트가 레이아웃을 벗어나지 않도록 줄바꿈 처리를 개선했습니다.
  - 진행 단계, 섹션 헤더, 섹션 메시지, 세그먼트 컨트롤, 선택 컨트롤 및 테이블의 제목·설명·라벨에도 일관된 텍스트 줄바꿈을 적용했습니다.
  - 단어 단위 가독성을 유지하면서 필요한 경우 긴 문자열도 적절히 나뉘어 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->