### PR TITLE
docs: props 테이블 줄바꿈 깨짐 수정 및 ElementType 타입 표기 보존

### DIFF
--- a/docs/src/features/docs/components/mdx/code-block/index.tsx
+++ b/docs/src/features/docs/components/mdx/code-block/index.tsx
@@ -15,6 +15,7 @@ import { IconCopy } from '@montage-ui/icon';
 
 import { codeBlockStyle, copyButtonStyle, inlineCodeStyle } from './style';
 
+import type { WithSxProps } from '@montage-ui/engine';
 import type { ComponentPropsWithoutRef } from 'react';
 
 refractor.register(js);
@@ -27,14 +28,14 @@ refractor.register(diff);
 refractor.register(kotlin);
 refractor.register(swift);
 
-type Props = ComponentPropsWithoutRef<'code'>;
+type Props = WithSxProps<ComponentPropsWithoutRef<'code'>>;
 
 const CodeBlock = ({ children, ...props }: Props) => {
   const toast = useToast();
 
   if (!props.className) {
     return (
-      <Box as="code" {...props} sx={inlineCodeStyle}>
+      <Box as="code" {...props} sx={[inlineCodeStyle, props.sx]}>
         {children}
       </Box>
     );
@@ -49,7 +50,7 @@ const CodeBlock = ({ children, ...props }: Props) => {
     <>
       <Box
         {...props}
-        sx={codeBlockStyle}
+        sx={[codeBlockStyle, props.sx]}
         dangerouslySetInnerHTML={{
           __html: toHtml(result as Parameters<typeof toHtml>[0]),
         }}

--- a/docs/src/features/docs/components/mdx/code-block/index.tsx
+++ b/docs/src/features/docs/components/mdx/code-block/index.tsx
@@ -15,7 +15,7 @@ import { IconCopy } from '@montage-ui/icon';
 
 import { codeBlockStyle, copyButtonStyle, inlineCodeStyle } from './style';
 
-import type { WithSxProps } from '@montage-ui/engine';
+import type { SxProp } from '@montage-ui/core';
 import type { ComponentPropsWithoutRef } from 'react';
 
 refractor.register(js);
@@ -28,7 +28,7 @@ refractor.register(diff);
 refractor.register(kotlin);
 refractor.register(swift);
 
-type Props = WithSxProps<ComponentPropsWithoutRef<'code'>>;
+type Props = ComponentPropsWithoutRef<'code'> & { sx?: SxProp };
 
 const CodeBlock = ({ children, ...props }: Props) => {
   const toast = useToast();

--- a/docs/src/features/docs/components/mdx/mdx-render/style.ts
+++ b/docs/src/features/docs/components/mdx/mdx-render/style.ts
@@ -7,8 +7,8 @@ export const mdxRootStyle = (theme: Theme) => css`
   ${typographyStyle('body2-reading', 'medium')}
 
   & > :not(:is([data-role="demo"])):not(:is([data-role="hierarchy"])):not(:is([data-role="variants"])) {
+    overflow-wrap: anywhere;
     word-break: keep-all;
-    overflow-wrap: break-word;
 
     [data-role='property-type'] {
       font-family: inherit !important;

--- a/docs/src/features/docs/components/mdx/props-table/index.tsx
+++ b/docs/src/features/docs/components/mdx/props-table/index.tsx
@@ -57,7 +57,12 @@ const PropsTable = ({ component, fallback }: Props) => {
             <TableRow key={name}>
               <TableCell>
                 <FlexBox alignItems="center" gap="4px">
-                  <CodeBlock>
+                  <CodeBlock
+                    sx={{
+                      wordBreak: 'keep-all',
+                      overflowWrap: 'initial',
+                    }}
+                  >
                     {`${name}${!isOptional && name !== 'as' ? ' *' : ''}`}
                   </CodeBlock>
                   {description && (
@@ -65,6 +70,7 @@ const PropsTable = ({ component, fallback }: Props) => {
                       <TooltipTrigger>
                         <IconCircleInfo
                           sx={(theme) => ({
+                            flexShrink: 0,
                             color: theme.semantic.foreground.neutral.tertiary,
                           })}
                         />

--- a/scripts/api-generator/src/resolver.ts
+++ b/scripts/api-generator/src/resolver.ts
@@ -3,6 +3,7 @@ import type { Type } from 'ts-morph';
 export class Resolver {
   private readonly preservedTypeNames = new Set([
     'ReactNode',
+    'ElementType',
     'ReactElement',
     'ReactFragment',
     'ReactPortal',
@@ -21,7 +22,10 @@ export class Resolver {
    * 보존할 타입 이름인지 확인
    */
   public isPreservedType(name: string): boolean {
-    return this.preservedTypeNames.has(name);
+    return (
+      this.preservedTypeNames.has(name) ||
+      this.preservedTypeNames.has(name.replace(/<.*>$/, ''))
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- props 테이블 이름 셀이 중간에 줄바꿈되던 문제 수정: `CodeBlock`이 `sx`를 받도록 하고 이름 셀에 `word-break: keep-all` 적용, 설명 아이콘에 `flex-shrink: 0`
- MDX 본문을 `overflow-wrap: anywhere`로 바꿔 긴 토큰이 레이아웃을 밀어내지 않게 함
- api-generator: 제네릭 인자가 붙은 `ElementType<...>`도 보존 타입으로 인식해 `as` prop 타입이 풀어져 표기되지 않도록 수정

배포 영향이 없는 docs / 스크립트 변경이라 마일스톤 없음.

## Test plan

- [ ] `pnpm -F docs dev`로 컴포넌트 문서의 props 테이블 렌더링 확인 (이름 셀 줄바꿈, 아이콘 크기)
- [ ] `pnpm build:api` 후 `docs/generated/api.json`에서 `as` prop 타입이 `ElementType<...>`로 유지되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 문서 내 코드 블록과 인라인 코드에 사용자 지정 스타일을 적용할 수 있습니다.
  * 속성 표의 prop 이름이 셀 안에서 더 일관되게 표시되도록 줄바꿈 동작을 조정했습니다.
  * 긴 콘텐츠와 타입 표현의 줄바꿈 처리를 개선했습니다.
  * 제네릭 타입이 포함된 요소 타입이 API 문서 생성 과정에서 올바르게 인식됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->