### PR TITLE
fix(core): 오버레이 포커스 이동 시 확대 상태에서 화면이 튀는 현상 수정

### DIFF
--- a/packages/core/src/components/date-calendar/helpers.ts
+++ b/packages/core/src/components/date-calendar/helpers.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+import { focusIntoView } from '../../utils/internal/element';
+
 import type { Dayjs } from 'dayjs';
 import type { RefObject } from 'react';
 import type { DateType, ViewType } from './types';
@@ -162,35 +164,22 @@ export const focusDate = (
 ) => {
   switch (type) {
     case 'year':
-      return containerRef.current
-        ?.querySelector<HTMLDivElement>(`[data-year='${value}']`)
-        ?.focus();
+      return focusIntoView(
+        containerRef.current?.querySelector<HTMLElement>(
+          `[data-year='${value}']`,
+        ),
+      );
     case 'month':
-      return containerRef.current
-        ?.querySelector<HTMLDivElement>(`[data-month='${value}']`)
-        ?.focus();
+      return focusIntoView(
+        containerRef.current?.querySelector<HTMLElement>(
+          `[data-month='${value}']`,
+        ),
+      );
     case 'day':
-      return containerRef.current
-        ?.querySelector<HTMLDivElement>(
+      return focusIntoView(
+        containerRef.current?.querySelector<HTMLElement>(
           `[data-date='${value}']:not([aria-disabled='true'])[data-other-month='false']`,
-        )
-        ?.focus();
-  }
-};
-
-export const scrollIntoViewDate = (
-  type: Omit<ViewType, 'day'>,
-  value: number,
-  containerRef: RefObject<HTMLDivElement | null>,
-) => {
-  switch (type) {
-    case 'year':
-      return containerRef.current
-        ?.querySelector<HTMLDivElement>(`[data-year='${value}']`)
-        ?.scrollIntoView();
-    case 'month':
-      return containerRef.current
-        ?.querySelector<HTMLDivElement>(`[data-month='${value}']`)
-        ?.scrollIntoView();
+        ),
+      );
   }
 };

--- a/packages/core/src/components/date-calendar/index.tsx
+++ b/packages/core/src/components/date-calendar/index.tsx
@@ -54,7 +54,6 @@ import {
   getWeekdays,
   isDisabledDate,
   isValidDate,
-  scrollIntoViewDate,
 } from './helpers';
 
 import type { Dayjs } from 'dayjs';
@@ -403,7 +402,6 @@ const YearCalendar = forwardRef<
         : -1;
 
       if (selectedDateIdx !== -1) {
-        scrollIntoViewDate('year', yearRange[selectedDateIdx]!, containerRef);
         focusDate('year', yearRange[selectedDateIdx]!, containerRef);
         setFocusedIdx(selectedDateIdx);
         return;
@@ -414,7 +412,6 @@ const YearCalendar = forwardRef<
         : -1;
 
       if (todayDateIdx !== -1) {
-        scrollIntoViewDate('year', yearRange[todayDateIdx]!, containerRef);
         focusDate('year', yearRange[todayDateIdx]!, containerRef);
         setFocusedIdx(todayDateIdx);
         return;
@@ -656,11 +653,6 @@ const MonthCalendar = memo(
           : -1;
 
         if (selectedDateIdx !== -1) {
-          scrollIntoViewDate(
-            'month',
-            monthRange[selectedDateIdx]!.value,
-            containerRef,
-          );
           focusDate('month', monthRange[selectedDateIdx]!.value, containerRef);
           setFocusedIdx(selectedDateIdx);
           return;
@@ -677,11 +669,6 @@ const MonthCalendar = memo(
           : -1;
 
         if (todayDateIdx !== -1) {
-          scrollIntoViewDate(
-            'month',
-            monthRange[todayDateIdx]!.value,
-            containerRef,
-          );
           focusDate('month', monthRange[todayDateIdx]!.value, containerRef);
           setFocusedIdx(todayDateIdx);
           return;

--- a/packages/core/src/components/date-range-calendar/helpers.ts
+++ b/packages/core/src/components/date-range-calendar/helpers.ts
@@ -5,6 +5,7 @@ import {
   dayjsTimezone,
   isValidDate,
 } from '../date-calendar/helpers';
+import { focusIntoView } from '../../utils/internal/element';
 
 import type { Dayjs } from 'dayjs';
 import type { DateType, ViewType } from '../date-calendar/types';
@@ -75,36 +76,23 @@ export const focusRangeDate = (
 ) => {
   switch (type) {
     case 'day':
-      return containerRef.current
-        ?.querySelector<HTMLButtonElement>(
+      return focusIntoView(
+        containerRef.current?.querySelector<HTMLElement>(
           `[data-date="${value}"]:not([aria-disabled='true'])`,
-        )
-        ?.focus();
+        ),
+      );
     case 'month':
-      return containerRef.current
-        ?.querySelector<HTMLButtonElement>(`[data-month="${value}"]`)
-        ?.focus();
+      return focusIntoView(
+        containerRef.current?.querySelector<HTMLElement>(
+          `[data-month="${value}"]`,
+        ),
+      );
     case 'year':
-      return containerRef.current
-        ?.querySelector<HTMLButtonElement>(`[data-year="${value}"]`)
-        ?.focus();
-  }
-};
-
-export const scrollIntoViewRangeDate = (
-  type: ViewType,
-  value: string,
-  containerRef: { current: HTMLDivElement | null },
-) => {
-  switch (type) {
-    case 'year':
-      return containerRef.current
-        ?.querySelector<HTMLButtonElement>(`[data-year="${value}"]`)
-        ?.scrollIntoView({ block: 'center' });
-    case 'month':
-      return containerRef.current
-        ?.querySelector<HTMLButtonElement>(`[data-month="${value}"]`)
-        ?.scrollIntoView({ block: 'center' });
+      return focusIntoView(
+        containerRef.current?.querySelector<HTMLElement>(
+          `[data-year="${value}"]`,
+        ),
+      );
   }
 };
 

--- a/packages/core/src/components/date-range-calendar/index.tsx
+++ b/packages/core/src/components/date-range-calendar/index.tsx
@@ -44,7 +44,6 @@ import {
   isDateInRangeForView,
   isDateInVisiblePanels,
   isSameDateForView,
-  scrollIntoViewRangeDate,
 } from './helpers';
 import {
   rangeCalendarContainerStyle,
@@ -814,7 +813,6 @@ const RangeMonthPanel = memo(() => {
       if (selectedDateIdx !== -1) {
         setFocusedIdx(selectedDateIdx);
         const mv = `${dayjsTimezone(dayjs(defaultSelectedDate), timezone).year()}-${String(monthRange[selectedDateIdx]!.value + 1).padStart(2, '0')}`;
-        scrollIntoViewRangeDate('month', mv, containerRef);
         focusRangeDate('month', mv, containerRef);
         return;
       }
@@ -1224,11 +1222,6 @@ const RangeYearPanel = memo(({ yearsOrder = 'asc' }: RangeYearPanelProps) => {
         : -1;
 
       if (selectedDateIdx !== -1) {
-        scrollIntoViewRangeDate(
-          'year',
-          String(yearRange[selectedDateIdx]!),
-          containerRef,
-        );
         focusRangeDate(
           'year',
           String(yearRange[selectedDateIdx]!),
@@ -1243,11 +1236,6 @@ const RangeYearPanel = memo(({ yearsOrder = 'asc' }: RangeYearPanelProps) => {
         : -1;
 
       if (todayDateIdx !== -1) {
-        scrollIntoViewRangeDate(
-          'year',
-          String(yearRange[todayDateIdx]!),
-          containerRef,
-        );
         focusRangeDate('year', String(yearRange[todayDateIdx]!), containerRef);
         setFocusedIdx(todayDateIdx);
         return;

--- a/packages/core/src/components/focus-scope/helpers.ts
+++ b/packages/core/src/components/focus-scope/helpers.ts
@@ -92,9 +92,23 @@ export const removeLinks = (items: Array<HTMLElement>) => {
 };
 
 const findVisible = (elements: Array<HTMLElement>, container: HTMLElement) => {
+  // `checkVisibility` performs a single native check for `visibility: hidden`
+  // and `display: none` across the ancestor chain. This avoids the repeated
+  // `getComputedStyle` calls per ancestor that the fallback path requires,
+  // which reduces the cost of style resolution triggered by earlier DOM writes
+  // (e.g. react-remove-scroll, DismissableLayer setting body styles).
+  const canUseCheckVisibility =
+    typeof container.checkVisibility === 'function' &&
+    container.checkVisibility({ checkVisibilityCSS: true });
+
   for (const element of elements) {
+    const hidden = canUseCheckVisibility
+      ? !element.checkVisibility({ checkVisibilityCSS: true })
+      : isHidden(element, { upTo: container });
     // we stop checking if it's hidden at the `container` level (excluding)
-    if (!isHidden(element, { upTo: container })) return element;
+    if (!hidden) {
+      return element;
+    }
   }
 };
 

--- a/packages/core/src/components/menu/index.tsx
+++ b/packages/core/src/components/menu/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import {
   RovingFocusGroup,
@@ -22,7 +22,10 @@ import { FlexBox } from '../flex-box';
 import { Typography } from '../typography';
 import { usePopoverContext } from '../popover/contexts';
 import { createScope } from '../../hooks/internal/use-scope-context';
-import { isElementDisabled } from '../../utils/internal/element';
+import {
+  isElementDisabled,
+  scrollIntoViewIfNeeded,
+} from '../../utils/internal/element';
 
 import {
   MENU_ACTION_AREA_CONTENT_NAME,
@@ -146,14 +149,21 @@ const MenuContent = forwardRef(
       sx,
       children,
       forceMount,
+      onMountAutoFocus,
       ...props
     }: PolymorphicPropsInternal<MenuContentProps, T>,
     ref: ForwardedRef<T>,
   ) => {
     const scopes = useMenuScope('Menu');
+    const viewportRef = useRef<HTMLDivElement | null>(null);
 
     return (
-      <RovingFocusGroup orientation="vertical" dir="ltr" asChild>
+      <RovingFocusGroup
+        orientation="vertical"
+        dir="ltr"
+        asChild
+        preventScrollOnEntryFocus
+      >
         <PopoverContent
           ref={ref}
           position={position}
@@ -163,11 +173,30 @@ const MenuContent = forwardRef(
           forceMount={forceMount}
           aria-label="Select menu"
           variant="custom"
+          // RovingFocusGroup's onEntryFocus never fires here: the group mounts
+          // while the popover is closed, and Radix only attaches the listener
+          // to the node present at mount. FocusScope's mount event fires on
+          // every open, right before the active item receives focus.
+          onMountAutoFocus={composeEventHandlers(onMountAutoFocus, () => {
+            const firstSelectedItem =
+              viewportRef.current?.querySelector<HTMLElement>(
+                '[data-menu-selected="true"]',
+              );
+
+            if (viewportRef.current && firstSelectedItem) {
+              scrollIntoViewIfNeeded(viewportRef.current, firstSelectedItem);
+            }
+          })}
           {...props}
           {...scopes}
           sx={[menuPopoverContentStyle, sx]}
         >
-          <ScrollArea zIndex={11} sx={menuScrollAreaStyle} size="small">
+          <ScrollArea
+            zIndex={11}
+            sx={menuScrollAreaStyle}
+            size="small"
+            viewportRef={viewportRef}
+          >
             {children}
           </ScrollArea>
         </PopoverContent>
@@ -253,6 +282,7 @@ const MenuItem = forwardRef<any, MenuItemProps>(
       ),
       normal: (
         <ListCell
+          data-menu-selected={normalActive}
           disabled={disabled}
           role="menuitemradio"
           ref={ref}
@@ -327,6 +357,7 @@ const MenuItemRadio = forwardRef<any, MenuItemRadioProps>(
         }
         trailingContent={null}
         aria-current={undefined}
+        data-menu-selected={checked}
         {...props}
         onClick={composeEventHandlers(props.onClick, (e) => {
           if (!e.defaultPrevented) {
@@ -375,6 +406,7 @@ const MenuItemCheckbox = forwardRef<any, MenuItemRadioProps>(
         }
         trailingContent={null}
         aria-current={undefined}
+        data-menu-selected={checked}
         {...props}
         onClick={composeEventHandlers(props.onClick, (e) => {
           if (!e.defaultPrevented) {

--- a/packages/core/src/components/popper/index.tsx
+++ b/packages/core/src/components/popper/index.tsx
@@ -88,7 +88,11 @@ const PopperAnchor = forwardRef<
   const composedRefs = useComposedRefs(forwardedRef, ref);
 
   useEffect(() => {
-    context.onAnchorChange(ref.current);
+    const anchor = ref.current;
+
+    if (context.anchor !== anchor) {
+      context.onAnchorChange(anchor);
+    }
   });
 
   return <Slot ref={composedRefs} {...props} />;

--- a/packages/core/src/components/time-view/index.tsx
+++ b/packages/core/src/components/time-view/index.tsx
@@ -24,6 +24,7 @@ import {
   isValidDate,
 } from '../date-calendar/helpers';
 import { extendDayjs } from '../../utils/internal/date';
+import { scrollIntoViewIfNeeded } from '../../utils/internal/element';
 
 import {
   // ACCESSIBLE_MAX_TIME,
@@ -167,7 +168,26 @@ const TimeList = memo(
       }, [currentTimeValue]);
 
       return (
-        <RovingFocusGroup tabIndex={0} orientation="vertical" dir="ltr" asChild>
+        <RovingFocusGroup
+          tabIndex={0}
+          orientation="vertical"
+          dir="ltr"
+          asChild
+          preventScrollOnEntryFocus
+          onEntryFocus={() => {
+            const firstSelectedItem =
+              scrollViewportRef.current?.querySelector<HTMLElement>(
+                '[aria-selected="true"]',
+              );
+
+            if (scrollViewportRef.current && firstSelectedItem) {
+              scrollIntoViewIfNeeded(
+                scrollViewportRef.current,
+                firstSelectedItem,
+              );
+            }
+          }}
+        >
           <ScrollArea
             viewportRef={scrollViewportRef}
             size="small"

--- a/packages/core/src/components/time-view/style.ts
+++ b/packages/core/src/components/time-view/style.ts
@@ -66,7 +66,7 @@ export const timeItemStyle =
           `};
 
     &,
-    p {
+    span {
       text-align: center;
       font-weight: 400;
     }
@@ -75,7 +75,7 @@ export const timeItemStyle =
     active &&
     css`
       &,
-      p {
+      span {
         color: ${theme.semantic.foreground.neutral.primary};
       }
 

--- a/packages/core/src/utils/internal/element.ts
+++ b/packages/core/src/utils/internal/element.ts
@@ -5,3 +5,71 @@ export const isElementDisabled = (element: HTMLElement) => {
     element.ariaDisabled?.toString() === 'true'
   );
 };
+
+// Resolves a computed `scroll-padding-*` / `scroll-margin-*` value to px.
+// `auto` and unparsable values resolve to 0. Percentages are relative to `base`.
+const resolveScrollLength = (value: string, base: number) => {
+  const parsed = parseFloat(value);
+
+  if (Number.isNaN(parsed)) {
+    return 0;
+  }
+
+  return value.trim().endsWith('%') ? (parsed / 100) * base : parsed;
+};
+
+export const scrollIntoViewIfNeeded = (
+  viewport: HTMLElement,
+  element: HTMLElement,
+) => {
+  const viewportRect = viewport.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  const viewportStyle = getComputedStyle(viewport);
+  const elementStyle = getComputedStyle(element);
+
+  // Same as the native algorithm: the scrollport is shrunk by `scroll-padding`
+  // and the target is grown by `scroll-margin` before comparing edges.
+  const viewportTop =
+    viewportRect.top +
+    resolveScrollLength(viewportStyle.scrollPaddingTop, viewportRect.height);
+  const viewportBottom =
+    viewportRect.bottom -
+    resolveScrollLength(viewportStyle.scrollPaddingBottom, viewportRect.height);
+  const elementTop =
+    elementRect.top -
+    resolveScrollLength(elementStyle.scrollMarginTop, elementRect.height);
+  const elementBottom =
+    elementRect.bottom +
+    resolveScrollLength(elementStyle.scrollMarginBottom, elementRect.height);
+
+  const overflowTop = viewportTop - elementTop;
+  const overflowBottom = elementBottom - viewportBottom;
+
+  if (overflowTop <= 0 && overflowBottom <= 0) {
+    return;
+  }
+
+  // Align the center of the target with the center of the scrollport.
+  viewport.scrollTop +=
+    (elementTop + elementBottom) / 2 - (viewportTop + viewportBottom) / 2;
+};
+
+// Focuses `element` without letting the browser scroll any ancestor. A bare
+// `focus()` walks every scroll container up to the document, which throws a
+// zoomed-in page around; instead only the nearest ScrollArea viewport is
+// adjusted (when needed) before focusing with `preventScroll`.
+export const focusIntoView = (element: HTMLElement | null | undefined) => {
+  if (!element) {
+    return;
+  }
+
+  const viewport = element.closest<HTMLElement>(
+    '[data-radix-scroll-area-viewport]',
+  );
+
+  if (viewport) {
+    scrollIntoViewIfNeeded(viewport, element);
+  }
+
+  element.focus({ preventScroll: true });
+};


### PR DESCRIPTION
## Summary

- 옵션 없는 `focus()`가 문서까지 모든 스크롤 조상을 움직여, 브라우저 확대 상태에서 오버레이(메뉴·캘린더·타임뷰)가 열리거나 키보드로 항목을 이동할 때 페이지가 엉뚱한 위치로 튀던 현상을 수정
- `scrollIntoViewIfNeeded` / `focusIntoView` 내부 유틸 추가: 가장 가까운 ScrollArea 뷰포트만 조정(가려진 경우에만, 중앙 정렬, `scroll-padding`/`scroll-margin` 반영)한 뒤 `preventScroll`로 포커스
- DateCalendar / DateRangeCalendar: `focusDate`·`focusRangeDate`가 스크롤까지 담당하도록 통합, 별도 `scrollIntoView*` 헬퍼와 중복 호출 제거. 키보드 탐색 시에도 뷰포트가 포커스를 따라감
- Menu: 열릴 때 `onMountAutoFocus`에서 선택 항목을 뷰포트 중앙으로 이동하고 `preventScrollOnEntryFocus`로 진입 포커스 스크롤 차단. `RovingFocusGroup.onEntryFocus`는 메뉴가 닫힌 상태로 마운트되어 Radix가 리스너를 붙이지 못하므로 사용할 수 없음
- TimeView: 진입 포커스를 `preventDefault`로 막던 것을 `preventScrollOnEntryFocus`로 교체해 키보드 탐색 유지
- FocusScope: `checkVisibility`로 가시성 판정 비용 절감 / Popper: anchor 미변경 시 상태 갱신 생략 / TimeView 스타일: ListCell 텍스트 태그 변경(p → span) 반영

_No Jira ticket — 4.0.0 작업 중 발견된 폴리시 수정._

## Test plan

- [x] Chrome 152, 소스 번들 재현: DateCalendar / DatePicker 연도 뷰에서 ArrowDown ×6 → 포커스 항목이 뷰포트 안에 유지되고 sticky 헤더에 가려지지 않음, `window.scrollY` 변화 없음
- [x] Menu(40개 항목, item30 선택) 열기 → item30 포커스, 뷰포트 정중앙, 페이지 스크롤 없음. ArrowDown 탐색 정상
- [x] TimeView 리스트 진입 → 선택 시(15) 포커스, ArrowRight → 분 리스트 선택값(45) 포커스
- [x] 단위 테스트 71개(date-calendar, date-range-calendar, date-picker, date-range-picker, time-view, menu, select) 통과, lint / tsc 통과
- [ ] 브라우저 확대(150% 등) 상태에서 실제 앱의 Menu / DatePicker를 열고 키보드 이동 시 페이지 점프가 없는지 확인
- [ ] Safari 확인 (재현은 Chrome만 수행)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 달력과 날짜 범위 달력에서 선택한 날짜로 이동할 때 포커스와 스크롤 동작이 개선되었습니다.
  * 메뉴와 시간 목록에서 선택된 항목이 화면에 보이도록 자동 스크롤됩니다.
  * 숨겨진 요소를 판별하는 기능이 다양한 브라우저 환경에서 더 안정적으로 동작합니다.
  * 팝업 앵커 위치 업데이트가 불필요하게 반복되지 않습니다.
  * 시간 항목의 텍스트 스타일 적용이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->