### PR TITLE
feat(core): action area 디자인 개선 및 caption icon/background color API 추가

### DIFF
--- a/docs/data/components/actions/action-area/web.mdx
+++ b/docs/data/components/actions/action-area/web.mdx
@@ -24,10 +24,6 @@ const Demo = () => {
       <ActionArea variant="strong">
         <ActionAreaButton variant="main">Main</ActionAreaButton>
         <ActionAreaButton variant="alternative">Alternative</ActionAreaButton>
-      </ActionArea>
-
-      <ActionArea variant="strong">
-        <ActionAreaButton variant="main">Main</ActionAreaButton>
         <ActionAreaButton variant="sub">Sub</ActionAreaButton>
       </ActionArea>
     </FlexBox>
@@ -111,14 +107,13 @@ export default Demo;`}
 const Demo = () => {
   return (
     <ActionArea
-      sx={{ width: '100%' }}
       variant="compact"
       compactContent={(
-        <FormControl flexDirection="row" alignItems="center">
+        <FormControl flexDirection="row">
           <FormControlField>
             <Checkbox />
           </FormControlField>
-          <FormControlLabel>약관에 동의합니다.</FormControlLabel>
+          <FormControlLabel sx={{ paddingBlock: '1px' }}>약관에 동의합니다.</FormControlLabel>
         </FormControl>
       )}
     >
@@ -150,7 +145,7 @@ export default Demo;`}
 
 const Demo = () => {
   return (
-    <ActionArea extra sx={{ width: '100%' }}>
+    <ActionArea extra>
       <ActionAreaButton variant="main">Main</ActionAreaButton>
     </ActionArea>
   )
@@ -159,32 +154,55 @@ const Demo = () => {
 export default Demo;`}
 />
 
-또한 `extraContent` prop 을 통해 상단에 콘텐츠를 배치할 수 있습니다.
+### With extra content
 
-<Demo code={`import { ActionArea, ActionAreaButton, FormControl, FormControlField, FormControlLabel, Checkbox } from '@montage-ui/core';
+`extraContent` prop 을 통해 상단 영역에 콘텐츠를 배치할 수 있습니다.
+
+<Demo code={`import { ActionArea, ActionAreaButton, FormControl, FormControlField, FormControlLabel, Checkbox, FlexBox } from '@montage-ui/core';
+import { IconCircleInfo } from '@montage-ui/icon';
 
 const Demo = () => {
   return (
-    <ActionArea
-      extra
-      extraContent={(
-        <FormControl flexDirection="row" alignItems="center">
-          <FormControlField>
-            <Checkbox />
-          </FormControlField>
-          <FormControlLabel>약관에 동의합니다.</FormControlLabel>
-        </FormControl>
-      )}
-    >
-      <ActionAreaButton variant="main">Main</ActionAreaButton>
-    </ActionArea>
+    <FlexBox flexDirection="column" gap="12px" sx={{ width: '100%' }}>
+      <ActionArea
+        extra
+        extraContent={(
+          <FormControl flexDirection="row" alignItems="center">
+            <FormControlField>
+              <Checkbox />
+            </FormControlField>
+            <FormControlLabel>약관에 동의합니다.</FormControlLabel>
+          </FormControl>
+        )}
+      >
+        <ActionAreaButton variant="main">Main</ActionAreaButton>
+      </ActionArea>
+
+      <ActionArea
+        extra
+        extraContent={(
+          <FlexBox
+            sx={theme => ({
+              width: '100%',
+              height: '64px',
+              background: theme.semantic.surface.accent.violetOpaque,
+              opacity: 0.08
+            })}
+          />
+        )}
+      >
+        <ActionAreaButton variant="main">Main</ActionAreaButton>
+      </ActionArea>
+    </FlexBox>
   )
 }
 
 export default Demo;`}
 />
 
-`divider` prop 을 사용하면 상단 divider를 제어할 수 있지만 권장하지 않습니다.
+### Without divider
+
+`divider={false}` prop 을 사용하면 상단 divider 를 제거 수 있지만 권장하지 않습니다.
 
 <Demo code={`import { ActionArea, ActionAreaButton, FormControl, FormControlField, FormControlLabel, Checkbox } from '@montage-ui/core';
 
@@ -201,17 +219,43 @@ export default Demo;`}
 
 ## Caption
 
-`caption` prop 을 통해 캡션을 표시할 수 있습니다.
+`caption` prop 을 통해 캡션을 표시할 수 있으며 `captionIcon` 을 사용하여 캡션 영역에 아이콘을 추가할 수 있습니다.
 
-<Demo code={`import { ActionArea, ActionAreaButton } from '@montage-ui/core';
+`variant="cancel"` 에서는 사용하지 않습니다.
+
+<Demo code={`import { ActionArea, ActionAreaButton, FlexBox } from '@montage-ui/core';
+import { IconCircleInfo } from '@montage-ui/icon';
 
 const Demo = () => {
   return (
-    <ActionArea caption="Caption" sx={{ width: '100%' }}>
-      <ActionAreaButton>
-        Main
-      </ActionAreaButton>
-    </ActionArea>
+    <FlexBox flexDirection="column" gap="12px" sx={{ width: '100%' }}>
+      <ActionArea
+        variant="strong"
+        caption="Strong variant, Caption"
+        captionIcon={<IconCircleInfo />}
+      >
+        <ActionAreaButton variant="main">Main</ActionAreaButton>
+        <ActionAreaButton variant="alternative">Alternative</ActionAreaButton>
+      </ActionArea>
+
+      <ActionArea
+        variant="neutral"
+        caption="Neutral variant, Caption"
+        captionIcon={<IconCircleInfo />}
+      >
+        <ActionAreaButton variant="alternative">Alternative</ActionAreaButton>
+        <ActionAreaButton variant="main">Main</ActionAreaButton>
+      </ActionArea>
+
+      <ActionArea
+        variant="compact"
+        caption="Compact variant, Caption"
+        captionIcon={<IconCircleInfo />}
+      >
+        <ActionAreaButton variant="alternative">Alternative</ActionAreaButton>
+        <ActionAreaButton variant="main">Main</ActionAreaButton>
+      </ActionArea>
+    </FlexBox>
   )
 }
 
@@ -225,15 +269,24 @@ export default Demo;`}
 
 [Popup](/docs/components/presentation/popup/web), [Bottom sheet](/docs/components/presentation/bottom-sheet/web) 내부에서 사용할 경우 자동으로 스크롤 여부에 따라 background 옵션을 조정합니다.
 
+
+`backgroundColor` prop 을 이용하여 배경 색을 변경할 수 있습니다.
+
 <Demo
   defaultIsTransparent
-  code={`import { FlexBox, ActionArea, ActionAreaButton } from '@montage-ui/core';
+  code={`import { ActionArea, ActionAreaButton, FlexBox } from '@montage-ui/core';
 
 const Demo = () => {
   return (
-    <FlexBox sx={{ width: '100%' }}>
+    <FlexBox flexDirection="column" gap="12px" sx={{ width: '100%' }}>
       <ActionArea background>
         <ActionAreaButton variant="main">Main</ActionAreaButton>
+        <ActionAreaButton variant="alternative">Alternative</ActionAreaButton>
+      </ActionArea>
+
+      <ActionArea background backgroundColor="semantic.effect.dimmer.primary">
+        <ActionAreaButton variant="main">Main</ActionAreaButton>
+        <ActionAreaButton variant="alternative">Alternative</ActionAreaButton>
       </ActionArea>
     </FlexBox>
   )

--- a/docs/data/components/actions/action-area/web.mdx
+++ b/docs/data/components/actions/action-area/web.mdx
@@ -159,7 +159,6 @@ export default Demo;`}
 `extraContent` prop 을 통해 상단 영역에 콘텐츠를 배치할 수 있습니다.
 
 <Demo code={`import { ActionArea, ActionAreaButton, FormControl, FormControlField, FormControlLabel, Checkbox, FlexBox } from '@montage-ui/core';
-import { IconCircleInfo } from '@montage-ui/icon';
 
 const Demo = () => {
   return (
@@ -202,7 +201,7 @@ export default Demo;`}
 
 ### Without divider
 
-`divider={false}` prop 을 사용하면 상단 divider 를 제거 수 있지만 권장하지 않습니다.
+`divider={false}` prop 을 사용하면 상단 divider 를 제거할 수 있지만 권장하지 않습니다.
 
 <Demo code={`import { ActionArea, ActionAreaButton, FormControl, FormControlField, FormControlLabel, Checkbox } from '@montage-ui/core';
 
@@ -268,7 +267,6 @@ export default Demo;`}
 `background` prop 을 이용하여 gradient 혹은 divider를 표시할 수 있습니다.
 
 [Popup](/docs/components/presentation/popup/web), [Bottom sheet](/docs/components/presentation/bottom-sheet/web) 내부에서 사용할 경우 자동으로 스크롤 여부에 따라 background 옵션을 조정합니다.
-
 
 `backgroundColor` prop 을 이용하여 배경 색을 변경할 수 있습니다.
 

--- a/packages/core/src/components/action-area/index.tsx
+++ b/packages/core/src/components/action-area/index.tsx
@@ -1,14 +1,13 @@
 import { forwardRef } from 'react';
 
 import { FlexBox } from '../flex-box';
-import { Typography } from '../typography';
 import { Button } from '../button';
 import { TextButton } from '../text-button';
 import { useModalActionAreaContext } from '../modal/contexts';
 
 import { ACTION_AREA_BUTTON_NAME, ACTION_AREA_NAME } from './constants';
 import { ActionAreaProvider, useActionAreaContext } from './contexts';
-import { actionAreaStyle, actionButtonCancel } from './style';
+import { actionAreaStyle, actionButtonCancel, captionStyle } from './style';
 
 import type { ActionAreaButtonProps, ActionAreaProps } from './types';
 import type { ElementType, ForwardedRef, ReactNode } from 'react';
@@ -30,7 +29,9 @@ const ActionArea = forwardRef<
       variant = 'strong',
       children,
       caption,
+      captionIcon,
       background,
+      backgroundColor = 'semantic.surface.elevated.primary',
       divider = true,
       ...props
     },
@@ -54,6 +55,7 @@ const ActionArea = forwardRef<
               divider,
               extra,
               background: extra ? false : (background ?? modalSticky),
+              backgroundColor,
             }),
             props.sx,
           ]}
@@ -64,33 +66,61 @@ const ActionArea = forwardRef<
               flexDirection="column"
               alignItems="center"
               data-role="action-area-extra-content"
-              sx={{
-                marginBottom: 'calc(4px + var(--action-area-margin-y, 20px))',
-              }}
+              sx={(theme) => ({
+                padding: `${theme.spacing[0]} ${theme.spacing[4]} var(--action-area-margin-y, 20px)`,
+              })}
             >
               {extraContent}
             </FlexBox>
           )}
 
-          {Boolean(caption) && (
-            <Typography
-              align="center"
-              variant="label2"
-              weight="regular"
-              data-role="action-area-caption"
-              color="semantic.foreground.neutral.tertiary"
-              sx={{ marginBottom: '16px' }}
-            >
-              {caption}
-            </Typography>
-          )}
-          {variant === 'compact' && Boolean(compactContent) ? (
-            <FlexBox justifyContent="space-between" alignItems="center">
+          {variant !== 'compact' &&
+            variant !== 'cancel' &&
+            Boolean(caption) && (
               <FlexBox
-                flexDirection="row"
-                data-role="action-area-compact-content"
+                as="span"
+                data-role="action-area-caption"
+                sx={[
+                  captionStyle,
+                  (theme) => ({ marginBottom: theme.spacing[16] }),
+                ]}
+                justifyContent="center"
               >
-                {compactContent}
+                {captionIcon}
+                <span>{caption}</span>
+              </FlexBox>
+            )}
+          {variant === 'compact' &&
+          (Boolean(compactContent) || Boolean(caption)) ? (
+            <FlexBox
+              alignItems="center"
+              gap="12px"
+              justifyContent="space-between"
+              data-role="action-area-compact-wrapper"
+            >
+              <FlexBox
+                alignItems="center"
+                gap="12px"
+                data-role="action-area-compact-content-wrapper"
+              >
+                {caption && (
+                  <FlexBox
+                    as="span"
+                    data-role="action-area-caption"
+                    sx={captionStyle}
+                  >
+                    {captionIcon}
+                    <span>{caption}</span>
+                  </FlexBox>
+                )}
+                {compactContent && (
+                  <FlexBox
+                    flexDirection="row"
+                    data-role="action-area-compact-content"
+                  >
+                    {compactContent}
+                  </FlexBox>
+                )}
               </FlexBox>
               <FlexBox
                 flexShrink={0}
@@ -139,9 +169,7 @@ const ActionAreaButton = forwardRef(
       main: (
         <Button
           ref={ref}
-          variant={
-            buttonVariant ?? (parentVariant === 'cancel' ? 'outlined' : 'solid')
-          }
+          variant={buttonVariant ?? 'solid'}
           color={
             buttonColor ??
             (parentVariant === 'cancel' ? 'assistive' : 'primary')
@@ -157,7 +185,7 @@ const ActionAreaButton = forwardRef(
           ref={ref}
           variant={buttonVariant ?? 'outlined'}
           size="large"
-          color={buttonColor ?? 'primary'}
+          color={buttonColor ?? 'assistive'}
           fullWidth={parentVariant === 'strong'}
           {...props}
           sx={[actionButtonCancel({ variant, parentVariant }), props.sx]}

--- a/packages/core/src/components/action-area/style.ts
+++ b/packages/core/src/components/action-area/style.ts
@@ -14,10 +14,20 @@ export const actionAreaStyle =
 
     --action-area-background-color: ${getColorByToken(theme, backgroundColor!)};
 
+    [data-role='action-area-extra-content'] {
+      [data-role='label-content'] > [data-role='label-content-text'] {
+        white-space: initial;
+      }
+    }
+
     [data-role='action-area-compact-content-wrapper'] {
       min-width: 0;
       word-break: keep-all;
       overflow-wrap: anywhere;
+
+      [data-role='label-content'] > [data-role='label-content-text'] {
+        white-space: initial;
+      }
     }
 
     ${actionAreaBackgroundStyle({ divider, background, extra }, theme)}

--- a/packages/core/src/components/action-area/style.ts
+++ b/packages/core/src/components/action-area/style.ts
@@ -86,9 +86,12 @@ export const captionStyle = (theme: Theme) => css`
   gap: ${theme.spacing[4]};
   color: ${theme.semantic.foreground.neutral.tertiary};
   ${typographyStyle('label2', 'medium')}
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 
   svg {
     display: block;
+    flex-shrink: 0;
     margin-block: 1px;
     font-size: ${theme.dimension[16]};
   }

--- a/packages/core/src/components/action-area/style.ts
+++ b/packages/core/src/components/action-area/style.ts
@@ -1,16 +1,24 @@
-import { css } from '@montage-ui/engine';
+import { css, getColorByToken } from '@montage-ui/engine';
 
-import { gradient } from '../../utils';
+import { gradient, typographyStyle } from '../../utils';
 
 import type { ActionAreaButtonProps, ActionAreaProps } from './types';
 import type { Merge, Theme } from '@montage-ui/engine';
 
 export const actionAreaStyle =
-  ({ divider, background, extra }: ActionAreaProps) =>
+  ({ divider, background, extra, backgroundColor }: ActionAreaProps) =>
   (theme: Theme) => css`
     width: 100%;
     padding: var(--action-area-margin-y, 20px) var(--action-area-margin-x, 20px);
     position: relative;
+
+    --action-area-background-color: ${getColorByToken(theme, backgroundColor!)};
+
+    [data-role='action-area-compact-content-wrapper'] {
+      min-width: 0;
+      word-break: keep-all;
+      overflow-wrap: anywhere;
+    }
 
     ${actionAreaBackgroundStyle({ divider, background, extra }, theme)}
   `;
@@ -24,9 +32,9 @@ const actionAreaBackgroundStyle = (
       return css`
         ${divider &&
         css`
-          border-top: 1px solid ${theme.semantic.line.neutral.secondary};
+          border-top: 1px solid ${theme.semantic.line.neutral.tertiary};
         `}
-        background-color: ${theme.semantic.surface.elevated.primary};
+        background-color: var(--action-area-background-color);
       `;
     case false:
     default:
@@ -36,7 +44,7 @@ const actionAreaBackgroundStyle = (
               &::before {
                 pointer-events: none;
                 ${gradient(
-                  theme.semantic.surface.elevated.primary,
+                  'var(--action-area-background-color)',
                   'top',
                   'calc(var(--action-area-margin-y, 20px) * 2)',
                   'mask',
@@ -74,6 +82,18 @@ const actionAreaBackgroundStyle = (
   }
 };
 
+export const captionStyle = (theme: Theme) => css`
+  gap: ${theme.spacing[4]};
+  color: ${theme.semantic.foreground.neutral.tertiary};
+  ${typographyStyle('label2', 'medium')}
+
+  svg {
+    display: block;
+    margin-block: 1px;
+    font-size: ${theme.dimension[16]};
+  }
+`;
+
 export const actionButtonCancel = ({
   variant,
   parentVariant,
@@ -84,7 +104,6 @@ export const actionButtonCancel = ({
   if (parentVariant === 'neutral' && variant !== 'sub') {
     return css`
       flex: 1 1 0;
-      padding: 12px 15px;
     `;
   }
 

--- a/packages/core/src/components/action-area/types.ts
+++ b/packages/core/src/components/action-area/types.ts
@@ -1,4 +1,4 @@
-import type { WithSxProps } from '@montage-ui/engine';
+import type { ThemeColorsToken, WithSxProps } from '@montage-ui/engine';
 import type { TextButtonProps } from '../text-button/types';
 import type { ButtonProps } from '../button/types';
 import type { ReactNode } from 'react';
@@ -17,8 +17,17 @@ export type ActionAreaProps = WithSxProps<{
    * If `extra` is true, you can use `extraContent` to add content such as a checkbox above the buttons.
    */
   extra?: boolean;
-  /** Displays a caption above the buttons. */
+  /**
+   * Displays a caption next to the buttons.
+   * When `variant=compact`, it is displayed inline on the left of the buttons.
+   * It is not displayed when `variant=cancel`.
+   */
   caption?: ReactNode;
+  /**
+   * Displays an icon in front of the `caption`.
+   * The icon size and the gap between the caption are handled by the component.
+   */
+  captionIcon?: ReactNode;
   /**
    * When `extra=true`, this prop is used to display the content such as checkbox area above the button.
    */
@@ -32,6 +41,12 @@ export type ActionAreaProps = WithSxProps<{
    * When used inside a Modal, it is handled by the Modal's internal logic.
    */
   background?: boolean;
+  /**
+   * Customizes the background color applied when `background=true` or `extra=true`.
+   * When `background=true`, it is also used as the start color of the gradient.
+   * default is `semantic.surface.elevated.primary`
+   */
+  backgroundColor?: ThemeColorsToken;
   /**
    * When `extra=true`, a line is displayed at the top.
    */

--- a/packages/core/src/components/form-control/style.ts
+++ b/packages/core/src/components/form-control/style.ts
@@ -230,7 +230,7 @@ export const formLabelStyle =
     padding: ${theme.spacing[0]} ${theme.spacing[2]};
     ${formLabelSizeStyle({ size, variant, weight })}
 
-    & > [data-role='label-content'] {
+    [data-role='label-content'] {
       display: inline-flex;
       max-width: 100%;
       min-width: 0;


### PR DESCRIPTION
## Summary

Figma 4.0.0 스펙에 맞춰 Action Area 를 업데이트했습니다. WRP-2461(전반 업데이트)과 WRP-2512(버튼 색상 확정)를 함께 반영했습니다.

- **버튼 기본 색상 확정 (WRP-2512)**
  - `variant="alternative"`: `outlined` / `primary` → `outlined` / `assistive`
  - `variant="cancel"` 의 `variant="main"`: `outlined` / `assistive` → `solid` / `assistive`
  - `variant="sub"` 은 현행(`outlined` / `assistive`) 유지
  - `neutral` variant 버튼에 하드코딩되어 있던 `padding: 12px 15px` 제거 (Button `size="large"` 기본 패딩 사용)
- **caption 개편**
  - Typography 가운데 정렬 → 왼쪽 정렬, weight `regular` → `medium`
  - `variant="compact"`: `compactContent` 와 같은 줄 왼쪽에 인라인 배치 (`action-area-compact-wrapper` / `action-area-compact-content-wrapper` 구조 신설)
  - `variant="cancel"`: caption 미표시
  - compact 콘텐츠 영역에 `min-width: 0` 을 적용해, 버튼 영역(`flex-shrink: 0`)을 제외한 남은 폭을 넘지 않도록 처리
- **`captionIcon` prop 신설** — 아이콘 크기 16, 캡션과의 간격 4, 세로 가운데 정렬을 컴포넌트가 보장
- **`backgroundColor` prop 신설** — 미지정 시 `semantic.surface.elevated.primary`, 지정한 색은 `--action-area-background-color` 를 통해 sticky 그라디언트 시작색에도 함께 적용
- **여백 / divider 조정**
  - `extraContent` 하단 여백 `calc(4px + 20px)` → `20px`, 좌우 4px 패딩을 추가해 컨테이너 패딩과 합쳐 24px
  - divider 색 `line.neutral.secondary` → `line.neutral.tertiary`
- 문서(`docs`) 예제를 신규 API(`captionIcon`, `backgroundColor`)와 변경된 동작에 맞춰 정리

## Jira

- [WRP-2461](https://wantedlab.atlassian.net/browse/WRP-2461) — [WDS] Action Area 업데이트 (검토 중 / 하위 작업)
- [WRP-2512](https://wantedlab.atlassian.net/browse/WRP-2512) — [WDS] Action Area 버튼 색상 확정 반영 (열림 / 하위 작업)

Figma(4.0.0): https://www.figma.com/design/7RHtWV3Pw6I98UEDjbx5V1/branch/7H8Q2cRfxFL0fFHCbKt13L/0-Component?node-id=14852-42422

## Follow-up

- `--action-area-extra-content-margin` CSS 변수로 extra content 여백을 외부에서 제어하는 작업은 **Modal 업데이트 때 함께 처리 예정**입니다. 이 PR 에서는 `--action-area-margin-y` 기반 padding 으로만 처리했습니다.

## Test plan

- [ ] `pnpm -F docs dev` — Action Area 문서 페이지에서 variant 별 caption / captionIcon 렌더링 확인
- [ ] `compact` variant 에서 caption + compactContent 가 길 때 버튼 영역을 침범하지 않고 줄바꿈되는지 확인
- [ ] `background` + `backgroundColor` 조합에서 그라디언트 시작색이 함께 바뀌는지 확인
- [ ] `extra` variant 에서 divider 색과 상하좌우 여백 확인
- [ ] Popup / Bottom sheet 내부 sticky 동작 회귀 확인
- [ ] CI visual regression 스냅샷 갱신 (의도된 렌더링 변경)

[WRP-2461]: https://wantedlab.atlassian.net/browse/WRP-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * ActionArea에서 사용자 지정 배경색과 캡션 아이콘을 지원합니다.
  * 캡션, 추가 콘텐츠, 구분선 및 배경 그라디언트 표시를 개선했습니다.
  * Compact 레이아웃의 콘텐츠 배치와 줄바꿈 동작을 개선했습니다.
  * 버튼 변형별 기본 색상과 캡션 표시 동작을 조정했습니다.

* **버그 수정**
  * 중첩된 폼 라벨 콘텐츠에도 라벨 스타일이 올바르게 적용됩니다.

* **문서**
  * ActionArea 예제의 설명 오탈자를 수정하고 불필요한 항목을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->