### PR TITLE
feat(core): popper collisionPadding 추가 및 오버레이 뷰포트 대응

### DIFF
--- a/docs/data/components/presentation/popover/web.mdx
+++ b/docs/data/components/presentation/popover/web.mdx
@@ -301,6 +301,7 @@ export default Demo;`}
 [PopperContent](/docs/utilities/web-utility-components/popper) 컴포넌트의 옵션을 제공합니다.
 - `referenceHidden`
 - `referenceHiddenOffsets`
+- `collisionPadding`
 - `setContext`
 - `offset`
 - `position`

--- a/docs/data/components/presentation/tooltip/web.mdx
+++ b/docs/data/components/presentation/tooltip/web.mdx
@@ -582,6 +582,7 @@ export default Demo;`}
 [PopoverContent](/docs/components/presentation/popover/web) 컴포넌트의 옵션을 제공합니다.
 - `referenceHidden`
 - `referenceHiddenOffsets`
+- `collisionPadding`
 - `setContext`
 - `offset`
 - `position`

--- a/docs/src/features/docs/components/custom-render/token-popover/index.tsx
+++ b/docs/src/features/docs/components/custom-render/token-popover/index.tsx
@@ -8,7 +8,7 @@ import { IconMoon, IconSun } from '@montage-ui/icon';
 
 import { breakWordStyle } from '@/styles/text';
 
-import { palettePopoverWrapperStyle, popoverIconStyle } from './style';
+import { popoverIconStyle } from './style';
 
 import type { PropsWithChildren, ReactNode } from 'react';
 
@@ -33,7 +33,6 @@ const TokenPopover = ({
       offset={offset}
       variant="custom"
       sx={{ padding: '20px 24px' }}
-      wrapperProps={{ sx: palettePopoverWrapperStyle }}
       position="bottom-center"
     >
       <FlexBox gap="20px" flexDirection="column">

--- a/docs/src/features/docs/components/custom-render/token-popover/style.ts
+++ b/docs/src/features/docs/components/custom-render/token-popover/style.ts
@@ -6,9 +6,3 @@ export const popoverIconStyle = (theme: Theme) => css`
   color: ${theme.semantic.foreground.neutral.primary};
   font-size: 24px;
 `;
-
-export const palettePopoverWrapperStyle = css`
-  min-width: unset !important;
-  max-width: 100%;
-  padding-inline: var(--layout-padding-inline);
-`;

--- a/docs/src/features/docs/components/foundations/icons/collections/index.tsx
+++ b/docs/src/features/docs/components/foundations/icons/collections/index.tsx
@@ -21,7 +21,7 @@ import {
   iconDetailWrapperStyle,
   iconGridStyle,
   iconItemStyle,
-  iconPopoverWrapperStyle,
+  iconPopoverStyle,
 } from './style';
 
 import type { MouseEvent } from 'react';
@@ -103,11 +103,8 @@ const Collections = ({ icons }: Props) => {
 
               <PopoverContent
                 variant="custom"
-                sx={{
-                  padding: '20px 24px 24px',
-                }}
+                sx={iconPopoverStyle}
                 data-role="icon-detail-popover"
-                wrapperProps={{ sx: iconPopoverWrapperStyle }}
               >
                 <FlexBox flexDirection="column" gap="16px" flex="1">
                   <FlexBox gap="12px" justifyContent="space-between">

--- a/docs/src/features/docs/components/foundations/icons/collections/style.ts
+++ b/docs/src/features/docs/components/foundations/icons/collections/style.ts
@@ -54,11 +54,9 @@ export const iconDetailWrapperStyle = (theme: Theme) => css`
   box-shadow: inset 0 0 0 1px ${theme.semantic.line.neutral.tertiary};
 `;
 
-export const iconPopoverWrapperStyle = css`
-  min-width: unset !important;
-  max-width: 100%;
-  width: 380px;
-  padding-inline: var(--layout-padding-inline);
+export const iconPopoverStyle = css`
+  width: 300px;
+  padding: 20px 24px 24px;
 
   ${respondTo('500px')} {
     width: 100%;

--- a/docs/src/features/docs/components/mdx/section/variants/style.ts
+++ b/docs/src/features/docs/components/mdx/section/variants/style.ts
@@ -44,7 +44,7 @@ export const sectionVariantsControlMobileTriggerStyle = (theme: Theme) => css`
   position: absolute;
   right: 24px;
   top: 24px;
-  z-index: 1;
+  z-index: 3;
 
   &[aria-expanded='true'] {
     & > [data-component='with-interaction'] {

--- a/packages/core/src/components/autocomplete/style.ts
+++ b/packages/core/src/components/autocomplete/style.ts
@@ -14,7 +14,7 @@ export const autocompleteScrollAreaStyle = (theme: Theme) => css`
   border-radius: 16px;
   min-width: 140px;
   height: auto;
-  max-height: 400px;
+  max-height: min(400px, var(--popper-available-height, 100vh));
   border-radius: inherit;
 `;
 

--- a/packages/core/src/components/menu/style.ts
+++ b/packages/core/src/components/menu/style.ts
@@ -5,7 +5,7 @@ import type { Theme } from '@montage-ui/engine';
 
 export const menuPopoverContentStyle = (theme: Theme) => css`
   padding: 0;
-  width: 320px;
+  width: min(320px, var(--popper-available-width, 100vw));
   box-shadow: ${theme.semantic.elevation.shadow.normal.small};
   border-radius: 16px;
   backdrop-filter: none;
@@ -15,7 +15,7 @@ export const menuPopoverContentStyle = (theme: Theme) => css`
 export const menuScrollAreaStyle = (theme: Theme) => css`
   width: 100%;
   min-width: 140px;
-  max-height: 416px;
+  max-height: min(400px, var(--popper-available-height, 100vh));
   height: auto;
   border-radius: inherit;
   border: 1px solid ${theme.semantic.line.neutral.secondaryOpaque};

--- a/packages/core/src/components/menu/types.ts
+++ b/packages/core/src/components/menu/types.ts
@@ -42,6 +42,7 @@ export type MenuContentProps = Pick<
   | 'loop'
   | 'referenceHidden'
   | 'referenceHiddenOffsets'
+  | 'collisionPadding'
   | 'setContext'
   | 'wrapperProps'
   | 'forceMount'

--- a/packages/core/src/components/popover/index.tsx
+++ b/packages/core/src/components/popover/index.tsx
@@ -122,6 +122,7 @@ const PopoverContent = forwardRef(
       onUnmountAutoFocus,
       referenceHidden = false,
       referenceHiddenOffsets,
+      collisionPadding,
       setContext,
       wrapperProps,
       forceMount = false,
@@ -161,6 +162,7 @@ const PopoverContent = forwardRef(
           container={container}
           referenceHidden={referenceHidden}
           referenceHiddenOffsets={referenceHiddenOffsets}
+          collisionPadding={collisionPadding}
           setContext={setContext}
           wrapperProps={wrapperProps}
         >

--- a/packages/core/src/components/popover/style.ts
+++ b/packages/core/src/components/popover/style.ts
@@ -25,13 +25,14 @@ const popoverVariantStyle = (variant: PopoverContentProps['variant']) => {
     case 'custom':
       return css`
         padding: 16px;
+        max-width: var(--popper-available-width, 100vw);
       `;
     case 'normal':
     default:
       return css`
         border-radius: 12px;
         padding: 12px 14px;
-        max-width: 360px;
+        max-width: min(360px, var(--popper-available-width, 100vw));
         flex-direction: column;
         gap: 0px;
       `;

--- a/packages/core/src/components/popover/types.ts
+++ b/packages/core/src/components/popover/types.ts
@@ -32,6 +32,11 @@ export type PopoverContentProps = WithSxProps<
     referenceHidden?: PopperContentProps['referenceHidden'];
     /** When the element is hidden, the offset is adjusted. */
     referenceHiddenOffsets?: PopperContentProps['referenceHiddenOffsets'];
+    /**
+     * Specifies the distance in pixels from the collision boundary(viewport) edges.
+     * The content is shifted to stay within the boundary inset by this value.
+     */
+    collisionPadding?: PopperContentProps['collisionPadding'];
     /** The floating ui context can be obtained through a callback. */
     setContext?: PopperContentProps['setContext'];
     /** Specifies the container to be displayed by Portal. */

--- a/packages/core/src/components/popper/helpers.ts
+++ b/packages/core/src/components/popper/helpers.ts
@@ -6,6 +6,16 @@ import type {
 } from '@floating-ui/react';
 import type { PopperContentProps } from './types';
 
+export const getCollisionPaddingX = (
+  collisionPadding: PopperContentProps['collisionPadding'],
+) => {
+  if (typeof collisionPadding === 'number') {
+    return collisionPadding * 2;
+  }
+
+  return (collisionPadding?.left ?? 0) + (collisionPadding?.right ?? 0);
+};
+
 export const roundByDPR = (value: number) => {
   const dpr = window.devicePixelRatio || 1;
   return Math.round(value * dpr) / dpr;

--- a/packages/core/src/components/popper/index.test.tsx
+++ b/packages/core/src/components/popper/index.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import { Popper, PopperAnchor, PopperContent } from '.';
+
+import type { PopperContentProps } from './types';
+
+const VIEWPORT_WIDTH = 800;
+
+const renderPopper = (
+  collisionPadding?: PopperContentProps['collisionPadding'],
+) =>
+  render(
+    <Popper>
+      <PopperAnchor>
+        <button>anchor</button>
+      </PopperAnchor>
+      <PopperContent collisionPadding={collisionPadding}>
+        <div>content</div>
+      </PopperContent>
+    </Popper>,
+  );
+
+const getAvailableWidth = () =>
+  screen
+    .getByText('content')
+    .closest<HTMLElement>('[data-side]')
+    ?.style.getPropertyValue('--popper-available-width');
+
+describe('when rendering popper content', () => {
+  beforeEach(() => {
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: VIEWPORT_WIDTH,
+      configurable: true,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it('should provide the available width excluding the default collision padding', async () => {
+    renderPopper();
+
+    await waitFor(() => expect(getAvailableWidth()).toBe('760px'));
+  });
+
+  it('should provide the available width excluding the given collision padding', async () => {
+    renderPopper(16);
+
+    await waitFor(() => expect(getAvailableWidth()).toBe('768px'));
+  });
+
+  it('should provide the available width excluding the given collision padding of each side', async () => {
+    renderPopper({ left: 12, right: 8 });
+
+    await waitFor(() => expect(getAvailableWidth()).toBe('780px'));
+  });
+});

--- a/packages/core/src/components/popper/index.tsx
+++ b/packages/core/src/components/popper/index.tsx
@@ -31,6 +31,7 @@ import {
   usePopperContext,
 } from './contexts';
 import {
+  getCollisionPaddingX,
   getPlacementMapper,
   getSideAlignFromPlacement,
   roundByDPR,
@@ -174,6 +175,7 @@ const PopperContent = forwardRef<
       offset: givenOffset = 10,
       referenceHidden = false,
       referenceHiddenOffsets,
+      collisionPadding = 20,
       setContext,
       container,
       disablePortal,
@@ -196,6 +198,8 @@ const PopperContent = forwardRef<
 
     const floatingPlacement = getPlacementMapper(position);
 
+    const collisionPaddingX = getCollisionPaddingX(collisionPadding);
+
     const {
       refs,
       floatingStyles,
@@ -216,9 +220,32 @@ const PopperContent = forwardRef<
           mainAxis: true,
           crossAxis: false,
           limiter: limitShift(),
+          padding: collisionPadding,
         }),
         flip(),
-        size(),
+        size({
+          padding: collisionPadding,
+          apply: ({ elements, availableHeight }) => {
+            const { clientWidth } =
+              elements.floating.ownerDocument.documentElement;
+            const availableWidth = clientWidth - collisionPaddingX;
+
+            // Keeps the fallback of the css variables when the viewport cannot be measured.
+            if (availableWidth > 0) {
+              elements.floating.style.setProperty(
+                '--popper-available-width',
+                `${availableWidth}px`,
+              );
+            }
+
+            if (availableHeight > 0) {
+              elements.floating.style.setProperty(
+                '--popper-available-height',
+                `${availableHeight}px`,
+              );
+            }
+          },
+        }),
         arrow &&
           floatingUIarrow(({ placement }) => {
             return {

--- a/packages/core/src/components/popper/index.tsx
+++ b/packages/core/src/components/popper/index.tsx
@@ -222,7 +222,7 @@ const PopperContent = forwardRef<
           limiter: limitShift(),
           padding: collisionPadding,
         }),
-        flip(),
+        flip({ padding: collisionPadding }),
         size({
           padding: collisionPadding,
           apply: ({ elements, availableHeight }) => {

--- a/packages/core/src/components/popper/types.ts
+++ b/packages/core/src/components/popper/types.ts
@@ -25,6 +25,11 @@ export type PopperContentProps = {
   referenceHidden?: boolean;
   /** When the element is hidden, the offset is adjusted. */
   referenceHiddenOffsets?: SideObject;
+  /**
+   * Specifies the distance in pixels from the collision boundary(viewport) edges.
+   * The content is shifted to stay within the boundary inset by this value.
+   */
+  collisionPadding?: number | Partial<SideObject>;
   /** The props of the wrapper. */
   wrapperProps?: DefaultComponentProps<{}, 'div'>;
   /** The floating ui context can be obtained through a callback. */

--- a/packages/core/src/components/tooltip/index.tsx
+++ b/packages/core/src/components/tooltip/index.tsx
@@ -194,6 +194,7 @@ const TooltipContent = forwardRef(
       closeButton,
       referenceHidden = false,
       referenceHiddenOffsets,
+      collisionPadding,
       setContext,
       forceMount = false,
       shortcut,
@@ -257,6 +258,7 @@ const TooltipContent = forwardRef(
             offset={offset}
             referenceHidden={referenceHidden}
             referenceHiddenOffsets={referenceHiddenOffsets}
+            collisionPadding={collisionPadding}
             setContext={setContext}
             wrapperProps={{
               // Prevent mouseover events during the disappearing animation

--- a/packages/core/src/components/tooltip/style.ts
+++ b/packages/core/src/components/tooltip/style.ts
@@ -28,7 +28,7 @@ export const tooltipWrapperStyle =
   ({ size, xs, sm, md, lg, xl }: TooltipContentProps) =>
   (theme: Theme) => css`
     backdrop-filter: blur(32px);
-    max-width: 280px;
+    max-width: min(280px, var(--popper-available-width, 100vw));
 
     &[data-status='open'] {
       animation: ${mountKeyframes} 200ms ease-in-out;

--- a/packages/core/src/components/tooltip/types.ts
+++ b/packages/core/src/components/tooltip/types.ts
@@ -57,6 +57,11 @@ type TooltipDefaultProps = WithSxProps<{
   referenceHidden?: PopperContentProps['referenceHidden'];
   /** When the element is hidden, the offset is adjusted. */
   referenceHiddenOffsets?: PopperContentProps['referenceHiddenOffsets'];
+  /**
+   * Specifies the distance in pixels from the collision boundary(viewport) edges.
+   * The content is shifted to stay within the boundary inset by this value.
+   */
+  collisionPadding?: PopperContentProps['collisionPadding'];
   /** The floating ui context can be obtained through a callback. */
   setContext?: PopperContentProps['setContext'];
   /** Whether to force mount the tooltip. */


### PR DESCRIPTION
## Summary

- `PopperContent`에 `collisionPadding` prop 추가 — `shift` 미들웨어에 하드코딩돼 있던 좌우 20px 여백을 사용처에서 조정할 수 있게 했습니다. 기본값 `20`, 타입은 `number | Partial<SideObject>`이며 Radix Popper의 동일 개념 prop과 네이밍을 맞췄습니다.
- 뷰포트 가용 영역을 CSS 변수로 노출 — `size()` 미들웨어에서 `--popper-available-width`, `--popper-available-height`를 floating element에 설정합니다. 폭은 `documentElement.clientWidth`를 써서 `100vw`와 달리 스크롤바를 제외한 실제 가용 폭이고, 높이는 flip이 최종 결정한 placement 기준으로 anchor부터 경계까지 남은 거리(`offset` 차감 후)입니다.
- 오버레이 최대 크기를 가용 영역으로 제한 — 고정값이라 좁은 뷰포트에서 화면을 벗어나던 문제를 수정했습니다.

| 컴포넌트 | 변경 |
| --- | --- |
| Popover `normal` | `max-width: 360px` → `min(360px, 가용폭)` |
| Popover `custom` | 없음 → `가용폭` |
| Tooltip | `max-width: 280px` → `min(280px, 가용폭)` |
| Menu | `width: 320px` → `min(320px, 가용폭)`, `max-height: 416px` → `min(416px, 가용높이)` |
| Autocomplete | `max-width: 가용폭` 추가, `max-height: 400px` → `min(400px, 가용높이)` |

DatePicker / DateRangePicker / TimePicker / SelectMultiple은 기존 prop 상속 구조를 타고 `collisionPadding`이 자동으로 열립니다.

높이 제한은 내부에 `ScrollArea`가 있어 넘침을 스크롤로 흡수하는 Menu, Autocomplete에만 걸었습니다. Tooltip은 `PopperArrow`가 박스 바깥에 `position: absolute`로 그려져 `overflow` 처리 시 화살표가 잘리고, hover로 뜨는 특성상 스크롤도 성립하지 않아 제외했습니다.

docs 사이트에서 `wrapperProps`로 `min-width`를 강제 해제하고 `padding-inline`을 넣어 넘침을 막던 우회 코드도 함께 제거했습니다.

## Jira

[WRP-2432](https://wantedlab.atlassian.net/browse/WRP-2432) — Popper collisionPadding prop 추가 및 오버레이 컴포넌트 최대 크기 뷰포트 대응

- Status: 열림
- Type: 작업
- Relates to: [WRP-802](https://wantedlab.atlassian.net/browse/WRP-802) ([디자인시스템] 4.0.0 Major 업데이트)

## Test plan

- [x] 좁은 뷰포트(모바일)에서 Tooltip / Popover / Menu / Autocomplete가 화면 좌우 20px 안쪽에 들어오는지
- [x] anchor를 화면 중앙·하단에 두고 Menu / Autocomplete를 열었을 때 높이가 잘리고 내부 스크롤로 동작하는지
- [x] `collisionPadding`에 `number`와 `{ left, right }` 두 형태를 넣었을 때 모두 반영되는지
- [x] docs 사이트의 토큰 팝오버 / 아이콘 상세 팝오버가 우회 스타일 제거 후에도 정상 표시되는지
- [x] 유닛 테스트 354개 통과 (`packages/core/src/components/popper/index.test.tsx` 신규)
- [x] 시각 회귀 테스트 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WRP-2432]: https://wantedlab.atlassian.net/browse/WRP-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Popover, Tooltip, Menu, Popper에 충돌 영역과의 여백을 설정하는 `collisionPadding` 옵션을 추가했습니다.
  * 팝오버와 툴팁이 화면에서 사용 가능한 공간에 맞춰 너비를 자동 조정합니다.

* **버그 수정**
  * 좁은 화면이나 가장자리에서 메뉴, 자동완성 목록, 팝오버 및 툴팁이 화면 밖으로 벗어나지 않도록 개선했습니다.
  * 팝오버와 메뉴의 높이 및 너비 계산이 실제 가용 공간을 반영합니다.

* **문서**
  * Popover와 Tooltip의 `collisionPadding` 옵션 사용 안내를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->