### PR TITLE
fix(wds): slider 터치 드래그 불가 및 드래그 고착 수정

### DIFF
--- a/packages/wds/src/components/slider/index.test.tsx
+++ b/packages/wds/src/components/slider/index.test.tsx
@@ -19,15 +19,20 @@ const TRACK_WIDTH = 100;
  */
 const firePointer = (
   element: Element,
-  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
   clientX: number,
+  {
+    pointerId = 1,
+    buttons = type === 'pointerdown' || type === 'pointermove' ? 1 : 0,
+  }: { pointerId?: number; buttons?: number } = {},
 ) => {
   const event = new MouseEvent(type, {
     bubbles: true,
     cancelable: true,
     clientX,
+    buttons,
   });
-  Object.defineProperty(event, 'pointerId', { value: 1 });
+  Object.defineProperty(event, 'pointerId', { value: pointerId });
   fireEvent(element, event);
 };
 
@@ -461,6 +466,114 @@ describe('when operating a slider with a pointer', () => {
 
     dragThumb(container, 0, -80);
     expect(getValues(container)).toEqual(['0']);
+  });
+
+  it('should report completion when a touch gesture is cancelled mid-drag', () => {
+    const onValueChangeComplete = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20]}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    const thumb = getThumbs(container)[0]!;
+    firePointer(thumb, 'pointerdown', 20);
+    fireEvent.focus(thumb);
+    firePointer(thumb, 'pointermove', 70);
+    firePointer(thumb, 'pointercancel', 70);
+
+    expect(getValues(container)).toEqual(['70']);
+    expect(onValueChangeComplete).toHaveBeenCalledTimes(1);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([70]);
+  });
+
+  it('should accept a fresh drag after a cancelled one', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20]} />,
+    );
+    stubTrackRect(container);
+
+    const thumb = getThumbs(container)[0]!;
+    firePointer(thumb, 'pointerdown', 20);
+    fireEvent.focus(thumb);
+    firePointer(thumb, 'pointercancel', 20);
+
+    dragThumb(container, 0, 80);
+
+    expect(getValues(container)).toEqual(['80']);
+  });
+
+  it('should ignore a second pointer while a drag is in flight', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20]} />,
+    );
+    stubTrackRect(container);
+
+    const thumb = getThumbs(container)[0]!;
+    firePointer(thumb, 'pointerdown', 20);
+    fireEvent.focus(thumb);
+    firePointer(thumb, 'pointermove', 40);
+
+    const track = getTrack(container);
+    firePointer(track, 'pointerdown', 90, { pointerId: 2 });
+    firePointer(track, 'pointermove', 95, { pointerId: 2 });
+    firePointer(track, 'pointerup', 95, { pointerId: 2 });
+
+    expect(getValues(container)).toEqual(['40']);
+
+    firePointer(thumb, 'pointermove', 55);
+    firePointer(thumb, 'pointerup', 55);
+
+    expect(getValues(container)).toEqual(['55']);
+  });
+
+  it('should let go of a drag whose release never arrived', () => {
+    const onValueChangeComplete = vi.fn();
+    const { container } = render(
+      <Slider
+        min={0}
+        max={100}
+        defaultValue={[20]}
+        onValueChangeComplete={onValueChangeComplete}
+      />,
+    );
+    stubTrackRect(container);
+
+    const thumb = getThumbs(container)[0]!;
+    firePointer(thumb, 'pointerdown', 20);
+    fireEvent.focus(thumb);
+    firePointer(thumb, 'pointermove', 70);
+
+    // The button came up off-window, so the next move reports nothing held.
+    firePointer(thumb, 'pointermove', 95, { buttons: 0 });
+
+    expect(getValues(container)).toEqual(['70']);
+    expect(onValueChangeComplete).toHaveBeenCalledTimes(1);
+    expect(onValueChangeComplete).toHaveBeenCalledWith([70]);
+
+    firePointer(thumb, 'pointermove', 10, { buttons: 0 });
+    expect(getValues(container)).toEqual(['70']);
+  });
+
+  it('should let the same pointer take over a drag it never released', () => {
+    const { container } = render(
+      <Slider min={0} max={100} defaultValue={[20]} />,
+    );
+    stubTrackRect(container);
+
+    const thumb = getThumbs(container)[0]!;
+    firePointer(thumb, 'pointerdown', 20);
+    fireEvent.focus(thumb);
+    firePointer(thumb, 'pointermove', 40);
+
+    // No pointerup ever lands, so the next press has to break the deadlock.
+    clickTrack(container, 80);
+
+    expect(getValues(container)).toEqual(['80']);
   });
 
   it('should still run the consumer pointer handlers', () => {

--- a/packages/wds/src/components/slider/index.tsx
+++ b/packages/wds/src/components/slider/index.tsx
@@ -28,7 +28,7 @@ import {
   sliderThumbStyle,
 } from './style';
 
-import type { ReactNode } from 'react';
+import type { PointerEvent, ReactNode } from 'react';
 import type {
   SliderLabelProps,
   SliderProps,
@@ -61,6 +61,7 @@ const Slider = forwardRef<
       onPointerDown,
       onPointerUp,
       onPointerMove,
+      onPointerCancel,
       onKeyDown,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onChange: _,
@@ -72,6 +73,7 @@ const Slider = forwardRef<
     const thumbRefs = useRef<Set<HTMLSpanElement>>(new Set());
     const currentFocusedIndex = useRef(0);
     const rect = useRef<DOMRect | undefined>(undefined);
+    const activePointerId = useRef<number | null>(null);
     const [node, setNode] = useState<HTMLSpanElement | null>(null);
 
     const [values = [], setValues] = useControllableState({
@@ -158,6 +160,35 @@ const Slider = forwardRef<
       return cb(pointerPosition - newRect.left);
     };
 
+    /**
+     * A touch gesture can be taken away at any moment — a system swipe, an
+     * incoming call — and `pointercancel` is the only notice we get. Treat it
+     * exactly like a release so the values the user already dragged to are
+     * reported and the cached rect cannot leak into the next drag.
+     */
+    const endSlide = (event: PointerEvent<HTMLElement>) => {
+      if (activePointerId.current !== event.pointerId) return;
+
+      const target = event.target as HTMLElement;
+      if (target.hasPointerCapture(event.pointerId)) {
+        target.releasePointerCapture(event.pointerId);
+      }
+
+      activePointerId.current = null;
+      rect.current = undefined;
+
+      /**
+       * Comparing a single index misses changes whenever thumbs end up
+       * stacked or swapped, so compare the whole set instead.
+       */
+      const hasChanged =
+        slideStartValues.current.toString() !== values.toString();
+
+      if (hasChanged) {
+        onValueChangeComplete?.(values);
+      }
+    };
+
     const initialValuesRef = useRef(values);
 
     useEffect(() => {
@@ -233,6 +264,21 @@ const Slider = forwardRef<
           onPointerDown={composeEventHandlers(onPointerDown, (event) => {
             if (disabled) return;
 
+            /**
+             * A touch device happily starts a second pointer mid-drag. Letting
+             * it through would reset the drag origin and teleport the thumb
+             * under the finger that is already dragging. The *same* pointer
+             * pressing again means we missed its release, so let it take the
+             * drag over rather than deadlocking the slider.
+             */
+            if (
+              activePointerId.current !== null &&
+              activePointerId.current !== event.pointerId
+            ) {
+              return;
+            }
+
+            activePointerId.current = event.pointerId;
             slideStartValues.current = values;
 
             const target = event.target as HTMLElement;
@@ -244,7 +290,7 @@ const Slider = forwardRef<
             );
 
             if (closestThumb && thumbRefs.current.has(closestThumb)) {
-              target.focus();
+              closestThumb.focus();
             } else {
               const newValue = getValueFromPointer(event.clientX);
               if (newValue === undefined) return;
@@ -254,36 +300,27 @@ const Slider = forwardRef<
             }
           })}
           onPointerMove={composeEventHandlers(onPointerMove, (event) => {
-            if (disabled) return;
+            if (disabled || activePointerId.current !== event.pointerId) return;
 
-            const target = event.target as HTMLElement;
-            if (target.hasPointerCapture(event.pointerId)) {
-              const newValue = getValueFromPointer(event.clientX);
-              if (newValue === undefined) return;
-
-              handleValueChange(newValue, currentFocusedIndex.current);
+            /**
+             * A release can go missing entirely — the button comes up outside
+             * the window, the window loses focus mid-drag, the captured node
+             * is torn out from under us. `buttons` is the ground truth for
+             * "still held", so trust it over our own bookkeeping instead of
+             * trailing a pointer that was let go a long time ago.
+             */
+            if (event.buttons === 0) {
+              endSlide(event);
+              return;
             }
+
+            const newValue = getValueFromPointer(event.clientX);
+            if (newValue === undefined) return;
+
+            handleValueChange(newValue, currentFocusedIndex.current);
           })}
-          onPointerUp={composeEventHandlers(onPointerUp, (event) => {
-            if (disabled) return;
-
-            const target = event.target as HTMLElement;
-            if (target.hasPointerCapture(event.pointerId)) {
-              target.releasePointerCapture(event.pointerId);
-
-              /**
-               * Comparing a single index misses changes whenever thumbs end up
-               * stacked or swapped, so compare the whole set instead.
-               */
-              const hasChanged =
-                slideStartValues.current.toString() !== values.toString();
-              rect.current = undefined;
-
-              if (hasChanged) {
-                onValueChangeComplete?.(values);
-              }
-            }
-          })}
+          onPointerUp={composeEventHandlers(onPointerUp, endSlide)}
+          onPointerCancel={composeEventHandlers(onPointerCancel, endSlide)}
         >
           <Box sx={sliderProgressStyle} data-role="slider-progress-range">
             <Box

--- a/packages/wds/src/components/slider/style.ts
+++ b/packages/wds/src/components/slider/style.ts
@@ -9,14 +9,7 @@ export const sliderProgressWrapperStyle =
     padding: 8px;
     border-radius: 1000px;
     position: relative;
-
-    /*
-     * A touch device hands a horizontal swipe to its own pan gesture before a
-     * single pointermove reaches us, and cancels the pointer on the way out.
-     * Calling preventDefault on pointerdown cannot claim the gesture back --
-     * only touch-action can, so the drag never starts without this.
-     */
-    touch-action: none;
+    touch-action: ${disabled ? 'auto' : 'none'};
     user-select: none;
     -webkit-tap-highlight-color: transparent;
 

--- a/packages/wds/src/components/slider/style.ts
+++ b/packages/wds/src/components/slider/style.ts
@@ -10,6 +10,16 @@ export const sliderProgressWrapperStyle =
     border-radius: 1000px;
     position: relative;
 
+    /*
+     * A touch device hands a horizontal swipe to its own pan gesture before a
+     * single pointermove reaches us, and cancels the pointer on the way out.
+     * Calling preventDefault on pointerdown cannot claim the gesture back --
+     * only touch-action can, so the drag never starts without this.
+     */
+    touch-action: none;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+
     ${disabled
       ? css`
           cursor: initial;


### PR DESCRIPTION
## Summary

- **터치 디바이스에서 드래그가 아예 시작되지 않던 문제 수정.** 트랙에 `touch-action` 이 없어 브라우저가 가로 스와이프를 자기 팬 제스처로 먼저 가져가고 `pointercancel` 을 내보내, `pointermove` 가 한 번도 도착하지 않았습니다. `pointerdown` 의 `preventDefault` 로는 되찾을 수 없는 동작이라 `touch-action: none` 으로 제스처를 붙잡습니다.
- **`pointercancel` 처리 추가.** 기존엔 `pointerup` 에만 정리 로직이 있어 취소된 제스처가 캐시된 트랙 rect 를 남겼고, 모바일에서 화면을 회전하면 다음 드래그가 옛 좌표로 계산됐습니다.
- **드래그를 활성 `pointerId` 로 추적.** 드래그 중 두 번째 손가락이 드래그 원점을 리셋하고 thumb 을 순간이동시키던 문제를 막습니다. 터치는 항상 암묵적 포인터 캡처를 받기 때문에 기존 `hasPointerCapture` 검사로는 걸러지지 않았습니다.
- **릴리즈 유실에 대한 자가 치유.** 창 밖 버튼 업이나 드래그 중 창 포커스 상실로 `pointerup` 이 통째로 유실될 수 있습니다. `buttons` 로 실제 눌림 여부를 확인해 값 갱신 전에 빠져나가고, 같은 `pointerId` 의 재입력은 드래그를 넘겨받게 해 슬라이더가 고착되지 않게 합니다.
- **thumb 포커스 대상 오류 수정.** `closestThumb` 을 찾아놓고 `target.focus()` 를 부르고 있었습니다. `target` 은 포커스 불가능한 `slider-thumb-interaction` span 이라 no-op 이었고, thumb 자체의 `onPointerDown` 이 우연히 대신 처리하고 있었습니다.

## 왜 Android 에서만 보였나

Chrome 은 스펙대로 히트 테스트 시점의 `touch-action` 만 보고 컴포지터 스레드에서 스크롤 여부를 결정하므로, 메인 스레드에서 뒤늦게 부르는 `preventDefault` 는 스크롤 억제에 영향이 없습니다. 반면 WebKit 은 pointer event 를 touch event 에서 합성하면서 `pointerdown` 의 `preventDefault` 를 존중합니다. 즉 이 코드는 WebKit 의 관대한 동작에 우연히 기대고 있었고, 그게 없는 Android 에서만 증상이 드러났습니다.

## Test plan

- [x] 단위 테스트 67 passed / 3 skipped — 릴리즈 유실·교착 해제 케이스는 수정을 되돌리면 정확히 그 2개만 실패하는 것까지 확인
- [x] `tsc --noEmit`, `eslint`, `prettier --check` 통과
- [ ] Android Chrome 실기기 — 세로 스크롤이 있는 페이지에서 트랙/thumb 드래그
- [ ] iOS Safari 회귀 확인 (기존에 동작하던 경로)
- [ ] PC — 슬라이더 밖 / 브라우저 창 밖에서 마우스 업 후 thumb 이 따라오지 않는지
- [ ] PC — 드래그 중 alt-tab 후 복귀

## 남은 한계

창 밖에서 버튼을 뗀 경우 `onValueChangeComplete` 가 마우스가 슬라이더 위로 돌아올 때까지 지연됩니다. 완전히 없애려면 드래그 중 `window` 에 `pointerup` 리스너를 다는 방식(MUI 방식)이 필요한데, state 플래그와 effect 가 추가로 붙어 이번엔 제외했습니다. 보고된 증상은 완전히 사라집니다.

---

_Jira 티켓 없음 — 티켓 없이 진행하기로 확인받았습니다._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 슬라이더 드래그 중 포인터 취소, 버튼 해제, 포인터 종료 상황을 안정적으로 처리합니다.
  - 다른 포인터의 입력이 현재 드래그를 방해하지 않도록 개선했습니다.
  - 드래그가 취소된 후에도 새 드래그를 정상적으로 시작할 수 있습니다.

- **사용성 개선**
  - 활성 슬라이더에서는 원치 않는 화면 동작을 방지하고, 비활성 상태에서는 기본 터치 동작을 지원합니다.
  - 썸네일을 직접 선택하면 해당 썸네일에 포커스가 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->